### PR TITLE
feat: enhance homepage layout

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,21 @@
+import styles from '../styles/Home.module.css';
+import SearchBar from './SearchBar';
+
+export default function Hero() {
+  return (
+    <section className={styles.hero}>
+      <nav className={styles.nav}>
+        <h1 className={styles.logo}>MyEstate</h1>
+        <div className={styles.navLinks}>
+          <a href="#buy">Buy</a>
+          <a href="#rent">Rent</a>
+          <a href="#sell">Sell</a>
+        </div>
+      </nav>
+      <div className={styles.heroContent}>
+        <h2>Your trusted estate agent</h2>
+        <SearchBar />
+      </div>
+    </section>
+  );
+}

--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -1,0 +1,10 @@
+import styles from '../styles/Home.module.css';
+
+export default function SearchBar() {
+  return (
+    <form className={styles.searchBar} onSubmit={(e) => e.preventDefault()}>
+      <input type="text" placeholder="Search area or postcode" />
+      <button type="submit">Search</button>
+    </form>
+  );
+}

--- a/components/Stats.js
+++ b/components/Stats.js
@@ -1,0 +1,20 @@
+import styles from '../styles/Home.module.css';
+
+export default function Stats() {
+  const items = [
+    { number: '200+', text: 'buyers registered each week' },
+    { number: '98%', text: 'customer satisfaction' },
+    { number: '30+', text: 'local experts across London' }
+  ];
+
+  return (
+    <section className={styles.stats}>
+      {items.map((item) => (
+        <div className={styles.stat} key={item.text}>
+          <span className={styles.number}>{item.number}</span>
+          <span>{item.text}</span>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,18 @@
 import PropertyList from '../components/PropertyList';
+import Hero from '../components/Hero';
+import Stats from '../components/Stats';
 import { fetchProperties } from '../lib/apex27';
+import styles from '../styles/Home.module.css';
 
 export default function Home({ properties }) {
   return (
-    <main>
-      <h1>Property Listings</h1>
-      <PropertyList properties={properties} />
+    <main className={styles.main}>
+      <Hero />
+      <Stats />
+      <section className={styles.listings}>
+        <h2>Latest Properties</h2>
+        <PropertyList properties={properties} />
+      </section>
     </main>
   );
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,72 @@
+.main {
+  padding: 0;
+}
+
+.hero {
+  background-image: url('https://images.unsplash.com/photo-1560185008-ae5932cd2db7?auto=format&fit=crop&w=1500&q=80');
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+  padding: 1rem 2rem 6rem;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.navLinks a {
+  margin-left: 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.heroContent {
+  max-width: 600px;
+  margin-top: 3rem;
+}
+
+.searchBar {
+  margin-top: 1rem;
+  display: flex;
+}
+
+.searchBar input {
+  flex: 1;
+  padding: 0.5rem;
+}
+
+.searchBar button {
+  padding: 0.5rem 1rem;
+  background-color: #006064;
+  color: #fff;
+  border: none;
+}
+
+.stats {
+  display: flex;
+  justify-content: space-around;
+  padding: 2rem 1rem;
+  background: #f5f5f5;
+}
+
+.stat {
+  text-align: center;
+}
+
+.number {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #006064;
+}
+
+.listings {
+  padding: 2rem 1rem;
+}


### PR DESCRIPTION
## Summary
- add hero section and property search bar for Foxtons-inspired landing page
- introduce stats section and tailored styling
- update homepage to display latest properties below new sections

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf79e868c0832ea4bcfdb3d9228466