### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npx next export
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,12 @@
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || '';
+const isProd = process.env.NODE_ENV === 'production';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  images: { unoptimized: true },
+  basePath: isProd && repo ? `/${repo}` : undefined,
+  assetPrefix: isProd && repo ? `/${repo}/` : undefined,
+};
+
+export default nextConfig;

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,7 @@ export default function Home({ properties }) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const properties = await fetchProperties();
   return { props: { properties } };
 }

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -1,4 +1,4 @@
-import { fetchPropertyById } from '../../lib/apex27';
+import { fetchPropertyById, fetchProperties } from '../../lib/apex27';
 
 export default function Property({ property }) {
   if (!property) return <div>Property not found</div>;
@@ -12,7 +12,15 @@ export default function Property({ property }) {
   );
 }
 
-export async function getServerSideProps({ params }) {
+export async function getStaticPaths() {
+  const properties = await fetchProperties();
+  return {
+    paths: properties.map((p) => ({ params: { id: p.id } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
   const property = await fetchPropertyById(params.id);
   return { props: { property } };
 }


### PR DESCRIPTION
## Summary
- add workflow to build and deploy site to GitHub Pages
- configure Next.js for static export and Pages compatibility
- use static generation for property and index pages to allow export

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7a3f4740832e95dbc81dac2e9824