### PR TITLE
Add responsive header and footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,9 @@
+import styles from '../styles/Footer.module.css';
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <p>&copy; {new Date().getFullYear()} Aktonz. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { useState } from 'react';
+import styles from '../styles/Header.module.css';
+
+export default function Header() {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const toggleMobile = () => setMobileOpen(!mobileOpen);
+  const closeMobile = () => setMobileOpen(false);
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.logo}>
+        <Link href="/">
+          <Image src="/aktonz-logo.svg" alt="Aktonz" width={120} height={40} />
+        </Link>
+      </div>
+      <nav className={styles.nav}>
+        <ul className={styles.navList}>
+          <li className={styles.navItem}><Link href="/">Home</Link></li>
+          <li className={`${styles.navItem} ${styles.hasMega}`}>
+            <span>Properties</span>
+            <div className={styles.megaMenu}>
+              <div>
+                <h4>Buy</h4>
+                <Link href="#">Residential</Link>
+                <Link href="#">Commercial</Link>
+              </div>
+              <div>
+                <h4>Rent</h4>
+                <Link href="#">Residential</Link>
+                <Link href="#">Commercial</Link>
+              </div>
+            </div>
+          </li>
+          <li className={styles.navItem}><Link href="#">Contact</Link></li>
+        </ul>
+      </nav>
+      <button className={styles.hamburger} onClick={toggleMobile} aria-label="Menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      {mobileOpen && (
+        <div className={styles.mobileMenu}>
+          <ul>
+            <li><Link href="/" onClick={closeMobile}>Home</Link></li>
+            <li><Link href="#" onClick={closeMobile}>Properties</Link></li>
+            <li><Link href="#" onClick={closeMobile}>Contact</Link></li>
+          </ul>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,13 @@
 import '../styles/globals.css';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
 
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Header />
+      <Component {...pageProps} />
+      <Footer />
+    </>
+  );
 }

--- a/public/aktonz-logo.svg
+++ b/public/aktonz-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" role="img">
+  <rect width="120" height="40" fill="#0A0A0A" rx="4"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#FFFFFF" font-family="Arial, sans-serif" font-size="20">AKTONZ</text>
+</svg>

--- a/styles/Footer.module.css
+++ b/styles/Footer.module.css
@@ -1,0 +1,7 @@
+.footer {
+  text-align: center;
+  padding: 2rem;
+  background-color: #f5f5f5;
+  margin-top: 2rem;
+  border-top: 1px solid #eaeaea;
+}

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -1,0 +1,96 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background-color: #fff;
+  border-bottom: 1px solid #eaeaea;
+  position: relative;
+}
+
+.logo img {
+  display: block;
+}
+
+.nav {
+  display: none;
+}
+
+.navList {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navItem {
+  position: relative;
+}
+
+.hasMega:hover .megaMenu {
+  display: grid;
+}
+
+.megaMenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 400px;
+  padding: 1rem;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  z-index: 1000;
+}
+
+.hamburger {
+  display: block;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 25px;
+  height: 3px;
+  margin: 4px;
+  background-color: #333;
+}
+
+.mobileMenu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  width: 200px;
+  padding: 1rem;
+}
+
+.mobileMenu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mobileMenu li {
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .nav {
+    display: block;
+  }
+
+  .hamburger {
+    display: none;
+  }
+
+  .mobileMenu {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add header with desktop mega menu and mobile hamburger navigation
- include footer component with basic styling
- wire layout components into app and add placeholder Aktonz logo

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf85a6b1f0832e995a9919e487cfa0