### PR TITLE
Use proxy API endpoint and handle fetch failures

### DIFF
--- a/lib/apex27.js
+++ b/lib/apex27.js
@@ -1,32 +1,42 @@
-const API_URL = 'https://api.apex27.com/properties';
+const API_URL = 'https://private-anon-cd99d5599d-apex27.apiary-proxy.com/listings';
 
 export async function fetchProperties() {
   if (!process.env.APEX27_API_KEY) {
     return sampleProperties;
   }
-  const res = await fetch(API_URL, {
-    headers: { 'X-API-Key': process.env.APEX27_API_KEY }
-  });
-  if (!res.ok) {
-    console.error('Failed to fetch properties', res.status);
+  try {
+    const res = await fetch(API_URL, {
+      headers: { 'X-API-Key': process.env.APEX27_API_KEY }
+    });
+    if (!res.ok) {
+      console.error('Failed to fetch properties', res.status);
+      return sampleProperties;
+    }
+    const data = await res.json();
+    return data.properties || [];
+  } catch (err) {
+    console.error('Failed to fetch properties', err);
     return sampleProperties;
   }
-  const data = await res.json();
-  return data.properties || [];
 }
 
 export async function fetchPropertyById(id) {
   if (!process.env.APEX27_API_KEY) {
     return sampleProperties.find((p) => p.id === id) || null;
   }
-  const res = await fetch(`${API_URL}/${id}`, {
-    headers: { 'X-API-Key': process.env.APEX27_API_KEY }
-  });
-  if (!res.ok) {
-    console.error('Failed to fetch property', res.status);
+  try {
+    const res = await fetch(`${API_URL}/${id}`, {
+      headers: { 'X-API-Key': process.env.APEX27_API_KEY }
+    });
+    if (!res.ok) {
+      console.error('Failed to fetch property', res.status);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to fetch property', err);
     return null;
   }
-  return await res.json();
 }
 
 const sampleProperties = [


### PR DESCRIPTION
## Summary
- replace Apex27 API URL with provided Apiary proxy endpoint
- add try/catch around fetches to gracefully fall back to sample data on errors

## Testing
- `npm test`
- `npm run build`
- `npm start` *(fails: "next start" does not work with "output: export")*
- `npx serve@latest out`


------
https://chatgpt.com/codex/tasks/task_e_68bf84a31a44832eb457f3534ca4447c