### PR TITLE
Add sales and lettings property pages

### DIFF
--- a/components/Features.js
+++ b/components/Features.js
@@ -1,14 +1,17 @@
+import Link from 'next/link';
 import styles from '../styles/Home.module.css';
 
 export default function Features() {
   const items = [
     {
-      title: 'Extensive Listings',
-      text: 'Browse hundreds of properties for sale or rent across the country.'
+      title: 'Sales',
+      text: 'Browse our latest properties for sale.',
+      href: '/for-sale'
     },
     {
-      title: 'Trusted Agents',
-      text: 'Work with experienced agents with local market knowledge.'
+      title: 'Lettings',
+      text: 'Find the perfect home to rent.',
+      href: '/to-rent'
     },
     {
       title: 'Smart Search',
@@ -22,6 +25,7 @@ export default function Features() {
         <div className={styles.feature} key={item.title}>
           <h3>{item.title}</h3>
           <p>{item.text}</p>
+          {item.href && <Link href={item.href}>View {item.title}</Link>}
         </div>
       ))}
     </section>

--- a/components/Header.js
+++ b/components/Header.js
@@ -23,12 +23,12 @@ export default function Header() {
             <div className={styles.megaMenu}>
               <div>
                 <h4>Buy</h4>
-                <Link href="#">Residential</Link>
+                <Link href="/for-sale">Residential</Link>
                 <Link href="#">Commercial</Link>
               </div>
               <div>
                 <h4>Rent</h4>
-                <Link href="#">Residential</Link>
+                <Link href="/to-rent">Residential</Link>
                 <Link href="#">Commercial</Link>
               </div>
             </div>
@@ -45,7 +45,8 @@ export default function Header() {
         <div className={styles.mobileMenu}>
           <ul>
             <li><Link href="/" onClick={closeMobile}>Home</Link></li>
-            <li><Link href="#" onClick={closeMobile}>Properties</Link></li>
+            <li><Link href="/for-sale" onClick={closeMobile}>For Sale</Link></li>
+            <li><Link href="/to-rent" onClick={closeMobile}>To Rent</Link></li>
             <li><Link href="#" onClick={closeMobile}>Contact</Link></li>
           </ul>
         </div>

--- a/lib/apex27.js
+++ b/lib/apex27.js
@@ -39,12 +39,26 @@ export async function fetchPropertyById(id) {
   }
 }
 
+export async function fetchPropertiesByType(type) {
+  const properties = await fetchProperties();
+  return properties.filter((p) => p.type === type);
+}
+
 const sampleProperties = [
   {
     id: '1',
     title: 'Sample Flat in London',
     description: 'Two bedroom flat with garden.',
     price: '£500,000',
-    image: 'https://via.placeholder.com/300'
+    image: 'https://via.placeholder.com/300',
+    type: 'sale'
+  },
+  {
+    id: '2',
+    title: 'City Centre Apartment',
+    description: 'Modern apartment close to amenities.',
+    price: '£1,200 pcm',
+    image: 'https://via.placeholder.com/300',
+    type: 'rent'
   }
 ];

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -1,0 +1,17 @@
+import PropertyList from '../components/PropertyList';
+import { fetchPropertiesByType } from '../lib/apex27';
+import styles from '../styles/Home.module.css';
+
+export default function ForSale({ properties }) {
+  return (
+    <main className={styles.main}>
+      <h1>Properties for Sale</h1>
+      <PropertyList properties={properties} />
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const properties = await fetchPropertiesByType('sale');
+  return { props: { properties } };
+}

--- a/pages/property/index.js
+++ b/pages/property/index.js
@@ -1,0 +1,17 @@
+import PropertyList from '../../components/PropertyList';
+import { fetchProperties } from '../../lib/apex27';
+import styles from '../../styles/Home.module.css';
+
+export default function PropertyArchive({ properties }) {
+  return (
+    <main className={styles.main}>
+      <h1>All Properties</h1>
+      <PropertyList properties={properties} />
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const properties = await fetchProperties();
+  return { props: { properties } };
+}

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -1,0 +1,17 @@
+import PropertyList from '../components/PropertyList';
+import { fetchPropertiesByType } from '../lib/apex27';
+import styles from '../styles/Home.module.css';
+
+export default function ToRent({ properties }) {
+  return (
+    <main className={styles.main}>
+      <h1>Properties to Rent</h1>
+      <PropertyList properties={properties} />
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const properties = await fetchPropertiesByType('rent');
+  return { props: { properties } };
+}


### PR DESCRIPTION
## Summary
- add filtering by property type with sample sale and rent data
- implement property archive, for-sale and to-rent pages
- enhance header and home features with links to sales and lettings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8af46b50832ea40a214c40016665