### PR TITLE
Use Apex27 production API for listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm run dev
 
 ## Environment Variables
 
-Set `APEX27_API_KEY` to fetch real property data from the Apex27 API. Without it, the app displays sample listings.
+Create a `.env.local` file and set `APEX27_API_KEY` (and optionally `APEX27_BRANCH_ID` for your branch) to fetch real property data from the Apex27 API. Without these variables, the app displays sample listings.
 
 ## Build
 

--- a/lib/apex27.js
+++ b/lib/apex27.js
@@ -1,17 +1,31 @@
-const API_URL = 'https://private-anon-cd99d5599d-apex27.apiary-proxy.com/listings';
+const API_URL = 'https://api.apex27.co.uk/listings';
 
-export async function fetchProperties() {
+export async function fetchProperties(params = {}) {
   if (!process.env.APEX27_API_KEY) {
     return sampleProperties;
   }
+
+  const searchParams = new URLSearchParams({
+    status: 'live',
+    includeImages: '1',
+    includeGallery: '1',
+    ...params,
+  });
+
+  if (process.env.APEX27_BRANCH_ID) {
+    searchParams.set('branchId', process.env.APEX27_BRANCH_ID);
+  }
+
   try {
-    const res = await fetch(API_URL, {
-      headers: { 'X-API-Key': process.env.APEX27_API_KEY }
+    const res = await fetch(`${API_URL}?${searchParams.toString()}`, {
+      headers: { 'X-API-Key': process.env.APEX27_API_KEY },
     });
+
     if (!res.ok) {
       console.error('Failed to fetch properties', res.status);
       return sampleProperties;
     }
+
     const data = await res.json();
     return data.properties || [];
   } catch (err) {
@@ -24,14 +38,23 @@ export async function fetchPropertyById(id) {
   if (!process.env.APEX27_API_KEY) {
     return sampleProperties.find((p) => p.id === id) || null;
   }
+
   try {
-    const res = await fetch(`${API_URL}/${id}`, {
-      headers: { 'X-API-Key': process.env.APEX27_API_KEY }
+    const url = new URL(`${API_URL}/${id}`);
+
+    if (process.env.APEX27_BRANCH_ID) {
+      url.searchParams.set('branchId', process.env.APEX27_BRANCH_ID);
+    }
+
+    const res = await fetch(url, {
+      headers: { 'X-API-Key': process.env.APEX27_API_KEY },
     });
+
     if (!res.ok) {
       console.error('Failed to fetch property', res.status);
       return null;
     }
+
     return await res.json();
   } catch (err) {
     console.error('Failed to fetch property', err);
@@ -40,8 +63,10 @@ export async function fetchPropertyById(id) {
 }
 
 export async function fetchPropertiesByType(type) {
-  const properties = await fetchProperties();
-  return properties.filter((p) => p.type === type);
+  const properties = await fetchProperties({
+    transactionType: type === 'sale' ? 'sales' : 'lettings',
+  });
+  return properties;
 }
 
 const sampleProperties = [


### PR DESCRIPTION
## Summary
- query Apex27 production API instead of Apiary proxy
- allow branch-specific live listings with URL parameters
- document APEX27_API_KEY and optional branch ID in `.env.local`

## Testing
- `npm test`
- `npm run build` *(fails to reach api.apex27.co.uk: ENETUNREACH, falling back to sample data)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8caa80fc832ea237e4697c771b6a