### PR TITLE
Fix API blueprint formatting

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -17,10 +17,12 @@ Retrieve property listings for the specified branch.
 
 + Request
     + Headers
-        + X-Api-Key: `b3ccaef8aeecf3c82f2b9da07127cfd1` (string, required)
+
+            X-Api-Key: YOUR_API_KEY
 
 + Response 200 (application/json)
     + Body
+
             {
               "data": [
                 {


### PR DESCRIPTION
## Summary
- format `X-Api-Key` header block correctly
- convert response example into a properly indented code block

## Testing
- `npm test`
- `dredd apiary.apib http://example.com --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68bfa3c7625c832e941f2392a054abe1