### PR TITLE
Fix API blueprint formatting

### DIFF
--- a/.dredd.yml
+++ b/.dredd.yml
@@ -1,0 +1,3 @@
+blueprint: apiary.apib
+endpoint: https://api.apex27.co.uk
+header: "X-Api-Key: YOUR_API_KEY"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ commit them to the repository:
    npm run build
    ```
    The static site will be generated in the `out/` directory (e.g. `npx serve out`).
+
+## API Testing
+
+Use [Dredd](https://dredd.org/) to verify the API blueprint against the Apex27 service.
+
+```
+export APEX27_API_KEY=your_key
+NODE_OPTIONS=--dns-result-order=ipv4first dredd --config .dredd.yml --dry-run
+```
+
+The `--dry-run` flag checks the blueprint syntax without making network requests.
+Remove it to test against the live API.

--- a/apiary.apib
+++ b/apiary.apib
@@ -17,10 +17,12 @@ Retrieve property listings for the specified branch.
 
 + Request
     + Headers
-        + X-Api-Key: `b3ccaef8aeecf3c82f2b9da07127cfd1` (string, required)
+
+            X-Api-Key: YOUR_API_KEY
 
 + Response 200 (application/json)
     + Body
+
             {
               "data": [
                 {


### PR DESCRIPTION
## Summary
- format `X-Api-Key` header block correctly
- convert response example into a properly indented code block
- add Dredd config and README docs for running API tests

## Testing
- `npm test`
- `dredd apiary.apib https://api.apex27.co.uk --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68bfa3c7625c832e941f2392a054abe1