### PR TITLE
Revamp home page with Foxtons-inspired hero and features

### DIFF
--- a/components/Features.js
+++ b/components/Features.js
@@ -1,33 +1,41 @@
-import Link from 'next/link';
 import styles from '../styles/Home.module.css';
 
 export default function Features() {
   const items = [
     {
-      title: 'Sales',
-      text: 'Browse our latest properties for sale.',
-      href: '/for-sale'
+      icon: '🏠',
+      title: 'Let your property hassle free',
+      text: 'Our team handles everything from tenant search to management.'
     },
     {
-      title: 'Lettings',
-      text: 'Find the perfect home to rent.',
-      href: '/to-rent'
+      icon: '💰',
+      title: "What's your home worth?",
+      text: 'Get an instant online valuation today.'
     },
     {
-      title: 'Smart Search',
-      text: 'Filter by price, location and property type to find your ideal home.'
+      icon: '🔍',
+      title: 'Find the right property for you',
+      text: 'Browse thousands of homes across London.'
+    },
+    {
+      icon: '🤝',
+      title: 'Need help? Ask our experts',
+      text: 'Our local agents are here to support you.'
     }
   ];
 
   return (
-    <section className={styles.features}>
-      {items.map((item) => (
-        <div className={styles.feature} key={item.title}>
-          <h3>{item.title}</h3>
-          <p>{item.text}</p>
-          {item.href && <Link href={item.href}>View {item.title}</Link>}
-        </div>
-      ))}
+    <section className={styles.featuresSection}>
+      <h2>When you need experts</h2>
+      <div className={styles.featuresGrid}>
+        {items.map((item) => (
+          <div className={styles.featureCard} key={item.title}>
+            <div className={styles.featureIcon}>{item.icon}</div>
+            <h3>{item.title}</h3>
+            <p>{item.text}</p>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -11,12 +11,12 @@ export default function Hero() {
           <a href="#rent">Rent</a>
           <a href="#sell">Sell</a>
         </div>
+        <a href="#login" className={styles.loginButton}>Login</a>
       </nav>
       <div className={styles.heroContent}>
-        <h2>Your trusted estate agent</h2>
-        <p className={styles.subtitle}>Find your perfect home to buy or rent</p>
+        <h2>London's Estate Agent</h2>
+        <p className={styles.subtitle}>Get it done with London's number one</p>
         <SearchBar />
-        <a href="#listings" className={styles.ctaButton}>Browse listings</a>
       </div>
     </section>
   );

--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -1,10 +1,36 @@
+import { useState } from 'react';
 import styles from '../styles/Home.module.css';
 
 export default function SearchBar() {
+  const [mode, setMode] = useState('buy');
+
   return (
-    <form className={styles.searchBar} onSubmit={(e) => e.preventDefault()}>
-      <input type="text" placeholder="Search area or postcode" />
-      <button type="submit">Search</button>
-    </form>
+    <div className={styles.searchWrapper}>
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={mode === 'buy' ? styles.activeTab : ''}
+          onClick={() => setMode('buy')}
+        >
+          Buy
+        </button>
+        <button
+          type="button"
+          className={mode === 'rent' ? styles.activeTab : ''}
+          onClick={() => setMode('rent')}
+        >
+          Rent
+        </button>
+      </div>
+      <div className={styles.searchControls}>
+        <form className={styles.searchBar} onSubmit={(e) => e.preventDefault()}>
+          <input type="text" placeholder="Search area or postcode" />
+          <button type="submit">Search</button>
+        </form>
+        <a href="#valuation" className={styles.valuationButton}>
+          Get a free valuation
+        </a>
+      </div>
+    </div>
   );
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -11,6 +11,22 @@
   position: relative;
 }
 
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.heroContent {
+  position: relative;
+  max-width: 600px;
+  margin-top: 3rem;
+}
+
 .subtitle {
   margin-top: 0.5rem;
   font-size: 1.2rem;
@@ -25,6 +41,7 @@
   text-decoration: none;
 }
 
+
 .nav {
   display: flex;
   justify-content: space-between;
@@ -36,32 +53,81 @@
   font-size: 1.5rem;
 }
 
+.navLinks {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
 .navLinks a {
-  margin-left: 1rem;
+  margin: 0 1rem;
   color: #fff;
   text-decoration: none;
 }
 
-.heroContent {
-  max-width: 600px;
-  margin-top: 3rem;
+.loginButton {
+  color: #fff;
+  text-decoration: none;
+  margin-left: 1rem;
+}
+
+
+.searchWrapper {
+  margin-top: 1rem;
+  background: #fff;
+  color: #000;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.tabs {
+  display: flex;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 0.5rem;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+}
+
+.activeTab {
+  background: #006d5b;
+  color: #fff;
+}
+
+.searchControls {
+  display: flex;
+  margin-top: 0.5rem;
 }
 
 .searchBar {
-  margin-top: 1rem;
+  flex: 1;
   display: flex;
 }
 
 .searchBar input {
   flex: 1;
   padding: 0.5rem;
+  border: 1px solid #ccc;
 }
 
 .searchBar button {
   padding: 0.5rem 1rem;
-  background-color: #000;
+  background: #006d5b;
   color: #fff;
   border: none;
+}
+
+.valuationButton {
+  margin-left: 0.5rem;
+  background: #ffe500;
+  color: #000;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
 }
 
 .stats {
@@ -82,16 +148,32 @@
   color: #000;
 }
 
-.features {
-  display: flex;
-  justify-content: space-around;
+
+.featuresSection {
   padding: 2rem 1rem;
-  background: #fff;
+  background: #f5f5f5;
+  text-align: center;
 }
 
-.feature {
-  max-width: 200px;
+.featuresGrid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.featureCard {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  width: 200px;
   text-align: center;
+}
+
+.featureIcon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
 .listings {


### PR DESCRIPTION
## Summary
- Style hero with Foxtons-like banner, login link and updated tagline
- Add buy/rent tabs, search box and valuation button
- Replace feature section with "When you need experts" grid

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2128228d8832e94fbc5859400a808