### PR TITLE
Run Apex27 cache in GitHub Pages workflows

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -28,6 +28,9 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    env:
+      APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
+      APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +76,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Cache Apex27 listings
+        run: ${{ steps.detect-package-manager.outputs.manager }} run cache
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
+      APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,6 +27,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Cache Apex27 listings
+        run: npm run cache
       - run: npm run build
       - run: touch out/.nojekyll
 


### PR DESCRIPTION
## Summary
- expose `APEX27_API_KEY` and optional branch ID to Next.js build jobs
- run `npm run cache` during CI to populate listings before `next build`

## Testing
- `npm test`
- `APEX27_API_KEY=dummy APEX27_BRANCH_ID=123 npm run cache` *(fails: connect ENETUNREACH)*
- `APEX27_API_KEY=dummy APEX27_BRANCH_ID=123 npm run build` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c2170f47f8832e9f090f326a215acd