### PR TITLE
Run Apex27 cache in GitHub Pages workflows

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -28,6 +28,9 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    env:
+      APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
+      APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +76,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Cache Apex27 listings
+        run: ${{ steps.detect-package-manager.outputs.manager }} run cache
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
+      APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,6 +27,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Cache Apex27 listings
+        run: npm run cache
       - run: npm run build
       - run: touch out/.nojekyll
 

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -60,13 +60,14 @@ export async function fetchProperties(params = {}) {
 
 export async function fetchPropertyById(id) {
   const cached = await getCachedProperties();
+  const idStr = String(id);
 
   if (!process.env.APEX27_API_KEY) {
-    return cached ? cached.find((p) => p.id === id) || null : null;
+    return cached ? cached.find((p) => String(p.id) === idStr) || null : null;
   }
 
   try {
-    const url = new URL(`${API_URL}/${id}`);
+    const url = new URL(`${API_URL}/${idStr}`);
     if (process.env.APEX27_BRANCH_ID) {
       url.searchParams.set('branchId', process.env.APEX27_BRANCH_ID);
     }
@@ -80,7 +81,7 @@ export async function fetchPropertyById(id) {
 
     if (res.status === 403) {
       console.error('Apex27 API key unauthorized (HTTP 403) when fetching property by id.');
-      return cached ? cached.find((p) => p.id === id) || null : null;
+      return cached ? cached.find((p) => String(p.id) === idStr) || null : null;
     }
 
     if (!res.ok) {
@@ -92,7 +93,7 @@ export async function fetchPropertyById(id) {
     return data.data || data;
   } catch (err) {
     console.error('Failed to fetch property', err);
-    return cached ? cached.find((p) => p.id === id) || null : null;
+    return cached ? cached.find((p) => String(p.id) === idStr) || null : null;
   }
 }
 
@@ -108,7 +109,7 @@ export async function fetchPropertiesByType(type) {
   }
 
   return list.map((p) => ({
-    id: p.id,
+    id: String(p.id),
     title: p.displayAddress || p.address1 || p.title || '',
     description: p.summary || p.description || '',
     price:

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -1,5 +1,5 @@
 import PropertyList from '../components/PropertyList';
-import { fetchPropertiesByType } from '../lib/apex27';
+import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
 export default function ForSale({ properties }) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import PropertyList from '../components/PropertyList';
 import Hero from '../components/Hero';
 import Features from '../components/Features';
 import Stats from '../components/Stats';
-import { fetchPropertiesByType } from '../lib/apex27';
+import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
 export default function Home({ properties }) {

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -1,4 +1,4 @@
-import { fetchPropertyById, fetchProperties } from '../../lib/apex27';
+import { fetchPropertyById, fetchProperties } from '../../lib/apex27.mjs';
 
 export default function Property({ property }) {
   if (!property) return <div>Property not found</div>;
@@ -15,7 +15,7 @@ export default function Property({ property }) {
 export async function getStaticPaths() {
   const properties = await fetchProperties();
   return {
-    paths: properties.map((p) => ({ params: { id: p.id } })),
+    paths: properties.map((p) => ({ params: { id: String(p.id) } })),
     fallback: false,
   };
 }

--- a/pages/property/index.js
+++ b/pages/property/index.js
@@ -1,5 +1,5 @@
 import PropertyList from '../../components/PropertyList';
-import { fetchProperties } from '../../lib/apex27';
+import { fetchProperties } from '../../lib/apex27.mjs';
 import styles from '../../styles/Home.module.css';
 
 export default function PropertyArchive({ properties }) {

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -1,5 +1,5 @@
 import PropertyList from '../components/PropertyList';
-import { fetchPropertiesByType } from '../lib/apex27';
+import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
 export default function ToRent({ properties }) {

--- a/scripts/cacheListings.mjs
+++ b/scripts/cacheListings.mjs
@@ -27,7 +27,7 @@ function loadEnvLocal() {
 // Load env before importing fetchProperties
 loadEnvLocal();
 
-const { fetchProperties } = await import('../lib/apex27.js');
+const { fetchProperties } = await import('../lib/apex27.mjs');
 
 async function cacheListings() {
   const properties = await fetchProperties();


### PR DESCRIPTION
## Summary
- expose `APEX27_API_KEY` and optional branch ID to Next.js build jobs
- run `npm run cache` during CI to populate listings before `next build`
- ensure property IDs are treated as strings when generating static paths and querying cached data

## Testing
- `npm test`
- `npm run cache`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2170f47f8832e9f090f326a215acd