### PR TITLE
Improve property listing layout

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,9 +1,20 @@
 export default function PropertyCard({ property }) {
+  const status = property.status ? property.status.replace(/_/g, ' ') : null;
   return (
     <div className="property-card">
-      <h2>{property.title}</h2>
-      {property.image && <img src={property.image} alt={property.title} />}
-      <p>{property.price}</p>
+      <div className="image-wrapper">
+        {property.image && (
+          <img src={property.image} alt={property.title} />
+        )}
+        {status && <span className="status-badge">{status}</span>}
+      </div>
+      <div className="details">
+        <h3 className="title">{property.title}</h3>
+        {property.price && <p className="price">{property.price}</p>}
+        {property.description && (
+          <p className="description">{property.description}</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/PropertyList.js
+++ b/components/PropertyList.js
@@ -5,7 +5,7 @@ export default function PropertyList({ properties }) {
   return (
     <div className="property-list">
       {properties.map((p) => (
-        <Link href={`/property/${p.id}`} key={p.id}>
+        <Link href={`/property/${p.id}`} key={p.id} className="property-link">
           <PropertyCard property={p} />
         </Link>
       ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,8 +6,67 @@ body {
   color: #000;
 }
 
+.property-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.property-list a {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
 .property-card {
-  border: 1px solid #ccc;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.property-card .image-wrapper {
+  position: relative;
+}
+
+.property-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.property-card .status-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: #ffe500;
+  color: #000;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.property-card .details {
   padding: 1rem;
-  margin-bottom: 1rem;
+}
+
+.property-card .title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.property-card .price {
+  margin: 0.5rem 0;
+  font-weight: bold;
+  color: #008060;
+}
+
+.property-card .description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #555;
 }


### PR DESCRIPTION
## Summary
- Redesign property cards with image overlays, status badge, and price/details
- Add grid-based property list styling for more polished layout
- Make entire property cards clickable links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c220846db0832e8e74de000e5fdf9e