### PR TITLE
Show featured sales and filter sale listings

### DIFF
--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -12,6 +12,11 @@ export default function ForSale({ properties }) {
 }
 
 export async function getStaticProps() {
-  const properties = await fetchPropertiesByType('sale');
+  const allSale = await fetchPropertiesByType('sale');
+  const allowed = ['available', 'under_offer', 'sold'];
+  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
+  const properties = allSale.filter(
+    (p) => p.status && allowed.includes(normalize(p.status))
+  );
   return { props: { properties } };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ export default function Home({ properties }) {
       <Features />
       <Stats />
       <section className={styles.listings} id="listings">
-        <h2>Featured Lettings</h2>
+        <h2>Featured Sales</h2>
         <PropertyList properties={properties} />
       </section>
     </main>
@@ -20,7 +20,12 @@ export default function Home({ properties }) {
 }
 
 export async function getStaticProps() {
-  const allRent = await fetchPropertiesByType('rent');
-  const properties = allRent.filter((p) => p.featured);
+  const allSale = await fetchPropertiesByType('sale');
+  const allowed = ['available', 'under_offer', 'sold'];
+  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
+  const sale = allSale.filter(
+    (p) => p.status && allowed.includes(normalize(p.status))
+  );
+  const properties = sale.filter((p) => p.featured);
   return { props: { properties } };
 }


### PR DESCRIPTION
## Summary
- Display featured sales properties on the home page
- Filter for-sale listings to only include available, under-offer, or sold statuses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c22347fb5c832e9355e31fd0ae7613