### PR TITLE
Add image slider and slide-out offer form to property page

### DIFF
--- a/components/ImageSlider.js
+++ b/components/ImageSlider.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import styles from '../styles/ImageSlider.module.css';
+
+export default function ImageSlider({ images = [] }) {
+  const [index, setIndex] = useState(0);
+  if (!images || images.length === 0) return null;
+
+  const prev = () => setIndex((index - 1 + images.length) % images.length);
+  const next = () => setIndex((index + 1) % images.length);
+
+  return (
+    <div className={styles.slider}>
+      <img src={images[index]} alt={`Property image ${index + 1}`} />
+      {images.length > 1 && (
+        <>
+          <button className={styles.prev} onClick={prev} aria-label="Previous image">
+            &#10094;
+          </button>
+          <button className={styles.next} onClick={next} aria-label="Next image">
+            &#10095;
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import styles from '../styles/OfferDrawer.module.css';
+
+export default function OfferDrawer({ propertyTitle }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button className={styles.offerButton} onClick={() => setOpen(true)}>
+        Make an offer
+      </button>
+      {open && <div className={styles.overlay} onClick={() => setOpen(false)}></div>}
+      <aside className={`${styles.drawer} ${open ? styles.open : ''}`}>
+        <div className={styles.header}>
+          <h2>Make an offer</h2>
+          <button className={styles.close} onClick={() => setOpen(false)} aria-label="Close">
+            &times;
+          </button>
+        </div>
+        <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+          <p className={styles.address}>{propertyTitle}</p>
+          <label>
+            Offer price
+            <input type="number" name="price" />
+          </label>
+          <label>
+            Frequency
+            <select name="frequency">
+              <option value="pw">Per week</option>
+              <option value="pcm">Per month</option>
+            </select>
+          </label>
+          <button type="submit" className={styles.submit}>
+            Make an offer
+          </button>
+        </form>
+      </aside>
+    </>
+  );
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -1,5 +1,11 @@
 import PropertyList from '../../components/PropertyList';
-import { fetchPropertyById, fetchProperties, fetchPropertiesByType } from '../../lib/apex27.mjs';
+import ImageSlider from '../../components/ImageSlider';
+import OfferDrawer from '../../components/OfferDrawer';
+import {
+  fetchPropertyById,
+  fetchProperties,
+  fetchPropertiesByType,
+} from '../../lib/apex27.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 
 export default function Property({ property, recommendations }) {
@@ -9,12 +15,15 @@ export default function Property({ property, recommendations }) {
   return (
     <main className={styles.main}>
       <section className={styles.hero}>
-        {property.image && (
-          <img className={styles.image} src={property.image} alt={property.title} />
+        {property.images && property.images.length > 0 && (
+          <div className={styles.sliderWrapper}>
+            <ImageSlider images={property.images} />
+          </div>
         )}
         <div className={styles.summary}>
           <h1>{property.title}</h1>
           {property.price && <p className={styles.price}>{property.price}</p>}
+          <OfferDrawer propertyTitle={property.title} />
         </div>
       </section>
 
@@ -81,6 +90,7 @@ export async function getStaticProps({ params }) {
         rawProperty.images && rawProperty.images[0]
           ? rawProperty.images[0].url
           : null,
+      images: rawProperty.images ? rawProperty.images.map((img) => img.url) : [],
       features:
         rawProperty.mainFeatures ||
         rawProperty.keyFeatures ||

--- a/styles/ImageSlider.module.css
+++ b/styles/ImageSlider.module.css
@@ -1,0 +1,31 @@
+.slider {
+  position: relative;
+  width: 100%;
+}
+
+.slider img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border: 1px solid #ccc;
+}
+
+.prev,
+.next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+.prev {
+  left: 0.5rem;
+}
+
+.next {
+  right: 0.5rem;
+}

--- a/styles/OfferDrawer.module.css
+++ b/styles/OfferDrawer.module.css
@@ -1,0 +1,72 @@
+.offerButton {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #0070f3;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 320px;
+  max-width: 100%;
+  height: 100vh;
+  background: #fff;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.address {
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.submit {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #0070f3;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}

--- a/styles/PropertyDetails.module.css
+++ b/styles/PropertyDetails.module.css
@@ -11,11 +11,8 @@
   align-items: flex-start;
 }
 
-.image {
+.sliderWrapper {
   width: 60%;
-  height: auto;
-  object-fit: cover;
-  border: 1px solid #ccc;
 }
 
 .summary {


### PR DESCRIPTION
## Summary
- Display property photos in a simple one-at-a-time slider on the property detail page
- Introduce an interactive "Make an offer" button that opens a slide-out form
- Fetch full image arrays for properties to power the new slider

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c222e86458832e88661c5cfaf61bf9