### PR TITLE
Add image slider to property listing cards

### DIFF
--- a/components/ImageSlider.js
+++ b/components/ImageSlider.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styles from '../styles/ImageSlider.module.css';
 
-export default function ImageSlider({ images = [] }) {
+export default function ImageSlider({ images = [], imgStyle = {} }) {
   const [index, setIndex] = useState(0);
   if (!images || images.length === 0) return null;
 
@@ -10,7 +10,11 @@ export default function ImageSlider({ images = [] }) {
 
   return (
     <div className={styles.slider}>
-      <img src={images[index]} alt={`Property image ${index + 1}`} />
+      <img
+        src={images[index]}
+        alt={`Property image ${index + 1}`}
+        style={imgStyle}
+      />
       {images.length > 1 && (
         <>
           <button className={styles.prev} onClick={prev} aria-label="Previous image">

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,10 +1,23 @@
+import ImageSlider from './ImageSlider';
+
 export default function PropertyCard({ property }) {
   const status = property.status ? property.status.replace(/_/g, ' ') : null;
   return (
     <div className="property-card">
       <div className="image-wrapper">
-        {property.image && (
-          <img src={property.image} alt={property.title} />
+        {property.images && property.images.length > 0 ? (
+          <ImageSlider
+            images={property.images}
+            imgStyle={{
+              width: '100%',
+              height: '200px',
+              objectFit: 'cover',
+              display: 'block',
+              border: 0,
+            }}
+          />
+        ) : (
+          property.image && <img src={property.image} alt={property.title} />
         )}
         {status && <span className="status-badge">{status}</span>}
       </div>

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -119,6 +119,7 @@ export async function fetchPropertiesByType(type) {
           : p.price
         : null,
     image: p.images && p.images[0] ? p.images[0].url : null,
+    images: p.images ? p.images.map((img) => img.url) : [],
     status: p.status ?? null,
     featured: p.featured ?? false,
 


### PR DESCRIPTION
## Summary
- show multiple property photos in card view using slider
- expose image arrays from API and allow slider image styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c226be7ecc832e8ec2b3941b7d06ab