### PR TITLE
Display featured sales and lettings on homepage

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -11,6 +11,9 @@ export default function PropertyCard({ property }) {
         ) : (
           property.image && <img src={property.image} alt={property.title} />
         )}
+        {property.featured && (
+          <span className="featured-badge">Featured</span>
+        )}
         {status && <span className="status-badge">{status}</span>}
       </div>
       <div className="details">

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Stats from '../components/Stats';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function Home({ properties }) {
+export default function Home({ sales, lettings }) {
   return (
     <main className={styles.main}>
       <Hero />
@@ -13,19 +13,32 @@ export default function Home({ properties }) {
       <Stats />
       <section className={styles.listings} id="listings">
         <h2>Featured Sales</h2>
-        <PropertyList properties={properties} />
+        <PropertyList properties={sales} />
+      </section>
+      <section className={styles.listings}>
+        <h2>Featured Lettings</h2>
+        <PropertyList properties={lettings} />
       </section>
     </main>
   );
 }
 
 export async function getStaticProps() {
-  const allSale = await fetchPropertiesByType('sale');
-  const allowed = ['available', 'under_offer', 'sold'];
+  const [allSale, allRent] = await Promise.all([
+    fetchPropertiesByType('sale'),
+    fetchPropertiesByType('rent'),
+  ]);
+
   const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  const sale = allSale.filter(
-    (p) => p.status && allowed.includes(normalize(p.status))
-  );
-  const properties = sale.filter((p) => p.featured);
-  return { props: { properties } };
+  const isAvailable = (p) => p.status && normalize(p.status) === 'available';
+
+  const sales = allSale
+    .filter((p) => isAvailable(p) && p.featured)
+    .slice(0, 4);
+
+  const lettings = allRent
+    .filter((p) => isAvailable(p) && p.featured)
+    .slice(0, 4);
+
+  return { props: { sales, lettings } };
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,10 +46,21 @@ body {
   border: none;
 }
 
-.property-card .status-badge {
+.property-card .featured-badge {
   position: absolute;
   top: 8px;
   left: 8px;
+  background: #ffe500;
+  color: #000;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.property-card .status-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
   background: #ffe500;
   color: #000;
   padding: 2px 6px;


### PR DESCRIPTION
## Summary
- Display separate sections for Featured Sales and Featured Lettings on the homepage
- Limit both sections to four available, featured properties
- Add "Featured" badge styling and reposition status badge on property cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c22b2d36f0832e97372fdc975fc5a3