### PR TITLE
Uniform property card and image heights

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,12 +10,14 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 2rem;
+  align-items: stretch;
 }
 
-.property-list a {
+.property-list .property-link {
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
+  height: 100%;
 }
 
 .property-card {
@@ -26,22 +28,24 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
+  height: 100%;
 }
 
 .property-card .image-wrapper {
   position: relative;
+  height: 200px;
 }
 
 .property-card img {
   width: 100%;
-  height: 200px;
+  height: 100%;
   object-fit: cover;
   display: block;
 }
 
 .property-card .slider img {
   width: 100%;
-  height: 200px;
+  height: 100%;
   object-fit: cover;
   border: none;
 }
@@ -59,6 +63,9 @@ body {
 
 .property-card .details {
   padding: 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .property-card .title {
@@ -76,4 +83,10 @@ body {
   margin: 0;
   font-size: 0.875rem;
   color: #555;
+}
+
+@media (max-width: 600px) {
+  .property-card .image-wrapper {
+    height: 150px;
+  }
 }


### PR DESCRIPTION
## Summary
- Make property cards fill their grid cells for consistent heights.
- Give property images a fixed wrapper with responsive height and ensure images cover uniformly.
- Adjust mobile layout with media query for smaller image height.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c22bb0f894832ea7082eb397f28fe5