### PR TITLE
Fix property card height to 700px

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,7 +28,7 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 700px;
 }
 
 .property-card .image-wrapper {


### PR DESCRIPTION
## Summary
- Set property card container height to fixed 700px for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c22ee9f870832eae16ee244e3800db