### PR TITLE
Increase image slider height to 400px

### DIFF
--- a/styles/ImageSlider.module.css
+++ b/styles/ImageSlider.module.css
@@ -1,11 +1,11 @@
 .slider {
   position: relative;
-  height: 300px;
+  height: 400px;
 }
 
 .slide img {
   width: 100%;
-  height: 300px;
+  height: 400px;
   display: block;
   object-fit: cover;
   border: 1px solid #ccc;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,7 +38,7 @@ body {
 .property-card .image-wrapper {
   position: relative;
   width: 100%;
-  height: 200px;
+  height: 400px;
 }
 
 .property-card img {
@@ -50,8 +50,8 @@ body {
 }
 
 .property-card .slider img {
-  width: 300px;
-  height: 300px;
+  width: 100%;
+  height: 400px;
   object-fit: cover;
   border: none;
 }
@@ -109,11 +109,11 @@ body {
   }
 
   .property-card .image-wrapper {
-    height: 150px;
+    height: 400px;
   }
 
   .property-card .slider img {
-    height: 150px;
+    height: 400px;
 
   }
 }


### PR DESCRIPTION
## Summary
- bump image slider and slide image height to 400px
- enlarge property card image wrapper and slider images to match 400px height, including on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c23846f2d8832e85941aa20de423b1