### PR TITLE
Display property type and room counts on details page

### DIFF
--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -7,6 +7,7 @@ import {
   fetchPropertiesByType,
 } from '../../lib/apex27.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
+import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 
 export default function Property({ property, recommendations }) {
   if (!property) return <div>Property not found</div>;
@@ -22,6 +23,24 @@ export default function Property({ property, recommendations }) {
         )}
         <div className={styles.summary}>
           <h1>{property.title}</h1>
+          {property.type && <p className={styles.type}>{property.type}</p>}
+          <div className={styles.stats}>
+            {property.receptions != null && (
+              <span>
+                <FaCouch /> {property.receptions}
+              </span>
+            )}
+            {property.bedrooms != null && (
+              <span>
+                <FaBed /> {property.bedrooms}
+              </span>
+            )}
+            {property.bathrooms != null && (
+              <span>
+                <FaBath /> {property.bathrooms}
+              </span>
+            )}
+          </div>
           {property.price && <p className={styles.price}>{property.price}</p>}
           <OfferDrawer propertyTitle={property.title} />
         </div>
@@ -96,6 +115,11 @@ export async function getStaticProps({ params }) {
         rawProperty.keyFeatures ||
         rawProperty.features ||
         [],
+      type: rawProperty.propertyType || rawProperty.type || '',
+      receptions:
+        rawProperty.receptionRooms ?? rawProperty.receptions ?? null,
+      bedrooms: rawProperty.bedrooms ?? rawProperty.beds ?? null,
+      bathrooms: rawProperty.bathrooms ?? rawProperty.baths ?? null,
     };
   }
 

--- a/styles/PropertyDetails.module.css
+++ b/styles/PropertyDetails.module.css
@@ -19,6 +19,25 @@
   flex: 1;
 }
 
+.type {
+  font-size: 1.1rem;
+  margin-top: 0.25rem;
+  color: #555;
+}
+
+.stats {
+  display: flex;
+  gap: 1rem;
+  margin: 0.5rem 0;
+  color: #555;
+}
+
+.stats span {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .price {
   font-size: 1.5rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- show property type underneath the title on the details page
- display receptions, bedrooms and bathrooms with icons
- extend property data to include type and room counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23ac7e7a0832eb57ff34b17a46d2d