### PR TITLE
Enable property search across sale and rent listings

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -1,9 +1,21 @@
 import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import styles from '../styles/Home.module.css';
 
 export default function SearchBar() {
   const [mode, setMode] = useState('buy');
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const base = mode === 'buy' ? '/for-sale' : '/to-rent';
+    const url = query.trim()
+      ? `${base}?search=${encodeURIComponent(query.trim())}`
+      : base;
+    router.push(url);
+  }
 
   return (
     <div className={styles.searchWrapper}>
@@ -24,8 +36,13 @@ export default function SearchBar() {
         </button>
       </div>
       <div className={styles.searchControls}>
-        <form className={styles.searchBar} onSubmit={(e) => e.preventDefault()}>
-          <input type="text" placeholder="Search area or postcode" />
+        <form className={styles.searchBar} onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Search area or postcode"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
           <button type="submit">Search</button>
         </form>
         <Link href="/valuation" className={styles.valuationButton}>

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -2,21 +2,32 @@ import PropertyList from '../components/PropertyList';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function ForSale({ properties }) {
+export default function ForSale({ properties, search }) {
   return (
     <main className={styles.main}>
-      <h1>Properties for Sale</h1>
+      <h1>{search ? `Search results for "${search}"` : 'Properties for Sale'}</h1>
       <PropertyList properties={properties} />
     </main>
   );
 }
 
-export async function getStaticProps() {
+export async function getServerSideProps({ query }) {
   const allSale = await fetchPropertiesByType('sale');
   const allowed = ['available', 'under_offer', 'sold'];
   const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  const properties = allSale.filter(
+  let properties = allSale.filter(
     (p) => p.status && allowed.includes(normalize(p.status))
   );
-  return { props: { properties } };
+
+  const search = query.search ? String(query.search) : '';
+  if (search) {
+    const lower = search.toLowerCase();
+    properties = properties.filter(
+      (p) =>
+        p.title.toLowerCase().includes(lower) ||
+        (p.description && p.description.toLowerCase().includes(lower))
+    );
+  }
+
+  return { props: { properties, search } };
 }

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -2,16 +2,25 @@ import PropertyList from '../components/PropertyList';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function ToRent({ properties }) {
+export default function ToRent({ properties, search }) {
   return (
     <main className={styles.main}>
-      <h1>Properties to Rent</h1>
+      <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
       <PropertyList properties={properties} />
     </main>
   );
 }
 
-export async function getStaticProps() {
-  const properties = await fetchPropertiesByType('rent');
-  return { props: { properties } };
+export async function getServerSideProps({ query }) {
+  let properties = await fetchPropertiesByType('rent');
+  const search = query.search ? String(query.search) : '';
+  if (search) {
+    const lower = search.toLowerCase();
+    properties = properties.filter(
+      (p) =>
+        p.title.toLowerCase().includes(lower) ||
+        (p.description && p.description.toLowerCase().includes(lower))
+    );
+  }
+  return { props: { properties, search } };
 }


### PR DESCRIPTION
## Summary
- Add working home page search bar that routes to sale or rent listings with query
- Filter sale and rent pages on server side to show results matching search text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23e9422f4832eb0bd9a36bb50f690