### PR TITLE
Display viewing button beside offer button

### DIFF
--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -43,7 +43,10 @@ export default function Property({ property, recommendations }) {
             )}
           </div>
           {property.price && <p className={styles.price}>{property.price}</p>}
-          <OfferDrawer propertyTitle={property.title} />
+          <div className={styles.actions}>
+            <OfferDrawer propertyTitle={property.title} />
+            <ViewingForm propertyTitle={property.title} />
+          </div>
         </div>
       </section>
 
@@ -67,7 +70,6 @@ export default function Property({ property, recommendations }) {
 
       <section className={styles.contact}>
         <p>Interested in this property?</p>
-        <ViewingForm propertyTitle={property.title} />
         <a href="tel:+441234567890">Call our team</a>
       </section>
 

--- a/styles/OfferDrawer.module.css
+++ b/styles/OfferDrawer.module.css
@@ -1,5 +1,4 @@
 .offerButton {
-  margin-top: 1rem;
   padding: 0.5rem 1rem;
   background-color: #0070f3;
   color: #fff;

--- a/styles/PropertyDetails.module.css
+++ b/styles/PropertyDetails.module.css
@@ -19,6 +19,12 @@
   flex: 1;
 }
 
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
 .type {
   font-size: 1.1rem;
   margin-top: 0.25rem;

--- a/styles/ViewingForm.module.css
+++ b/styles/ViewingForm.module.css
@@ -1,5 +1,4 @@
 .viewingButton {
-  margin-top: 1rem;
   padding: 0.5rem 1rem;
   background-color: #0070f3;
   color: #fff;


### PR DESCRIPTION
## Summary
- Move "Book a viewing" trigger next to "Make an offer" on property page
- Add flex-based actions container for aligned buttons
- Clean up button styles by removing top margins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c23f3e0078832e9f2491719f191b06