### PR TITLE
Use static props for property listings

### DIFF
--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -1,33 +1,38 @@
+import { useMemo } from 'react';
+import { useRouter } from 'next/router';
 import PropertyList from '../components/PropertyList';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function ForSale({ properties, search }) {
-  return (
-    <main className={styles.main}>
-      <h1>{search ? `Search results for "${search}"` : 'Properties for Sale'}</h1>
-      <PropertyList properties={properties} />
-    </main>
-  );
-}
+export default function ForSale({ properties }) {
+  const router = useRouter();
+  const search = typeof router.query.search === 'string' ? router.query.search : '';
 
-export async function getServerSideProps({ query }) {
-  const allSale = await fetchPropertiesByType('sale');
-  const allowed = ['available', 'under_offer', 'sold'];
-  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  let properties = allSale.filter(
-    (p) => p.status && allowed.includes(normalize(p.status))
-  );
-
-  const search = query.search ? String(query.search) : '';
-  if (search) {
+  const filtered = useMemo(() => {
+    if (!search) return properties;
     const lower = search.toLowerCase();
-    properties = properties.filter(
+    return properties.filter(
       (p) =>
         p.title.toLowerCase().includes(lower) ||
         (p.description && p.description.toLowerCase().includes(lower))
     );
-  }
+  }, [properties, search]);
 
-  return { props: { properties, search } };
+  return (
+    <main className={styles.main}>
+      <h1>{search ? `Search results for "${search}"` : 'Properties for Sale'}</h1>
+      <PropertyList properties={filtered} />
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const allSale = await fetchPropertiesByType('sale');
+  const allowed = ['available', 'under_offer', 'sold'];
+  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
+  const properties = allSale.filter(
+    (p) => p.status && allowed.includes(normalize(p.status))
+  );
+
+  return { props: { properties } };
 }

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -1,26 +1,32 @@
+import { useMemo } from 'react';
+import { useRouter } from 'next/router';
 import PropertyList from '../components/PropertyList';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function ToRent({ properties, search }) {
-  return (
-    <main className={styles.main}>
-      <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
-      <PropertyList properties={properties} />
-    </main>
-  );
-}
+export default function ToRent({ properties }) {
+  const router = useRouter();
+  const search = typeof router.query.search === 'string' ? router.query.search : '';
 
-export async function getServerSideProps({ query }) {
-  let properties = await fetchPropertiesByType('rent');
-  const search = query.search ? String(query.search) : '';
-  if (search) {
+  const filtered = useMemo(() => {
+    if (!search) return properties;
     const lower = search.toLowerCase();
-    properties = properties.filter(
+    return properties.filter(
       (p) =>
         p.title.toLowerCase().includes(lower) ||
         (p.description && p.description.toLowerCase().includes(lower))
     );
-  }
-  return { props: { properties, search } };
+  }, [properties, search]);
+
+  return (
+    <main className={styles.main}>
+      <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
+      <PropertyList properties={filtered} />
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const properties = await fetchPropertiesByType('rent');
+  return { props: { properties } };
 }


### PR DESCRIPTION
## Summary
- refactor property listing pages to use `getStaticProps`
- move search filtering client-side for sale and rent listings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c240fa0d58832ea1d3e5cfdc4f80bc