### PR TITLE
feat: add area guides page with regions

### DIFF
--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -1,4 +1,5 @@
 const API_URL = 'https://api.apex27.co.uk/listings';
+const REGIONS_URL = 'https://api.apex27.co.uk/search-regions';
 
 // Lazy-load cached listings only on the server to avoid bundling fs in the browser
 async function getCachedProperties() {
@@ -126,4 +127,57 @@ export async function fetchPropertiesByType(type) {
     featured: p.featured ?? false,
 
   }));
+}
+
+export async function fetchSearchRegions() {
+  if (!process.env.APEX27_API_KEY) {
+    return [];
+  }
+
+  try {
+    const res = await fetch(REGIONS_URL, {
+      headers: {
+        'x-api-key': process.env.APEX27_API_KEY,
+        accept: 'application/json',
+      },
+    });
+
+    if (res.status === 403) {
+      console.error('Apex27 API key unauthorized (HTTP 403).');
+      return [];
+    }
+
+    if (!res.ok) {
+      console.error('Failed to fetch search regions', res.status);
+      return [];
+    }
+
+    const data = await res.json();
+    const regions = Array.isArray(data) ? data : data.data || data.regions || [];
+
+    if (regions.some((r) => Array.isArray(r.children) && r.children.length)) {
+      return regions;
+    }
+
+    const map = new Map();
+    regions.forEach((r) => {
+      map.set(r.id, { ...r, children: [] });
+    });
+
+    const roots = [];
+    regions.forEach((r) => {
+      const parentId = r.parentId ?? r.parent_id ?? r.parent ?? null;
+      const node = map.get(r.id);
+      if (parentId && map.has(parentId)) {
+        map.get(parentId).children.push(node);
+      } else {
+        roots.push(node);
+      }
+    });
+
+    return roots;
+  } catch (err) {
+    console.error('Failed to fetch search regions', err);
+    return [];
+  }
 }

--- a/pages/area-guides/index.js
+++ b/pages/area-guides/index.js
@@ -1,0 +1,28 @@
+import { fetchSearchRegions } from '../../lib/apex27.mjs';
+import styles from '../../styles/AreaGuides.module.css';
+
+export default function AreaGuides({ regions }) {
+  return (
+    <main className={styles.main}>
+      <h1>Area Guides</h1>
+      {regions.map((region) => (
+        <section key={region.id} className={styles.region}>
+          <h2>{region.name}</h2>
+          {region.children && region.children.length > 0 && (
+            <ul className={styles.subAreas}>
+              {region.children.map((sub) => (
+                <li key={sub.id}>{sub.name}</li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+      {regions.length === 0 && <p>No regions available.</p>}
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const regions = await fetchSearchRegions();
+  return { props: { regions } };
+}

--- a/styles/AreaGuides.module.css
+++ b/styles/AreaGuides.module.css
@@ -1,0 +1,20 @@
+.main {
+  padding: 2rem 1rem;
+}
+
+.region {
+  margin-bottom: 2rem;
+}
+
+.region h2 {
+  margin-bottom: 0.5rem;
+}
+
+.subAreas {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.subAreas li {
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
## Summary
- add search region fetcher for Apex27 API
- list parent and sub areas on new area guides page
- style area guide sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c24321b180832ea99dcf602e773f0f