### PR TITLE
Fix lettings listing navigation

### DIFF
--- a/components/PropertyList.js
+++ b/components/PropertyList.js
@@ -5,8 +5,10 @@ export default function PropertyList({ properties }) {
   return (
     <div className="property-list">
       {properties.map((p) => (
-        <Link href={`/property/${p.id}`} key={p.id} className="property-link">
-          <PropertyCard property={p} />
+        <Link href={`/property/${p.id}`} key={p.id} legacyBehavior>
+          <a className="property-link">
+            <PropertyCard property={p} />
+          </a>
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Wrap `PropertyCard` in an `<a>` tag within Next.js `Link` to ensure listing items navigate to property detail pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c24f9148a0832ea36eb58fea68084e