### PR TITLE
feat: show rent frequency for rental properties

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,4 +1,5 @@
 import ImageSlider from './ImageSlider';
+import { formatRentFrequency } from '../lib/format.mjs';
 
 export default function PropertyCard({ property }) {
   const status = property.status ? property.status.replace(/_/g, ' ') : null;
@@ -18,7 +19,13 @@ export default function PropertyCard({ property }) {
       </div>
       <div className="details">
         <h3 className="title">{property.title}</h3>
-        {property.price && <p className="price">{property.price}</p>}
+        {property.price && (
+          <p className="price">
+            {property.price}
+            {property.rentFrequency &&
+              ` ${formatRentFrequency(property.rentFrequency)}`}
+          </p>
+        )}
         {property.description && (
           <p className="description">{property.description}</p>
         )}

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -127,6 +127,7 @@ export async function fetchPropertiesByType(type) {
           ? `£${p.price}`
           : p.price
         : null,
+    rentFrequency: p.rentFrequency ?? null,
     image: p.images && p.images[0] ? p.images[0].url : null,
     images: p.images ? p.images.map((img) => img.url) : [],
     status: p.status ?? null,

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -1,0 +1,10 @@
+export function formatRentFrequency(freq) {
+  if (!freq) return '';
+  const map = {
+    W: 'pw',
+    M: 'pcm',
+    Q: 'pq',
+    Y: 'pa',
+  };
+  return map[freq] || freq;
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -9,6 +9,7 @@ import {
 } from '../../lib/apex27.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
+import { formatRentFrequency } from '../../lib/format.mjs';
 
 export default function Property({ property, recommendations }) {
   if (!property) return <div>Property not found</div>;
@@ -42,7 +43,13 @@ export default function Property({ property, recommendations }) {
               </span>
             )}
           </div>
-          {property.price && <p className={styles.price}>{property.price}</p>}
+          {property.price && (
+            <p className={styles.price}>
+              {property.price}
+              {property.rentFrequency &&
+                ` ${formatRentFrequency(property.rentFrequency)}`}
+            </p>
+          )}
           <div className={styles.actions}>
             <OfferDrawer propertyTitle={property.title} />
             <ViewingForm propertyTitle={property.title} />
@@ -109,6 +116,7 @@ export async function getStaticProps({ params }) {
             ? `£${rawProperty.price}`
             : rawProperty.price
           : null,
+      rentFrequency: rawProperty.rentFrequency ?? null,
       image:
         rawProperty.images && rawProperty.images[0]
           ? rawProperty.images[0].url


### PR DESCRIPTION
## Summary
- include rent frequency in property API mapping
- display rent frequency next to price on property card and details
- add rent frequency formatter for common codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c250df9da8832eab3c5f251bdcda08