### PR TITLE
Fix rental property page paths

### DIFF
--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -91,10 +91,14 @@ export default function Property({ property, recommendations }) {
 }
 
 export async function getStaticPaths() {
-  const properties = await fetchProperties();
+  const [sale, rent] = await Promise.all([
+    fetchProperties({ transactionType: 'sale' }),
+    fetchProperties({ transactionType: 'rent' }),
+  ]);
+  const properties = [...sale, ...rent];
   return {
     paths: properties.map((p) => ({ params: { id: String(p.id) } })),
-    fallback: false,
+    fallback: 'blocking',
   };
 }
 


### PR DESCRIPTION
## Summary
- fetch both sale and rent listings when generating property paths
- enable blocking fallback for property page generation

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c253130c38832e8c810f9e6b41bd27