### PR TITLE
Improve responsive design for property site

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -99,12 +99,14 @@
 
 .searchControls {
   display: flex;
+  flex-direction: column;
   margin-top: 0.5rem;
 }
 
 .searchBar {
   flex: 1;
   display: flex;
+  flex-direction: column;
 }
 
 .searchBar input {
@@ -118,10 +120,12 @@
   background: #808080;
   color: #fff;
   border: none;
+  margin-top: 0.5rem;
 }
 
 .valuationButton {
-  margin-left: 0.5rem;
+  margin-left: 0;
+  margin-top: 0.5rem;
   background: #ffe500;
   color: #000;
   padding: 0.5rem 1rem;
@@ -132,6 +136,8 @@
 
 .stats {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
   justify-content: space-around;
   padding: 2rem 1rem;
   background: #f5f5f5;
@@ -167,7 +173,7 @@
   background: #fff;
   padding: 1rem;
   border-radius: 4px;
-  width: 200px;
+  width: 100%;
   text-align: center;
 }
 
@@ -178,4 +184,31 @@
 
 .listings {
   padding: 2rem 1rem;
+}
+
+@media (min-width: 768px) {
+  .searchControls {
+    flex-direction: row;
+  }
+
+  .searchBar {
+    flex-direction: row;
+  }
+
+  .searchBar button {
+    margin-top: 0;
+  }
+
+  .valuationButton {
+    margin-left: 0.5rem;
+    margin-top: 0;
+  }
+
+  .stats {
+    flex-direction: row;
+  }
+
+  .featureCard {
+    width: 200px;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,10 +15,9 @@ body {
 
 .property-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 400px);
+  grid-template-columns: 1fr;
   gap: 2rem;
   align-items: stretch;
-
   justify-content: center;
 }
 
@@ -27,7 +26,6 @@ body {
   color: inherit;
   display: flex;
   height: 100%;
-
 }
 
 .property-card {
@@ -39,26 +37,24 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-
 }
 
 .property-card .image-wrapper {
   position: relative;
   width: 100%;
-  height: 400px;
+  height: 260px;
 }
 
 .property-card img {
   width: 100%;
   height: 100%;
-
   object-fit: cover;
   display: block;
 }
 
 .property-card .slider img {
   width: 100%;
-  height: 400px;
+  height: 260px;
   object-fit: cover;
   border: none;
 }
@@ -90,7 +86,6 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-
 }
 
 .property-card .title {
@@ -110,17 +105,24 @@ body {
   color: #555;
 }
 
-@media (max-width: 600px) {
+@media (min-width: 768px) {
   .property-list {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
 
-  .property-card .image-wrapper {
-    height: 400px;
+  .property-card .image-wrapper,
+  .property-card .slider img {
+    height: 320px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .property-list {
+    grid-template-columns: repeat(3, 1fr);
   }
 
+  .property-card .image-wrapper,
   .property-card .slider img {
     height: 400px;
-
   }
 }


### PR DESCRIPTION
## Summary
- Refine global property list and card styles with mobile-first breakpoints for tablet and desktop layouts
- Make home page search controls, stats, and feature cards stack on small screens and align in rows on larger screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25900a7e8832eb75167d0414733a0