### PR TITLE
Enable static export for GitHub Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ const isProd = process.env.NODE_ENV === 'production';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   images: { unoptimized: true },
   basePath: isProd && repo ? `/${repo}` : undefined,
   assetPrefix: isProd && repo ? `/${repo}/` : undefined,


### PR DESCRIPTION
## Summary
- enable static export in Next.js config so `npm run build` generates a deployable `out` folder for GitHub Pages

## Testing
- `npm test`
- `npm run build` *(fails: Module not found: Can't resolve 'nodemailer')*


------
https://chatgpt.com/codex/tasks/task_e_68c25a062c58832e8e16c975f7e6af0d