### PR TITLE
fix: handle property features from varied formats

### DIFF
--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -13,7 +13,7 @@ import { formatRentFrequency } from '../../lib/format.mjs';
 
 export default function Property({ property, recommendations }) {
   if (!property) return <div>Property not found</div>;
-  const features = property.features || [];
+  const features = Array.isArray(property.features) ? property.features : [];
 
   return (
     <main className={styles.main}>
@@ -132,11 +132,22 @@ export async function getStaticProps({ params }) {
           ? rawProperty.images[0].url
           : null,
       images: rawProperty.images ? rawProperty.images.map((img) => img.url) : [],
-      features:
-        rawProperty.mainFeatures ||
-        rawProperty.keyFeatures ||
-        rawProperty.features ||
-        [],
+      features: (() => {
+        const rawFeatures =
+          rawProperty.mainFeatures ||
+          rawProperty.keyFeatures ||
+          rawProperty.features ||
+          rawProperty.bullets ||
+          [];
+        if (Array.isArray(rawFeatures)) return rawFeatures;
+        if (typeof rawFeatures === 'string') {
+          return rawFeatures
+            .split(/\r?\n|,/)
+            .map((f) => f.trim())
+            .filter(Boolean);
+        }
+        return [];
+      })(),
       type: rawProperty.propertyType || rawProperty.type || '',
       receptions:
         rawProperty.receptionRooms ?? rawProperty.receptions ?? null,


### PR DESCRIPTION
## Summary
- ensure property features are treated as arrays on the property details page
- parse feature strings and include `bullets` field when formatting property data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25ab6cd38832eb6baa376d810c6c7