### PR TITLE
refactor: streamline hero for mobile

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,19 +1,9 @@
-import Link from 'next/link';
 import styles from '../styles/Home.module.css';
 import SearchBar from './SearchBar';
 
 export default function Hero() {
   return (
     <section className={styles.hero}>
-      <nav className={styles.nav}>
-        <h1 className={styles.logo}>MyEstate</h1>
-        <div className={styles.navLinks}>
-          <Link href="/for-sale">Buy</Link>
-          <Link href="/to-rent">Rent</Link>
-          <Link href="/sell">Sell</Link>
-        </div>
-        <Link href="/login" className={styles.loginButton}>Login</Link>
-      </nav>
       <div className={styles.heroContent}>
         <h2>London's Estate Agent</h2>
         <p className={styles.subtitle}>Get it done with London's number one</p>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -42,35 +42,6 @@
 }
 
 
-.nav {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.logo {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.navLinks {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
-.navLinks a {
-  margin: 0 1rem;
-  color: #fff;
-  text-decoration: none;
-}
-
-.loginButton {
-  color: #fff;
-  text-decoration: none;
-  margin-left: 1rem;
-}
-
 
 .searchWrapper {
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- remove redundant navigation from hero component
- drop unused nav styles and keep hero search styling
- add viewport meta tag for proper mobile scaling

## Testing
- `npm test`
- `npm run build` *(warnings: ENETUNREACH fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c498428a84832e889bf3f53c32776d