### PR TITLE
Make property details page responsive for mobile

### DIFF
--- a/styles/ImageSlider.module.css
+++ b/styles/ImageSlider.module.css
@@ -51,3 +51,13 @@
   opacity: 1;
 }
 
+@media (max-width: 768px) {
+  .slider {
+    height: 250px;
+  }
+
+  .slide img {
+    height: 250px;
+  }
+}
+

--- a/styles/PropertyDetails.module.css
+++ b/styles/PropertyDetails.module.css
@@ -75,3 +75,30 @@
   color: #fff;
   text-decoration: none;
 }
+
+@media (max-width: 768px) {
+  .hero {
+    flex-direction: column;
+  }
+
+  .sliderWrapper {
+    width: 100%;
+  }
+
+  .summary {
+    width: 100%;
+  }
+
+  .actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .actions > * {
+    width: 100%;
+  }
+
+  .stats {
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- stack hero content and actions vertically on small screens for a cleaner mobile layout
- adjust image slider height for mobile devices

## Testing
- `npm test`
- `npm run build` *(fails to fetch remote data but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_68c498f12008832e8da96cac0c915c70