### PR TITLE
refactor: streamline hero for mobile

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,19 +1,9 @@
-import Link from 'next/link';
 import styles from '../styles/Home.module.css';
 import SearchBar from './SearchBar';
 
 export default function Hero() {
   return (
     <section className={styles.hero}>
-      <nav className={styles.nav}>
-        <h1 className={styles.logo}>MyEstate</h1>
-        <div className={styles.navLinks}>
-          <Link href="/for-sale">Buy</Link>
-          <Link href="/to-rent">Rent</Link>
-          <Link href="/sell">Sell</Link>
-        </div>
-        <Link href="/login" className={styles.loginButton}>Login</Link>
-      </nav>
       <div className={styles.heroContent}>
         <h2>London's Estate Agent</h2>
         <p className={styles.subtitle}>Get it done with London's number one</p>

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -1,6 +1,9 @@
 const API_URL = 'https://api.apex27.co.uk/listings';
 const REGIONS_URL = 'https://api.apex27.co.uk/search-regions';
 
+const API_KEY = process.env.APEX27_API_KEY;
+const HAS_API_KEY = Boolean(API_KEY && API_KEY !== 'X-Api-Key');
+
 function slugify(str) {
   return String(str)
     .toLowerCase()
@@ -24,7 +27,7 @@ async function getCachedProperties() {
 export async function fetchProperties(params = {}) {
   const cached = await getCachedProperties();
 
-  if (!process.env.APEX27_API_KEY) {
+  if (!HAS_API_KEY) {
     return cached ?? [];
   }
 
@@ -41,7 +44,7 @@ export async function fetchProperties(params = {}) {
   try {
     const res = await fetch(`${API_URL}?${searchParams.toString()}`, {
       headers: {
-        'x-api-key': process.env.APEX27_API_KEY,
+        'x-api-key': API_KEY,
         accept: 'application/json',
       },
     });
@@ -69,7 +72,7 @@ export async function fetchPropertyById(id) {
   const cached = await getCachedProperties();
   const idStr = String(id);
 
-  if (!process.env.APEX27_API_KEY) {
+  if (!HAS_API_KEY) {
     return cached
       ?
           cached.find(
@@ -91,7 +94,7 @@ export async function fetchPropertyById(id) {
 
     const res = await fetch(url, {
       headers: {
-        'x-api-key': process.env.APEX27_API_KEY,
+        'x-api-key': API_KEY,
         accept: 'application/json',
       },
     });
@@ -167,14 +170,14 @@ export async function fetchPropertiesByType(type) {
 }
 
 export async function fetchSearchRegions() {
-  if (!process.env.APEX27_API_KEY) {
+  if (!HAS_API_KEY) {
     return [];
   }
 
   try {
     const res = await fetch(REGIONS_URL, {
       headers: {
-        'x-api-key': process.env.APEX27_API_KEY,
+        'x-api-key': API_KEY,
         accept: 'application/json',
       },
     });

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,16 @@
 import '../styles/globals.css';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
+import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
       <Header />
       <Component {...pageProps} />
       <Footer />

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -42,35 +42,6 @@
 }
 
 
-.nav {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.logo {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.navLinks {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
-.navLinks a {
-  margin: 0 1rem;
-  color: #fff;
-  text-decoration: none;
-}
-
-.loginButton {
-  color: #fff;
-  text-decoration: none;
-  margin-left: 1rem;
-}
-
 
 .searchWrapper {
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- remove redundant navigation from hero component
- drop unused nav styles and keep hero search styling
- ensure mobile viewport meta tag is set globally via the app component
- skip Apex27 API fetches when placeholder key is used to avoid build errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c498428a84832e889bf3f53c32776d