### PR TITLE
Add contact API endpoint and integrate form submission

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,0 +1,49 @@
+import nodemailer from 'nodemailer';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { name, email, message } = req.body || {};
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const from = process.env.EMAIL_FROM || process.env.SMTP_USER;
+    const aktonz = process.env.AKTONZ_EMAIL;
+
+    if (aktonz) {
+      await transporter.sendMail({
+        to: aktonz,
+        from,
+        subject: `New enquiry from ${name}`,
+        text: `${name} <${email}> says: ${message}`,
+      });
+    }
+
+    await transporter.sendMail({
+      to: email,
+      from,
+      subject: 'We received your message',
+      text: 'Thank you for contacting us. We will be in touch soon.',
+    });
+  } catch (err) {
+    console.error('Failed to send enquiry emails', err);
+    return res.status(500).json({ error: 'Failed to send message' });
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,25 +1,82 @@
+import { useState } from 'react';
 import styles from '../styles/Home.module.css';
 import contactStyles from '../styles/Contact.module.css';
 
 export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [status, setStatus] = useState({ message: '', error: false });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.id]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus({ message: '', error: false });
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setStatus({ message: 'Message sent successfully.', error: false });
+      setForm({ name: '', email: '', message: '' });
+    } catch (err) {
+      setStatus({ message: 'Failed to send message.', error: true });
+    }
+  };
+
   return (
     <main className={styles.main}>
       <div className={contactStyles.container}>
         <h1>Contact Us</h1>
-        <form className={contactStyles.form}>
+        <form className={contactStyles.form} onSubmit={handleSubmit}>
           <div className={contactStyles.field}>
             <label htmlFor="name">Name</label>
-            <input id="name" type="text" placeholder="Your name" required />
+            <input
+              id="name"
+              type="text"
+              placeholder="Your name"
+              value={form.name}
+              onChange={handleChange}
+              required
+            />
           </div>
           <div className={contactStyles.field}>
             <label htmlFor="email">Email</label>
-            <input id="email" type="email" placeholder="you@example.com" required />
+            <input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              value={form.email}
+              onChange={handleChange}
+              required
+            />
           </div>
           <div className={contactStyles.field}>
             <label htmlFor="message">Message</label>
-            <textarea id="message" rows="4" placeholder="How can we help?" required />
+            <textarea
+              id="message"
+              rows="4"
+              placeholder="How can we help?"
+              value={form.message}
+              onChange={handleChange}
+              required
+            />
           </div>
-          <button className={contactStyles.button} type="submit">Send Message</button>
+          <button className={contactStyles.button} type="submit">
+            Send Message
+          </button>
+          {status.message && (
+            <p
+              className={
+                status.error ? contactStyles.error : contactStyles.success
+              }
+            >
+              {status.message}
+            </p>
+          )}
         </form>
       </div>
     </main>

--- a/styles/Contact.module.css
+++ b/styles/Contact.module.css
@@ -40,3 +40,13 @@
 .button:hover {
   background-color: #333;
 }
+
+.success {
+  margin-top: 1rem;
+  color: green;
+}
+
+.error {
+  margin-top: 1rem;
+  color: red;
+}


### PR DESCRIPTION
## Summary
- add contact API that emails staff and user when inquiries are submitted
- update contact page form to post to new API and show submission status
- style contact form status messages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c49e7ca66c832ea15806b964ec19cc