### PR TITLE
Add mortgage and rent calculators

### DIFF
--- a/components/MortgageCalculator.js
+++ b/components/MortgageCalculator.js
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import styles from '../styles/Calculator.module.css';
+
+export default function MortgageCalculator({ defaultPrice = 0 }) {
+  const [price, setPrice] = useState(defaultPrice);
+  const [deposit, setDeposit] = useState(0);
+  const [rate, setRate] = useState(3);
+  const [term, setTerm] = useState(25);
+
+  const principal = Math.max(price - deposit, 0);
+  const monthlyRate = rate / 100 / 12;
+  const months = term * 12;
+  const monthlyPayment =
+    monthlyRate === 0
+      ? principal / months
+      :
+        (principal * monthlyRate * Math.pow(1 + monthlyRate, months)) /
+        (Math.pow(1 + monthlyRate, months) - 1);
+
+  return (
+    <div className={styles.calculator}>
+      <label>
+        Property price
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Deposit
+        <input
+          type="number"
+          value={deposit}
+          onChange={(e) => setDeposit(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Interest rate (%)
+        <input
+          type="number"
+          value={rate}
+          onChange={(e) => setRate(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Term (years)
+        <input
+          type="number"
+          value={term}
+          onChange={(e) => setTerm(Number(e.target.value))}
+        />
+      </label>
+      <div className={styles.result}>
+        Monthly payment: £{isFinite(monthlyPayment) ? monthlyPayment.toFixed(2) : '0.00'}
+      </div>
+    </div>
+  );
+}
+

--- a/components/RentAffordability.js
+++ b/components/RentAffordability.js
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import styles from '../styles/Calculator.module.css';
+
+export default function RentAffordability({ defaultRent = 0 }) {
+  const [income, setIncome] = useState(0);
+  const [rent, setRent] = useState(defaultRent);
+
+  const ratio = income > 0 ? (rent / income) * 100 : 0;
+  const recommended = income * 0.3;
+
+  return (
+    <div className={styles.calculator}>
+      <label>
+        Monthly income
+        <input
+          type="number"
+          value={income}
+          onChange={(e) => setIncome(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Monthly rent
+        <input
+          type="number"
+          value={rent}
+          onChange={(e) => setRent(Number(e.target.value))}
+        />
+      </label>
+      {income > 0 && (
+        <div className={styles.result}>
+          <p>Rent is {ratio.toFixed(1)}% of income.</p>
+          <p>Recommended max rent: £{recommended.toFixed(2)}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -2,6 +2,8 @@ import PropertyList from '../../components/PropertyList';
 import ImageSlider from '../../components/ImageSlider';
 import OfferDrawer from '../../components/OfferDrawer';
 import ViewingForm from '../../components/ViewingForm';
+import MortgageCalculator from '../../components/MortgageCalculator';
+import RentAffordability from '../../components/RentAffordability';
 import {
   fetchPropertyById,
   fetchProperties,
@@ -10,6 +12,26 @@ import {
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatRentFrequency } from '../../lib/format.mjs';
+
+function parsePriceNumber(value) {
+  return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
+}
+
+function rentToMonthly(price, freq) {
+  const amount = parsePriceNumber(price);
+  switch (freq) {
+    case 'W':
+      return (amount * 52) / 12;
+    case 'M':
+      return amount;
+    case 'Q':
+      return amount / 3;
+    case 'Y':
+      return amount / 12;
+    default:
+      return amount;
+  }
+}
 
 export default function Property({ property, recommendations }) {
   if (!property) return <div>Property not found</div>;
@@ -72,6 +94,22 @@ export default function Property({ property, recommendations }) {
         <section className={styles.description}>
           <h2>Description</h2>
           <p>{property.description}</p>
+        </section>
+      )}
+
+      {!property.rentFrequency && property.price && (
+        <section className={styles.calculatorSection}>
+          <h2>Mortgage Calculator</h2>
+          <MortgageCalculator defaultPrice={parsePriceNumber(property.price)} />
+        </section>
+      )}
+
+      {property.rentFrequency && property.price && (
+        <section className={styles.calculatorSection}>
+          <h2>Rent Affordability</h2>
+          <RentAffordability
+            defaultRent={rentToMonthly(property.price, property.rentFrequency)}
+          />
         </section>
       )}
 

--- a/pages/valuation.js
+++ b/pages/valuation.js
@@ -1,4 +1,6 @@
 import styles from '../styles/Valuation.module.css';
+import MortgageCalculator from '../components/MortgageCalculator';
+import RentAffordability from '../components/RentAffordability';
 
 export default function Valuation() {
   return (
@@ -54,6 +56,16 @@ export default function Valuation() {
           <li>Thousands of buyers and tenants ready to move</li>
           <li>No obligation – it's completely free</li>
         </ul>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Mortgage Calculator</h2>
+        <MortgageCalculator />
+      </section>
+
+      <section className={styles.section}>
+        <h2>Rent Affordability Calculator</h2>
+        <RentAffordability />
       </section>
 
       <section className={styles.cta}>

--- a/styles/Calculator.module.css
+++ b/styles/Calculator.module.css
@@ -1,0 +1,28 @@
+.calculator {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 1rem;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.calculator label {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.calculator input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid #ccc;
+}
+
+.result {
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
+

--- a/styles/PropertyDetails.module.css
+++ b/styles/PropertyDetails.module.css
@@ -57,6 +57,10 @@
   margin-bottom: 2rem;
 }
 
+.calculatorSection {
+  margin-bottom: 2rem;
+}
+
 .features ul {
   padding-left: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- Create reusable `MortgageCalculator` and `RentAffordability` components with basic styling.
- Integrate mortgage and rent calculators into property detail and valuation pages.
- Add shared calculator styles and section styling.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49e794c08832e83a1221d606c1d0b