### PR TITLE
Add favourites toggle and page

### DIFF
--- a/components/FavoriteButton.js
+++ b/components/FavoriteButton.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+export default function FavoriteButton({ propertyId }) {
+  const [favourite, setFavourite] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem('favourites') || '[]');
+      setFavourite(stored.includes(propertyId));
+    } catch {
+      setFavourite(false);
+    }
+  }, [propertyId]);
+
+  const toggleFavourite = () => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('favourites') || '[]');
+      let updated;
+      if (stored.includes(propertyId)) {
+        updated = stored.filter((id) => id !== propertyId);
+        setFavourite(false);
+      } else {
+        updated = [...stored, propertyId];
+        setFavourite(true);
+      }
+      localStorage.setItem('favourites', JSON.stringify(updated));
+    } catch {
+      // Ignore write errors
+    }
+  };
+
+  return (
+    <button
+      className={`favorite-button${favourite ? ' active' : ''}`}
+      onClick={toggleFavourite}
+      aria-pressed={favourite}
+      type="button"
+    >
+      {favourite ? 'Unfavourite' : 'Favourite'}
+    </button>
+  );
+}

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,4 +1,5 @@
 import ImageSlider from './ImageSlider';
+import FavoriteButton from './FavoriteButton';
 import { formatRentFrequency } from '../lib/format.mjs';
 
 export default function PropertyCard({ property }) {
@@ -36,6 +37,9 @@ export default function PropertyCard({ property }) {
         )}
         {property.description && (
           <p className="description">{property.description}</p>
+        )}
+        {property.id && (
+          <FavoriteButton propertyId={property.id} />
         )}
       </div>
     </div>

--- a/pages/favourites.js
+++ b/pages/favourites.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import PropertyList from '../components/PropertyList';
+import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import styles from '../styles/Home.module.css';
+
+export default function Favourites({ properties }) {
+  const [favourites, setFavourites] = useState([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const ids = JSON.parse(localStorage.getItem('favourites') || '[]');
+      const list = properties.filter((p) => ids.includes(p.id));
+      setFavourites(list);
+    } catch {
+      setFavourites([]);
+    }
+  }, [properties]);
+
+  return (
+    <main className={styles.main}>
+      <h1>Favourite Properties</h1>
+      {favourites.length > 0 ? (
+        <PropertyList properties={favourites} />
+      ) : (
+        <p>No favourite properties saved.</p>
+      )}
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const [sale, rent] = await Promise.all([
+    fetchPropertiesByType('sale', {
+      statuses: ['available', 'under_offer', 'sold'],
+    }),
+    fetchPropertiesByType('rent', {
+      statuses: ['available', 'under_offer', 'let_agreed', 'let'],
+    }),
+  ]);
+  const properties = [...sale, ...rent];
+  return { props: { properties } };
+}


### PR DESCRIPTION
## Summary
- add `FavoriteButton` component to manage favourite property IDs in `localStorage`
- show favourite toggle on each `PropertyCard`
- introduce `favourites` page that filters saved properties

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c49e74a978832e8973e939bad78f42