### PR TITLE
feat: add chat widget

### DIFF
--- a/components/ChatWidget.js
+++ b/components/ChatWidget.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+export default function ChatWidget() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    window.Tawk_API = window.Tawk_API || {};
+    window.Tawk_LoadStart = new Date();
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://embed.tawk.to/${process.env.NEXT_PUBLIC_TAWKTO_PROPERTY_ID}/default`;
+    script.charset = 'UTF-8';
+    script.setAttribute('crossorigin', '*');
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return null;
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import 'slick-carousel/slick/slick-theme.css';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import ChatWidget from '../components/ChatWidget';
 
 export default function MyApp({ Component, pageProps }) {
   return (
@@ -14,6 +15,7 @@ export default function MyApp({ Component, pageProps }) {
       <Header />
       <Component {...pageProps} />
       <Footer />
+      <ChatWidget />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add ChatWidget that injects Tawk.to script
- render ChatWidget in _app so chat loads on every page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c49fdb7f24832e9ee91090ed5ec26b