### PR TITLE
Use unique artifact names for Pages deployment

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
+          name: github-pages-${{ github.run_id }}
 
   # Deployment job
   deploy:
@@ -96,3 +97,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_id }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: out
+          name: github-pages-${{ github.run_id }}
 
   deploy:
     needs: build
@@ -48,3 +49,5 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- Include `github.run_id` in uploaded artifact names
- Pass matching artifact name to `actions/deploy-pages`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4a08a3158832e93dfdfd790f9041c