### PR TITLE
Add property comparison feature with localStorage

### DIFF
--- a/components/CompareButton.js
+++ b/components/CompareButton.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+
+export default function CompareButton({ propertyId }) {
+  const [isCompared, setIsCompared] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const list = JSON.parse(localStorage.getItem('compareList')) || [];
+    setIsCompared(list.includes(propertyId));
+  }, [propertyId]);
+
+  const toggleCompare = () => {
+    if (typeof window === 'undefined') return;
+    const list = JSON.parse(localStorage.getItem('compareList')) || [];
+    if (list.includes(propertyId)) {
+      const updated = list.filter((id) => id !== propertyId);
+      localStorage.setItem('compareList', JSON.stringify(updated));
+      setIsCompared(false);
+    } else {
+      list.push(propertyId);
+      localStorage.setItem('compareList', JSON.stringify(list));
+      setIsCompared(true);
+    }
+  };
+
+  return (
+    <button onClick={toggleCompare} className="compare-button">
+      {isCompared ? 'Remove' : 'Compare'}
+    </button>
+  );
+}

--- a/components/Header.js
+++ b/components/Header.js
@@ -104,6 +104,14 @@ export default function Header() {
           </li>
           <li className={styles.navItem}>
             <Link
+              href="/compare"
+              className={router.pathname === '/compare' ? styles.active : ''}
+            >
+              Compare
+            </Link>
+          </li>
+          <li className={styles.navItem}>
+            <Link
               href="/login"
               className={router.pathname === '/login' ? styles.active : ''}
             >
@@ -195,6 +203,15 @@ export default function Header() {
                 className={router.pathname === '/archive' ? styles.active : ''}
               >
                 Archive
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/compare"
+                onClick={closeMobile}
+                className={router.pathname === '/compare' ? styles.active : ''}
+              >
+                Compare
               </Link>
             </li>
             <li>

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,4 +1,6 @@
 import ImageSlider from './ImageSlider';
+import CompareButton from './CompareButton';
+import Link from 'next/link';
 import { formatRentFrequency } from '../lib/format.mjs';
 
 export default function PropertyCard({ property }) {
@@ -41,6 +43,8 @@ export default function PropertyCard({ property }) {
         {property.description && (
           <p className="description">{property.description}</p>
         )}
+        <CompareButton propertyId={property.id} />
+        <Link href="/compare">View Comparison</Link>
       </div>
     </div>
   );

--- a/components/PropertyComparison.js
+++ b/components/PropertyComparison.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import listings from '../data/listings.json';
+
+export default function PropertyComparison() {
+  const [properties, setProperties] = useState([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const ids = JSON.parse(localStorage.getItem('compareList')) || [];
+    const selected = listings.filter((p) => {
+      const id = String(p.id || p.listingId || p.listing_id);
+      return ids.includes(id);
+    });
+    const formatted = selected.map((p) => ({
+      id: String(p.id || p.listingId || p.listing_id),
+      title: p.displayAddress || p.address1 || p.title || '',
+      price:
+        p.price != null
+          ? p.priceCurrency === 'GBP'
+            ? `£${p.price}`
+            : p.price
+          : null,
+    }));
+    setProperties(formatted);
+  }, []);
+
+  if (properties.length === 0) {
+    return <p>No properties selected for comparison.</p>;
+  }
+
+  return (
+    <table className="comparison-table">
+      <thead>
+        <tr>
+          <th>Property</th>
+          <th>Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {properties.map((p) => (
+          <tr key={p.id}>
+            <td>{p.title}</td>
+            <td>{p.price || 'N/A'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -1,0 +1,10 @@
+import PropertyComparison from '../components/PropertyComparison';
+
+export default function ComparePage() {
+  return (
+    <main>
+      <h1>Property Comparison</h1>
+      <PropertyComparison />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `CompareButton` to toggle property IDs in localStorage
- Display selected properties in new comparison table and page
- Link to comparison page from property cards and navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49fd7ee34832e9063b4a5c12fb623