### PR TITLE
fix: avoid server-side Leaflet import

### DIFF
--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,29 +1,35 @@
 import { useEffect } from 'react';
-import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-
-// Configure default icon paths so markers appear correctly
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
-  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-});
 
 export default function PropertyMap({ properties = [], center = [51.5, -0.1], zoom = 12 }) {
   useEffect(() => {
-    const map = L.map('property-map').setView(center, zoom);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    }).addTo(map);
+    let map;
+    async function initMap() {
+      const L = (await import('leaflet')).default;
 
-    properties.forEach((p) => {
-      if (typeof p.lat === 'number' && typeof p.lng === 'number') {
-        L.marker([p.lat, p.lng]).addTo(map).bindPopup(`<strong>${p.title}</strong>`);
-      }
-    });
+      // Configure default icon paths so markers appear correctly
+      L.Icon.Default.mergeOptions({
+        iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+        iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+        shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+      });
+
+      map = L.map('property-map').setView(center, zoom);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      }).addTo(map);
+
+      properties.forEach((p) => {
+        if (typeof p.lat === 'number' && typeof p.lng === 'number') {
+          L.marker([p.lat, p.lng]).addTo(map).bindPopup(`<strong>${p.title}</strong>`);
+        }
+      });
+    }
+
+    initMap();
 
     return () => {
-      map.remove();
+      if (map) map.remove();
     };
   }, [properties, center, zoom]);
 


### PR DESCRIPTION
## Summary
- dynamically import Leaflet in PropertyMap to prevent server-side `window` usage

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a3b645e8832ea7ff158c3aca6172