### PR TITLE
Add agent profiles and agent API

### DIFF
--- a/components/AgentCard.js
+++ b/components/AgentCard.js
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export default function AgentCard({ agent }) {
+  if (!agent) return null;
+  return (
+    <div className="agent-card">
+      {agent.photo && (
+        <img src={agent.photo} alt={agent.name} className="agent-photo" />
+      )}
+      <h3>
+        <Link href={`/agents/${agent.id}`}>{agent.name}</Link>
+      </h3>
+      {agent.phone && (
+        <p>
+          <a href={`tel:${agent.phone}`}>{agent.phone}</a>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/data/agents.json
+++ b/data/agents.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "1723",
+    "name": "Shah Chowdhury",
+    "phone": "02033898009",
+    "photo": "https://via.placeholder.com/150",
+    "bio": "Specialist in London rentals and sales."
+  },
+  {
+    "id": "1724",
+    "name": "Jane Doe",
+    "phone": "02033898010",
+    "photo": "https://via.placeholder.com/150",
+    "bio": "Passionate about helping clients find their dream homes."
+  }
+]

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -258,6 +258,14 @@ export async function fetchPropertiesByType(type, options = {}) {
     if (!id) return acc;
     acc.push({
       id: String(id),
+      agentId:
+        p.user?.id != null
+          ? String(p.user.id)
+          : p.userId != null
+          ? String(p.userId)
+          : p.negotiatorId != null
+          ? String(p.negotiatorId)
+          : null,
       title: p.displayAddress || p.address1 || p.title || '',
       description: p.summary || p.description || '',
       price:

--- a/pages/agents/[id].js
+++ b/pages/agents/[id].js
@@ -1,0 +1,58 @@
+import PropertyList from '../../components/PropertyList';
+import agents from '../../data/agents.json';
+import { fetchProperties } from '../../lib/apex27.mjs';
+
+export default function AgentPage({ agent, listings }) {
+  if (!agent) {
+    return (
+      <main>
+        <h1>Agent not found</h1>
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      {agent.photo && (
+        <img src={agent.photo} alt={agent.name} style={{ maxWidth: '200px' }} />
+      )}
+      <h1>{agent.name}</h1>
+      {agent.bio && <p>{agent.bio}</p>}
+      {agent.phone && (
+        <p>
+          <a href={`tel:${agent.phone}`}>{agent.phone}</a>
+        </p>
+      )}
+      {listings && listings.length > 0 && (
+        <section>
+          <h2>Active Listings</h2>
+          <PropertyList properties={listings} />
+        </section>
+      )}
+    </main>
+  );
+}
+
+export async function getStaticPaths() {
+  const paths = agents.map((a) => ({ params: { id: String(a.id) } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const agent = agents.find((a) => String(a.id) === String(params.id)) || null;
+
+  const allProperties = await fetchProperties();
+  const normalize = (s) => String(s).toLowerCase().replace(/\s+/g, '_');
+  const listings = allProperties.filter((p) => {
+    if (p.agentId !== params.id) return false;
+    const status = normalize(p.status || '');
+    return !(
+      status.startsWith('sold') ||
+      status.startsWith('let') ||
+      status.includes('sale_agreed') ||
+      status.includes('let_agreed')
+    );
+  });
+
+  return { props: { agent, listings } };
+}

--- a/pages/api/agents.js
+++ b/pages/api/agents.js
@@ -1,0 +1,26 @@
+import agents from '../../data/agents.json';
+
+export default function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  const { id } = req.query;
+
+  if (id) {
+    const agent = agents.find((a) => String(a.id) === String(id));
+    if (agent) {
+      res.status(200).json(agent);
+    } else {
+      res.status(404).json({ error: 'Agent not found' });
+    }
+    return;
+  }
+
+  res.status(200).json(agents);
+}

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -3,10 +3,12 @@ import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import PropertyList from '../components/PropertyList';
 import PropertyMap from '../components/PropertyMap';
+import AgentCard from '../components/AgentCard';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import agentsData from '../data/agents.json';
 import styles from '../styles/Home.module.css';
 
-export default function ForSale({ properties }) {
+export default function ForSale({ properties, agents }) {
   const router = useRouter();
   const search = typeof router.query.search === 'string' ? router.query.search : '';
   const minPrice =
@@ -90,6 +92,17 @@ export default function ForSale({ properties }) {
       ) : (
         <PropertyMap properties={available} />
       )}
+
+      {agents && agents.length > 0 && (
+        <section>
+          <h2>Our Agents</h2>
+          <div className="agent-list">
+            {agents.map((agent) => (
+              <AgentCard key={agent.id} agent={agent} />
+            ))}
+          </div>
+        </section>
+      )}
     </main>
   );
 }
@@ -100,5 +113,7 @@ export async function getStaticProps() {
 
   });
 
-  return { props: { properties } };
+  const agents = agentsData;
+
+  return { props: { properties, agents } };
 }


### PR DESCRIPTION
## Summary
- add reusable `AgentCard` component and show agents on listing pages
- support agent IDs in Apex27 property data
- create dynamic agent profile pages and expose `/api/agents` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b00e26c0832e82fb3b9d9c60f78c