### PR TITLE
feat: add basic i18n support

### DIFF
--- a/next-i18next.config.mjs
+++ b/next-i18next.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es']
+  }
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import nextI18NextConfig from './next-i18next.config.mjs';
+
 const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || '';
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -7,6 +9,7 @@ const nextConfig = {
   images: { unoptimized: true },
   basePath: isProd && repo ? `/${repo}` : undefined,
   assetPrefix: isProd && repo ? `/${repo}/` : undefined,
+  i18n: nextI18NextConfig.i18n,
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,22 @@
       "dependencies": {
         "leaflet": "^1.9.4",
         "next": "^15.5.2",
+        "next-i18next": "^15.4.2",
         "nodemailer": "^6.9.11",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^4.12.0",
         "react-slick": "^0.31.0",
         "slick-carousel": "^1.8.1"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -590,6 +600,28 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001741",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
@@ -667,6 +699,24 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -676,6 +726,63 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.5.2.tgz",
+      "integrity": "sha512-lW8Zeh37i/o0zVr+NoCHfNnfvVw+M6FQbRp36ZZ/NyHDJ3NJVpp2HhAUyU9WafL5AssymNoOjMRB48mmx2P6Hw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.0.tgz",
+      "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -782,6 +889,42 @@
         }
       }
     },
+    "node_modules/next-i18next": {
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-15.4.2.tgz",
+      "integrity": "sha512-zgRxWf7kdXtM686ecGIBQL+Bq0+DqAhRlasRZ3vVF0TmrNTWkVhs52n//oU3Fj5O7r/xOKkECDUwfOuXVwTK/g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "core-js": "^3",
+        "hoist-non-react-statics": "^3.3.2",
+        "i18next-fs-backend": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.7.13",
+        "next": ">= 12.0.0",
+        "react": ">= 17.0.2",
+        "react-i18next": ">= 13.5.0"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
@@ -846,6 +989,33 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -854,6 +1024,12 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-slick": {
       "version": "0.31.0",
@@ -1001,6 +1177,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.1.1",
     "react-icons": "^4.12.0",
     "react-slick": "^0.31.0",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "next-i18next": "^15.4.2"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,8 +5,10 @@ import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import ChatWidget from '../components/ChatWidget';
+import { appWithTranslation } from 'next-i18next';
+import nextI18NextConfig from '../next-i18next.config.mjs';
 
-export default function MyApp({ Component, pageProps }) {
+function MyApp({ Component, pageProps }) {
   return (
     <>
       <Head>
@@ -19,3 +21,5 @@ export default function MyApp({ Component, pageProps }) {
     </>
   );
 }
+
+export default appWithTranslation(MyApp, nextI18NextConfig);

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,30 +4,34 @@ import Features from '../components/Features';
 import Stats from '../components/Stats';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../next-i18next.config.mjs';
 
 export default function Home({ sales, lettings, archiveSales, archiveLettings }) {
+  const { t } = useTranslation();
   return (
     <main className={styles.main}>
       <Hero />
       <Features />
       <Stats />
       <section className={styles.listings} id="listings">
-        <h2>Featured Sales</h2>
+        <h2>{t('featuredSales')}</h2>
         <PropertyList properties={sales} />
       </section>
       <section className={styles.listings}>
-        <h2>Featured Lettings</h2>
+        <h2>{t('featuredLettings')}</h2>
         <PropertyList properties={lettings} />
       </section>
       {archiveSales.length > 0 && (
         <section className={styles.listings}>
-          <h2>Archive Sales</h2>
+          <h2>{t('archiveSales')}</h2>
           <PropertyList properties={archiveSales} />
         </section>
       )}
       {archiveLettings.length > 0 && (
         <section className={styles.listings}>
-          <h2>Archive Lettings</h2>
+          <h2>{t('archiveLettings')}</h2>
           <PropertyList properties={archiveLettings} />
         </section>
       )}
@@ -35,7 +39,7 @@ export default function Home({ sales, lettings, archiveSales, archiveLettings })
   );
 }
 
-export async function getStaticProps() {
+export async function getStaticProps({ locale }) {
   const [allSale, allRent] = await Promise.all([
     fetchPropertiesByType('sale', {
       statuses: ['available', 'under_offer', 'sold', 'sold_stc', 'sale_agreed'],
@@ -65,5 +69,13 @@ export async function getStaticProps() {
   const archiveSales = allSale.filter(isSold).slice(0, 4);
   const archiveLettings = allRent.filter(isLet).slice(0, 4);
 
-  return { props: { sales, lettings, archiveSales, archiveLettings } };
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+      sales,
+      lettings,
+      archiveSales,
+      archiveLettings,
+    },
+  };
 }

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -13,6 +13,9 @@ import {
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatRentFrequency } from '../../lib/format.mjs';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config.mjs';
 
 function parsePriceNumber(value) {
   return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
@@ -35,7 +38,8 @@ function rentToMonthly(price, freq) {
 }
 
 export default function Property({ property, recommendations }) {
-  if (!property) return <div>Property not found</div>;
+  const { t } = useTranslation();
+  if (!property) return <div>{t('propertyNotFound')}</div>;
   const features = Array.isArray(property.features) ? property.features : [];
 
   return (
@@ -82,7 +86,7 @@ export default function Property({ property, recommendations }) {
 
       {features.length > 0 && (
         <section className={styles.features}>
-          <h2>Key features</h2>
+          <h2>{t('keyFeatures')}</h2>
           <ul>
             {features.map((f, i) => (
               <li key={i}>{f}</li>
@@ -93,21 +97,21 @@ export default function Property({ property, recommendations }) {
 
       {property.description && (
         <section className={styles.description}>
-          <h2>Description</h2>
+          <h2>{t('description')}</h2>
           <p>{property.description}</p>
         </section>
       )}
 
       {!property.rentFrequency && property.price && (
         <section className={styles.calculatorSection}>
-          <h2>Mortgage Calculator</h2>
+          <h2>{t('mortgageCalculator')}</h2>
           <MortgageCalculator defaultPrice={parsePriceNumber(property.price)} />
         </section>
       )}
 
       {property.rentFrequency && property.price && (
         <section className={styles.calculatorSection}>
-          <h2>Rent Affordability</h2>
+          <h2>{t('rentAffordability')}</h2>
           <RentAffordability
             defaultRent={rentToMonthly(property.price, property.rentFrequency)}
           />
@@ -115,13 +119,13 @@ export default function Property({ property, recommendations }) {
       )}
 
       <section className={styles.contact}>
-        <p>Interested in this property?</p>
-        <a href="tel:+441234567890">Call our team</a>
+        <p>{t('interestedInProperty')}</p>
+        <a href="tel:+441234567890">{t('callOurTeam')}</a>
       </section>
 
       {recommendations && recommendations.length > 0 && (
         <section className={styles.recommended}>
-          <h2>You might also be interested in</h2>
+          <h2>{t('youMightAlsoBeInterested')}</h2>
           <PropertyList properties={recommendations} />
         </section>
       )}
@@ -145,7 +149,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ params, locale }) {
   const rawProperty = await fetchPropertyById(params.id);
   let formatted = null;
   if (rawProperty) {
@@ -201,5 +205,11 @@ export async function getStaticProps({ params }) {
     .filter((p) => p.id !== params.id)
     .slice(0, 4);
 
-  return { props: { property: formatted, recommendations } };
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'], nextI18NextConfig)),
+      property: formatted,
+      recommendations,
+    },
+  };
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,14 @@
+{
+  "featuredSales": "Featured Sales",
+  "featuredLettings": "Featured Lettings",
+  "archiveSales": "Archive Sales",
+  "archiveLettings": "Archive Lettings",
+  "propertyNotFound": "Property not found",
+  "keyFeatures": "Key features",
+  "description": "Description",
+  "mortgageCalculator": "Mortgage Calculator",
+  "rentAffordability": "Rent Affordability",
+  "interestedInProperty": "Interested in this property?",
+  "callOurTeam": "Call our team",
+  "youMightAlsoBeInterested": "You might also be interested in"
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,0 +1,14 @@
+{
+  "featuredSales": "Ventas destacadas",
+  "featuredLettings": "Alquileres destacados",
+  "archiveSales": "Ventas archivadas",
+  "archiveLettings": "Alquileres archivados",
+  "propertyNotFound": "Propiedad no encontrada",
+  "keyFeatures": "Características clave",
+  "description": "Descripción",
+  "mortgageCalculator": "Calculadora de hipoteca",
+  "rentAffordability": "Asequibilidad del alquiler",
+  "interestedInProperty": "¿Interesado en esta propiedad?",
+  "callOurTeam": "Llama a nuestro equipo",
+  "youMightAlsoBeInterested": "También te puede interesar"
+}


### PR DESCRIPTION
## Summary
- integrate next-i18next and expose i18n config in Next.js setup
- wrap app with translation provider and localize home and property pages
- add English and Spanish locale files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b0127c38832eb0cb87920104c3c7