### PR TITLE
Reset offer and viewing forms when closed

### DIFF
--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -9,6 +9,19 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState('');
 
+  const resetFields = () => {
+    setPrice('');
+    setFrequency('pw');
+    setName('');
+    setEmail('');
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    resetFields();
+    setStatus('');
+  };
+
   async function handleSubmit(e) {
     e.preventDefault();
     setStatus('');
@@ -28,11 +41,7 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
 
       if (!res.ok) throw new Error('Request failed');
       setStatus('Offer submitted successfully.');
-      setPrice('');
-      setFrequency('pw');
-      setName('');
-      setEmail('');
-      setOpen(false);
+      resetFields();
     } catch {
       setStatus('Failed to submit offer.');
     }
@@ -43,11 +52,11 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
       <button className={styles.offerButton} onClick={() => setOpen(true)}>
         Make an offer
       </button>
-      {open && <div className={styles.overlay} onClick={() => setOpen(false)}></div>}
+      {open && <div className={styles.overlay} onClick={handleClose}></div>}
       <aside className={`${styles.drawer} ${open ? styles.open : ''}`}>
         <div className={styles.header}>
           <h2>Make an offer</h2>
-          <button className={styles.close} onClick={() => setOpen(false)} aria-label="Close">
+          <button className={styles.close} onClick={handleClose} aria-label="Close">
             &times;
           </button>
         </div>

--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -2,19 +2,27 @@ import { useState } from 'react';
 import styles from '../styles/ViewingForm.module.css';
 
 export default function ViewingForm({ propertyTitle }) {
-  const [open, setOpen] = useState(false);
-  const [form, setForm] = useState({
+  const initialForm = {
     name: '',
     email: '',
     phone: '',
     date: '',
     time: '',
-  });
+  };
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(initialForm);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState('');
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setForm(initialForm);
+    setSent(false);
+    setError('');
   };
 
   const handleSubmit = async (e) => {
@@ -28,6 +36,7 @@ export default function ViewingForm({ propertyTitle }) {
       });
       if (!res.ok) throw new Error('Request failed');
       setSent(true);
+      setForm(initialForm);
     } catch (err) {
       setError('Failed to book viewing');
     }
@@ -38,16 +47,14 @@ export default function ViewingForm({ propertyTitle }) {
       <button className={styles.viewingButton} onClick={() => setOpen(true)}>
         Book a viewing
       </button>
-      {open && (
-        <div className={styles.overlay} onClick={() => setOpen(false)}></div>
-      )}
+      {open && <div className={styles.overlay} onClick={handleClose}></div>}
       {open && (
         <div className={styles.modal}>
           <div className={styles.header}>
             <h2>Book a viewing</h2>
             <button
               className={styles.close}
-              onClick={() => setOpen(false)}
+              onClick={handleClose}
               aria-label="Close"
             >
               &times;
@@ -89,4 +96,3 @@ export default function ViewingForm({ propertyTitle }) {
     </>
   );
 }
-

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,9 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -4,6 +4,7 @@ import OfferDrawer from '../../components/OfferDrawer';
 import ViewingForm from '../../components/ViewingForm';
 import MortgageCalculator from '../../components/MortgageCalculator';
 import RentAffordability from '../../components/RentAffordability';
+import Head from 'next/head';
 import {
   fetchPropertyById,
   fetchProperties,
@@ -39,13 +40,17 @@ export default function Property({ property, recommendations }) {
   const features = Array.isArray(property.features) ? property.features : [];
 
   return (
-    <main className={styles.main}>
-      <section className={styles.hero}>
-        {(property.images?.length > 0 || property.media?.length > 0) && (
-          <div className={styles.sliderWrapper}>
-            <MediaGallery images={property.images} media={property.media} />
-          </div>
-        )}
+    <>
+      <Head>
+        <title>{property.title ? `${property.title} | Aktonz` : 'Property details'}</title>
+      </Head>
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          {(property.images?.length > 0 || property.media?.length > 0) && (
+            <div className={styles.sliderWrapper}>
+              <MediaGallery images={property.images} media={property.media} />
+            </div>
+          )}
         <div className={styles.summary}>
           <h1>{property.title}</h1>
           {property.type && <p className={styles.type}>{property.type}</p>}
@@ -125,7 +130,8 @@ export default function Property({ property, recommendations }) {
           <PropertyList properties={recommendations} />
         </section>
       )}
-    </main>
+      </main>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Reset offer form fields and status when the drawer is closed
- Clear viewing request form, status and errors on close
- Add dynamic property title and remove duplicate viewport meta tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b10c38c8832ea850bd0d465ae8de