### PR TITLE
Enhance property card with icons and hover interactivity

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,6 +1,7 @@
 import ImageSlider from './ImageSlider';
 import FavoriteButton from './FavoriteButton';
 import { formatRentFrequency } from '../lib/format.mjs';
+import { FaBed, FaBath } from 'react-icons/fa';
 
 export default function PropertyCard({ property }) {
   const rawStatus = property.status ? property.status.replace(/_/g, ' ') : null;
@@ -38,6 +39,22 @@ export default function PropertyCard({ property }) {
             {property.rentFrequency &&
               ` ${formatRentFrequency(property.rentFrequency)}`}
           </p>
+        )}
+        {(property.bedrooms != null || property.bathrooms != null) && (
+          <div className="features">
+            {property.bedrooms != null && (
+              <span className="feature">
+                <FaBed aria-hidden="true" />
+                {property.bedrooms}
+              </span>
+            )}
+            {property.bathrooms != null && (
+              <span className="feature">
+                <FaBath aria-hidden="true" />
+                {property.bathrooms}
+              </span>
+            )}
+          </div>
         )}
         {property.description && (
           <p className="description">{property.description}</p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -37,6 +37,17 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.property-list .property-link:hover .property-card,
+.property-list .property-link:focus .property-card {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+.property-list .property-link:focus {
+  outline: none;
 }
 
 .property-card .image-wrapper {
@@ -107,6 +118,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
 }
 
 .property-card .title {
@@ -118,6 +130,19 @@ body {
   margin: 0.5rem 0;
   font-weight: bold;
   color: #008060;
+}
+
+.property-card .features {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+}
+
+.property-card .feature {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .property-card .description {


### PR DESCRIPTION
## Summary
- add FontAwesome bed and bath icons to property card features
- refine card layout and spacing with flexbox
- highlight entire card on hover and focus for better interactivity

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b472ddf8832e88d63c4f1683bf46