### PR TITLE
Switch to responsive carousel and standardize image aspect ratios

### DIFF
--- a/components/MediaGallery.js
+++ b/components/MediaGallery.js
@@ -1,7 +1,10 @@
 import dynamic from 'next/dynamic';
 import styles from '../styles/MediaGallery.module.css';
 
-const Slider = dynamic(() => import('react-slick'), { ssr: false });
+const Carousel = dynamic(
+  () => import('react-responsive-carousel').then((m) => m.Carousel),
+  { ssr: false }
+);
 
 function normalizeYouTube(url) {
   try {
@@ -73,17 +76,21 @@ export default function MediaGallery({ images = [], media = [] }) {
   const items = [...media, ...images];
   if (items.length === 0) return null;
 
-  const settings = {
-    dots: true,
-    arrows: true,
-    infinite: true,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-  };
+  const renderThumbs = () =>
+    images.map((src, i) => <img key={i} src={src} alt={`Thumbnail ${i + 1}`} />);
 
   return (
     <div className={styles.slider}>
-      <Slider {...settings}>{items.map((url, i) => renderMedia(url, i))}</Slider>
+      <Carousel
+        showThumbs
+        showArrows
+        swipeable
+        emulateTouch
+        useKeyboardArrows
+        renderThumbs={renderThumbs}
+      >
+        {items.map((url, i) => renderMedia(url, i))}
+      </Carousel>
     </div>
   );
 }

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -87,6 +87,33 @@ export function extractMedia(listing) {
   return urls;
 }
 
+function enforceAspect(url, width = 640, height = 480) {
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split('.');
+    if (parts.length > 1) {
+      const ext = parts.pop();
+      if (!u.pathname.includes(`_${width}x${height}`)) {
+        u.pathname = `${parts.join('.')}_${width}x${height}.${ext}`;
+      }
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function normalizeImageUrl(img) {
+  if (!img) return null;
+  if (img.thumbnailUrl) return enforceAspect(img.thumbnailUrl);
+  if (img.url) return enforceAspect(img.url);
+  return null;
+}
+
+export function normalizeImages(images = []) {
+  return images.map((img) => normalizeImageUrl(img)).filter(Boolean);
+}
+
 export async function fetchProperties(params = {}) {
   const cached = await getCachedProperties();
 
@@ -256,6 +283,7 @@ export async function fetchPropertiesByType(type, options = {}) {
   return list.reduce((acc, p) => {
     const id = p.id ?? p.listingId ?? p.listing_id;
     if (!id) return acc;
+    const normalizedImages = normalizeImages(p.images || []);
     acc.push({
       id: String(id),
       agentId:
@@ -278,8 +306,8 @@ export async function fetchPropertiesByType(type, options = {}) {
       bedrooms: p.bedrooms ?? null,
       propertyType: p.propertyType ?? null,
       rentFrequency: p.rentFrequency ?? null,
-      image: p.images && p.images[0] ? p.images[0].url : null,
-      images: p.images ? p.images.map((img) => img.url) : [],
+      image: normalizedImages[0] || null,
+      images: normalizedImages,
       media: extractMedia(p),
       status: p.status ?? null,
       featured: p.featured ?? false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^4.12.0",
+        "react-responsive-carousel": "^3.2.23",
         "react-slick": "^0.31.0",
         "slick-carousel": "^1.8.1"
       }
@@ -691,6 +692,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -711,6 +718,18 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -791,6 +810,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -825,6 +853,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -846,6 +885,18 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -853,6 +904,23 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
       }
     },
     "node_modules/react-slick": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^4.12.0",
+    "react-responsive-carousel": "^3.2.23",
     "react-slick": "^0.31.0",
     "slick-carousel": "^1.8.1"
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import '../styles/globals.css';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
+import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -9,6 +9,7 @@ import {
   fetchProperties,
   fetchPropertiesByType,
   extractMedia,
+  normalizeImages,
 } from '../../lib/apex27.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
@@ -149,6 +150,7 @@ export async function getStaticProps({ params }) {
   const rawProperty = await fetchPropertyById(params.id);
   let formatted = null;
   if (rawProperty) {
+    const imgList = normalizeImages(rawProperty.images || []);
     formatted = {
       id: String(
         rawProperty.id ?? rawProperty.listingId ?? rawProperty.listing_id
@@ -166,11 +168,8 @@ export async function getStaticProps({ params }) {
             : rawProperty.price
           : null,
       rentFrequency: rawProperty.rentFrequency ?? null,
-      image:
-        rawProperty.images && rawProperty.images[0]
-          ? rawProperty.images[0].url
-          : null,
-      images: rawProperty.images ? rawProperty.images.map((img) => img.url) : [],
+      image: imgList[0] || null,
+      images: imgList,
       media: extractMedia(rawProperty),
       features: (() => {
         const rawFeatures =

--- a/styles/MediaGallery.module.css
+++ b/styles/MediaGallery.module.css
@@ -1,6 +1,5 @@
 .slider {
   position: relative;
-  height: 400px;
 }
 
 .slide img,
@@ -18,51 +17,7 @@
   object-fit: contain;
 }
 
-.slider :global(.slick-prev),
-.slider :global(.slick-next) {
-  z-index: 1;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.slider :global(.slick-prev) {
-  left: 10px;
-}
-
-.slider :global(.slick-next) {
-  right: 10px;
-}
-
-.slider :global(.slick-prev:before),
-.slider :global(.slick-next:before) {
-  font-size: 24px;
-  line-height: 1;
-  color: #fff;
-}
-
-.slider :global(.slick-dots) {
-  bottom: 10px;
-}
-
-.slider :global(.slick-dots li button:before) {
-  color: #fff;
-  opacity: 0.5;
-}
-
-.slider :global(.slick-dots li.slick-active button:before) {
-  opacity: 1;
-}
-
 @media (max-width: 768px) {
-  .slider {
-    height: 250px;
-  }
-
   .slide img,
   .slide iframe,
   .slide video {


### PR DESCRIPTION
## Summary
- Replace react-slick with lightweight react-responsive-carousel in MediaGallery with swipe, arrow and thumbnail support
- Import carousel styles globally
- Normalize image URLs from Apex27 API to enforce 4:3 aspect ratio for uniform galleries

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b47a8308832e8a58efd2c0326ca3