### PR TITLE
Improve accessibility for images and interactive components

### DIFF
--- a/components/AreaMap.js
+++ b/components/AreaMap.js
@@ -27,6 +27,15 @@ export default function AreaMap({ regions }) {
             key={s.name}
             className={styles.mapRegion}
             onClick={() => router.push(`/area-guides/${slug}`)}
+            role="button"
+            tabIndex={0}
+            aria-label={`View listings for ${s.name}`}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                router.push(`/area-guides/${slug}`);
+              }
+            }}
           >
             <rect x={s.x} y={s.y} width={s.w} height={s.h} />
             <text

--- a/components/ImageSlider.js
+++ b/components/ImageSlider.js
@@ -3,7 +3,7 @@ import styles from '../styles/ImageSlider.module.css';
 
 const Slider = dynamic(() => import('react-slick'), { ssr: false });
 
-export default function ImageSlider({ images = [] }) {
+export default function ImageSlider({ images = [], title = '' }) {
   if (!images || images.length === 0) return null;
 
   const settings = {
@@ -19,7 +19,10 @@ export default function ImageSlider({ images = [] }) {
       <Slider {...settings}>
         {images.map((src, i) => (
           <div key={i} className={styles.slide}>
-            <img src={src} alt={`Property image ${i + 1}`} />
+            <img
+              src={src}
+              alt={`${title || 'Property'} image ${i + 1}`}
+            />
           </div>
         ))}
       </Slider>

--- a/components/MediaGallery.js
+++ b/components/MediaGallery.js
@@ -64,7 +64,7 @@ function renderMedia(url, index) {
   }
   return (
     <div key={index} className={styles.slide}>
-      <img src={url} alt={`Media ${index + 1}`} />
+      <img src={url} alt={`Property media item ${index + 1}`} />
     </div>
   );
 }

--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -52,7 +52,21 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
       <button className={styles.offerButton} onClick={() => setOpen(true)}>
         Make an offer
       </button>
-      {open && <div className={styles.overlay} onClick={handleClose}></div>}
+      {open && (
+        <div
+          className={styles.overlay}
+          role="button"
+          tabIndex={0}
+          aria-label="Close drawer"
+          onClick={handleClose}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleClose();
+            }
+          }}
+        ></div>
+      )}
       <aside className={`${styles.drawer} ${open ? styles.open : ''}`}>
         <div className={styles.header}>
           <h2>Make an offer</h2>

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -15,10 +15,12 @@ export default function PropertyCard({ property }) {
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
       <div className="image-wrapper">
         {property.images && property.images.length > 0 ? (
-          <ImageSlider images={property.images} />
+          <ImageSlider images={property.images} title={property.title} />
 
         ) : (
-          property.image && <img src={property.image} alt={property.title} />
+          property.image && (
+            <img src={property.image} alt={`Image of ${property.title}`} />
+          )
         )}
         {property.featured && (
           <span className="featured-badge">Featured</span>

--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -47,7 +47,21 @@ export default function ViewingForm({ propertyTitle }) {
       <button className={styles.viewingButton} onClick={() => setOpen(true)}>
         Book a viewing
       </button>
-      {open && <div className={styles.overlay} onClick={handleClose}></div>}
+      {open && (
+        <div
+          className={styles.overlay}
+          role="button"
+          tabIndex={0}
+          aria-label="Close modal"
+          onClick={handleClose}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleClose();
+            }
+          }}
+        ></div>
+      )}
       {open && (
         <div className={styles.modal}>
           <div className={styles.header}>


### PR DESCRIPTION
## Summary
- add descriptive alt text for gallery and property images
- make map regions, modals, and drawers keyboard accessible

## Testing
- `npx @axe-core/cli http://localhost:3000` *(fails: cannot find Chrome binary)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b47f4be0832ebc63ac0fb2129da7