### PR TITLE
fix: guard tawk property

### DIFF
--- a/components/ChatWidget.js
+++ b/components/ChatWidget.js
@@ -4,12 +4,15 @@ export default function ChatWidget() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    const propertyId = process.env.NEXT_PUBLIC_TAWKTO_PROPERTY_ID;
+    if (!propertyId) return;
+
     window.Tawk_API = window.Tawk_API || {};
     window.Tawk_LoadStart = new Date();
 
     const script = document.createElement('script');
     script.async = true;
-    script.src = `https://embed.tawk.to/${process.env.NEXT_PUBLIC_TAWKTO_PROPERTY_ID}/default`;
+    script.src = `https://embed.tawk.to/${propertyId}/default`;
     script.charset = 'UTF-8';
     script.setAttribute('crossorigin', '*');
     document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- avoid loading Tawk chat script when property id is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4bd691ed8832e9f72f1a2b9bffb6c