### PR TITLE
Add static asset cache headers and strip extraneous response headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,53 @@ const nextConfig = {
   images: { unoptimized: true },
   basePath: isProd && repo ? `/${repo}` : undefined,
   assetPrefix: isProd && repo ? `/${repo}/` : undefined,
+  async headers() {
+    return [
+      {
+        source: '/_next/static/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/images/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/fonts/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/static/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'x-xss-protection', value: '' },
+          { key: 'content-security-policy', value: '' },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add Next.js `headers()` config to cache static files for a year
- override third-party `x-xss-protection` and `content-security-policy` headers so they are stripped

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:3000/_next/static/chunks/main-0c9b532bd56340ac.js` *(dev server; header rules aren't applied with `output: export` so caching headers cannot be demonstrated)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bdcbf138832e8e0fd4bb69ead557