### PR TITLE
chore: add browser compatibility fallbacks

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -168,3 +168,27 @@ body {
     height: 400px;
   }
 }
+
+/* Compatibility fixes for third-party library styles */
+.leaflet-overlay-pane svg {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.carousel .slider-wrapper.axis-horizontal .slider,
+.carousel .slider-wrapper.axis-vertical {
+  -webkit-box-orient: horizontal;
+}
+
+.leaflet-oldie .leaflet-popup-content-wrapper {
+  -ms-zoom: 1;
+  zoom: 1;
+}
+
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-tile {
+  -webkit-user-drag: none;
+  user-drag: none;
+}


### PR DESCRIPTION
## Summary
- add cross-browser user-select rules for Leaflet overlay
- add missing -webkit-box-orient and zoom fallbacks for third-party styles
- add user-drag fallback for Leaflet markers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c3b7f5c8832ea0df28e0782d2a40