### PR TITLE
Specify button types across site

### DIFF
--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -49,7 +49,11 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
 
   return (
     <>
-      <button className={styles.offerButton} onClick={() => setOpen(true)}>
+      <button
+        type="button"
+        className={styles.offerButton}
+        onClick={() => setOpen(true)}
+      >
         Make an offer
       </button>
       {open && (
@@ -70,7 +74,12 @@ export default function OfferDrawer({ propertyTitle, propertyId }) {
       <aside className={`${styles.drawer} ${open ? styles.open : ''}`}>
         <div className={styles.header}>
           <h2>Make an offer</h2>
-          <button className={styles.close} onClick={handleClose} aria-label="Close">
+          <button
+            type="button"
+            className={styles.close}
+            onClick={handleClose}
+            aria-label="Close"
+          >
             &times;
           </button>
         </div>

--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -44,7 +44,11 @@ export default function ViewingForm({ propertyTitle }) {
 
   return (
     <>
-      <button className={styles.viewingButton} onClick={() => setOpen(true)}>
+      <button
+        type="button"
+        className={styles.viewingButton}
+        onClick={() => setOpen(true)}
+      >
         Book a viewing
       </button>
       {open && (
@@ -67,6 +71,7 @@ export default function ViewingForm({ propertyTitle }) {
           <div className={styles.header}>
             <h2>Book a viewing</h2>
             <button
+              type="button"
               className={styles.close}
               onClick={handleClose}
               aria-label="Close"

--- a/pages/account/saved-searches.js
+++ b/pages/account/saved-searches.js
@@ -45,7 +45,9 @@ export default function SavedSearchesPage() {
         {searches.map((s) => (
           <li key={s.id}>
             <code>{JSON.stringify(s.params)}</code>
-            <button onClick={() => handleDelete(s.id)}>Delete</button>
+            <button type="button" onClick={() => handleDelete(s.id)}>
+              Delete
+            </button>
           </li>
         ))}
       </ul>

--- a/pages/area-guides/index.js
+++ b/pages/area-guides/index.js
@@ -19,6 +19,7 @@ export default function AreaGuides({ regions }) {
           <div className={styles.regionHeader}>
             {region.children && region.children.length > 0 && (
               <button
+                type="button"
                 aria-label={open[region.id] ? 'Collapse' : 'Expand'}
                 className={styles.toggle}
                 onClick={() => toggle(region.id)}

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -72,10 +72,18 @@ export default function ForSale({ properties, agents }) {
     <main className={styles.main}>
       <h1>{search ? `Search results for "${search}"` : 'Properties for Sale'}</h1>
       <div style={{ marginBottom: 'var(--spacing-md)' }}>
-        <button onClick={() => setViewMode('list')} disabled={viewMode === 'list'}>
+        <button
+          type="button"
+          onClick={() => setViewMode('list')}
+          disabled={viewMode === 'list'}
+        >
           List
         </button>{' '}
-        <button onClick={() => setViewMode('map')} disabled={viewMode === 'map'}>
+        <button
+          type="button"
+          onClick={() => setViewMode('map')}
+          disabled={viewMode === 'map'}
+        >
           Map
         </button>
       </div>

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -68,10 +68,18 @@ export default function ToRent({ properties }) {
     <main className={styles.main}>
       <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
       <div className={styles.viewModeControls}>
-        <button onClick={() => setViewMode('list')} disabled={viewMode === 'list'}>
+        <button
+          type="button"
+          onClick={() => setViewMode('list')}
+          disabled={viewMode === 'list'}
+        >
           List
         </button>{' '}
-        <button onClick={() => setViewMode('map')} disabled={viewMode === 'map'}>
+        <button
+          type="button"
+          onClick={() => setViewMode('map')}
+          disabled={viewMode === 'map'}
+        >
           Map
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Add explicit `type="button"` to interactive buttons in property listing pages and shared components to avoid implicit form submissions.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c7854880832e88f2795e44a47284