### PR TITLE
Remove cross-origin attribute from images

### DIFF
--- a/components/AgentCard.js
+++ b/components/AgentCard.js
@@ -9,7 +9,6 @@ export default function AgentCard({ agent }) {
           src={agent.photo}
           alt={agent.name}
           className="agent-photo"
-          crossOrigin="anonymous"
         />
       )}
       <h3>

--- a/components/Header.js
+++ b/components/Header.js
@@ -12,11 +12,7 @@ export default function Header() {
             alt="Aktonz"
             width={40}
             height={40}
-
-            crossOrigin="anonymous"
-
-
-          />
+            />
         </Link>
       </div>
       <nav className={styles.nav}>

--- a/components/ImageSlider.js
+++ b/components/ImageSlider.js
@@ -22,10 +22,7 @@ export default function ImageSlider({ images = [], title = '' }) {
             <img
               src={src}
               alt={`${title || 'Property'} image ${i + 1}`}
-
               loading={i === 0 ? 'eager' : 'lazy'}
-              crossOrigin="anonymous"
-
             />
           </div>
         ))}

--- a/components/MediaGallery.js
+++ b/components/MediaGallery.js
@@ -72,8 +72,6 @@ function renderMedia(url, index) {
         src={url}
         alt={`Property media item ${index + 1}`}
         loading={index === 0 ? 'eager' : 'lazy'}
-        crossOrigin="anonymous"
-
       />
     </div>
   );
@@ -124,8 +122,7 @@ export default function MediaGallery({ images = [], media = [] }) {
                 aria-label={`Show slide ${imageOffset + i + 1}`}
                 className={styles.thumbButton}
               >
-                <img src={src} alt={`Thumbnail ${i + 1}`} loading="lazy" crossOrigin="anonymous" />
-
+                <img src={src} alt={`Thumbnail ${i + 1}`} loading="lazy" />
               </button>
             </li>
           ))}

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -20,16 +20,13 @@ export default function PropertyCard({ property }) {
 
         ) : (
           property.image && (
-            <img
-              src={property.image}
-              alt={`Image of ${property.title}`}
-
-              loading="lazy"
-              crossOrigin="anonymous"
-
-            />
-          )
-        )}
+              <img
+                src={property.image}
+                alt={`Image of ${property.title}`}
+                loading="lazy"
+              />
+            )
+          )}
         {property.featured && (
           <span className="featured-badge">Featured</span>
         )}

--- a/pages/agents/[id].js
+++ b/pages/agents/[id].js
@@ -18,7 +18,6 @@ export default function AgentPage({ agent, listings }) {
           src={agent.photo}
           alt={agent.name}
           style={{ maxWidth: 'var(--size-avatar)' }}
-          crossOrigin="anonymous"
         />
       )}
       <h1>{agent.name}</h1>


### PR DESCRIPTION
## Summary
- Remove `crossOrigin="anonymous"` from all `<img>` tags to prevent CORS errors when loading external images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4db19bf94832e82749428d2ea09c4