### PR TITLE
Add cross-browser fallbacks for Leaflet map elements

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -191,6 +191,10 @@ body {
 .leaflet-marker-icon,
 .leaflet-marker-shadow,
 .leaflet-tile {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   -webkit-user-drag: none;
   user-drag: none;
 }


### PR DESCRIPTION
## Summary
- add vendor-prefixed `user-select` and `user-drag` fallbacks for Leaflet tiles and markers
- consolidate Leaflet compatibility rules in global stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4dcc47b84832eaf40abd08a2790a1