### PR TITLE
Guard custom headers for static export

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,54 @@ const isProd = process.env.NODE_ENV === 'production';
 const shouldExport = process.env.NEXT_EXPORT !== 'false';
 
 /** @type {import('next').NextConfig} */
+const staticHeaders = [
+  {
+    source: '/_next/static/(.*)',
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=31536000, immutable',
+      },
+    ],
+  },
+  {
+    source: '/images/(.*)',
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=31536000, immutable',
+      },
+    ],
+  },
+  {
+    source: '/fonts/(.*)',
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=31536000, immutable',
+      },
+    ],
+  },
+  {
+    source: '/static/(.*)',
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=31536000, immutable',
+      },
+    ],
+  },
+  {
+    source: '/property/:path*',
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'no-store',
+      },
+    ],
+  },
+];
+
 const nextConfig = {
   ...(shouldExport
     ? {
@@ -11,62 +59,15 @@ const nextConfig = {
         basePath: isProd && repo ? `/${repo}` : undefined,
         assetPrefix: isProd && repo ? `/${repo}/` : undefined,
       }
-    : {}),
-  async headers() {
-    return [
-      {
-        source: '/_next/static/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-      {
-        source: '/images/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-      {
-        source: '/fonts/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-      {
-        source: '/static/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-      {
-        source: '/property/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-store',
-          },
-        ],
-      },
-
-    ];
-  },
+    : {
+        async headers() {
+          return staticHeaders;
+        },
+      }),
 };
 
 // Custom HTTP headers such as Cache-Control cannot be configured via
 // `next.config.js` when using `output: 'export'`. They must be applied by the
-// hosting environment instead. The previous header configuration was removed to
-// avoid build-time warnings from Next.js.
+// hosting environment instead.
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Only apply custom caching headers when not performing a static export to avoid Next.js warnings.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4de79b734832e873564441c2f454d