### PR TITLE
Add cross-browser fallbacks for Leaflet map elements

### DIFF
--- a/node_modules/leaflet/dist/leaflet.css
+++ b/node_modules/leaflet/dist/leaflet.css
@@ -20,11 +20,12 @@
 .leaflet-tile,
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
         user-select: none;
-        /* Legacy vendor prefixes for older browsers:
-           -webkit-user-select: none;
-           -moz-user-select: none;
-           -webkit-user-drag: none; */
+        -webkit-user-drag: none;
+        user-drag: none;
         }
 /* Prevents IE11 from highlighting tiles in blue */
 .leaflet-tile::selection {
@@ -103,8 +104,10 @@
         }
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
 .leaflet-overlay-pane svg {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
         user-select: none;
-        /* Legacy: -moz-user-select: none; */
         }
 
 .leaflet-pane         { z-index: 400; }
@@ -590,12 +593,11 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border: 1px solid #fff;
 	border-radius: 3px;
 	color: #222;
-	white-space: nowrap;
+        white-space: nowrap;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
         user-select: none;
-        /* Legacy user-select prefixes:
-           -webkit-user-select: none;
-           -moz-user-select: none;
-           -ms-user-select: none; */
         pointer-events: none;
         box-shadow: 0 1px 3px rgba(0,0,0,0.4);
         }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -191,6 +191,10 @@ body {
 .leaflet-marker-icon,
 .leaflet-marker-shadow,
 .leaflet-tile {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   -webkit-user-drag: none;
   user-drag: none;
 }


### PR DESCRIPTION
## Summary
- add vendor-prefixed `user-select` and `user-drag` fallbacks for Leaflet tiles, markers, and tooltips
- consolidate Leaflet compatibility rules in global stylesheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4dcc47b84832eaf40abd08a2790a1