### PR TITLE
fix: load Leaflet styles globally

### DIFF
--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,6 +1,4 @@
 import { useEffect } from 'react';
-import '../styles/leaflet.css';
-
 export default function PropertyMap({ properties = [], center = [51.5, -0.1], zoom = 12 }) {
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import '../styles/globals.css';
 import '../styles/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../styles/carousel.css';
+import '../styles/leaflet.css';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';

--- a/styles/leaflet.css
+++ b/styles/leaflet.css
@@ -356,14 +356,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-radius: 5px;
 	}
 .leaflet-control-layers-toggle {
-	background-image: url(images/layers.png);
-	width: 36px;
-	height: 36px;
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/layers.png');
+        width: 36px;
+        height: 36px;
+        }
 .leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
-	background-size: 26px 26px;
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/layers-2x.png');
+        background-size: 26px 26px;
+        }
 .leaflet-touch .leaflet-control-layers-toggle {
 	width: 44px;
 	height: 44px;
@@ -404,8 +404,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 /* Default icon URLs */
 .leaflet-default-icon-path { /* used only in path-guessing heuristic, see L.Icon.Default */
-	background-image: url(images/marker-icon.png);
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png');
+        }
 
 
 /* attribution and scale controls */


### PR DESCRIPTION
## Summary
- import Leaflet CSS in `_app` so Next.js can build
- remove component-level Leaflet CSS import
- use CDN URLs for Leaflet control icons

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4e49b2b00832ea5d153b0454922ed