### PR TITLE
fix: load Leaflet styles globally and allow remote images

### DIFF
--- a/components/AgentCard.js
+++ b/components/AgentCard.js
@@ -9,9 +9,7 @@ export default function AgentCard({ agent }) {
           src={agent.photo}
           alt={agent.name}
           className="agent-photo"
-          crossOrigin="anonymous"
           referrerPolicy="no-referrer"
-
         />
       )}
       <h3>

--- a/components/Header.js
+++ b/components/Header.js
@@ -12,7 +12,6 @@ export default function Header() {
             alt="Aktonz"
             width={40}
             height={40}
-            crossOrigin="anonymous"
             referrerPolicy="no-referrer"
           />
 

--- a/components/ImageSlider.js
+++ b/components/ImageSlider.js
@@ -22,10 +22,7 @@ export default function ImageSlider({ images = [], title = '' }) {
             <img
               src={src}
               alt={`${title || 'Property'} image ${i + 1}`}
-              loading={i === 0 ? 'eager' : 'lazy'}
-              crossOrigin="anonymous"
               referrerPolicy="no-referrer"
-
             />
           </div>
         ))}

--- a/components/MediaGallery.js
+++ b/components/MediaGallery.js
@@ -71,10 +71,7 @@ function renderMedia(url, index) {
       <img
         src={url}
         alt={`Property media item ${index + 1}`}
-        loading={index === 0 ? 'eager' : 'lazy'}
-        crossOrigin="anonymous"
         referrerPolicy="no-referrer"
-
       />
     </div>
   );
@@ -128,8 +125,6 @@ export default function MediaGallery({ images = [], media = [] }) {
                 <img
                   src={src}
                   alt={`Thumbnail ${i + 1}`}
-                  loading="lazy"
-                  crossOrigin="anonymous"
                   referrerPolicy="no-referrer"
                 />
 

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -23,8 +23,6 @@ export default function PropertyCard({ property }) {
             <img
               src={property.image}
               alt={`Image of ${property.title}`}
-              loading="lazy"
-              crossOrigin="anonymous"
               referrerPolicy="no-referrer"
             />
           )

--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,6 +1,4 @@
 import { useEffect } from 'react';
-import '../styles/leaflet.css';
-
 export default function PropertyMap({ properties = [], center = [51.5, -0.1], zoom = 12 }) {
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -87,26 +87,10 @@ export function extractMedia(listing) {
   return urls;
 }
 
-function enforceAspect(url, width = 640, height = 480) {
-  try {
-    const u = new URL(url);
-    const parts = u.pathname.split('.');
-    if (parts.length > 1) {
-      const ext = parts.pop();
-      if (!u.pathname.includes(`_${width}x${height}`)) {
-        u.pathname = `${parts.join('.')}_${width}x${height}.${ext}`;
-      }
-    }
-    return u.toString();
-  } catch {
-    return url;
-  }
-}
-
 export function normalizeImageUrl(img) {
   if (!img) return null;
-  if (img.thumbnailUrl) return enforceAspect(img.thumbnailUrl);
-  if (img.url) return enforceAspect(img.url);
+  if (img.thumbnailUrl) return img.thumbnailUrl;
+  if (img.url) return img.url;
   return null;
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import '../styles/globals.css';
 import '../styles/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../styles/carousel.css';
+import '../styles/leaflet.css';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';

--- a/pages/agents/[id].js
+++ b/pages/agents/[id].js
@@ -18,8 +18,6 @@ export default function AgentPage({ agent, listings }) {
           src={agent.photo}
           alt={agent.name}
           style={{ maxWidth: 'var(--size-avatar)' }}
-          crossOrigin="anonymous"
-
         />
       )}
       <h1>{agent.name}</h1>

--- a/styles/leaflet.css
+++ b/styles/leaflet.css
@@ -356,14 +356,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-radius: 5px;
 	}
 .leaflet-control-layers-toggle {
-	background-image: url(images/layers.png);
-	width: 36px;
-	height: 36px;
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/layers.png');
+        width: 36px;
+        height: 36px;
+        }
 .leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
-	background-size: 26px 26px;
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/layers-2x.png');
+        background-size: 26px 26px;
+        }
 .leaflet-touch .leaflet-control-layers-toggle {
 	width: 44px;
 	height: 44px;
@@ -404,8 +404,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 /* Default icon URLs */
 .leaflet-default-icon-path { /* used only in path-guessing heuristic, see L.Icon.Default */
-	background-image: url(images/marker-icon.png);
-	}
+        background-image: url('https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png');
+        }
 
 
 /* attribution and scale controls */


### PR DESCRIPTION
## Summary
- import Leaflet CSS in `_app` so Next.js can build
- remove component-level Leaflet CSS import
- use CDN URLs for Leaflet control icons
- drop `crossOrigin` attributes so remote images can load
- remove explicit lazy-loading from property and gallery images to avoid deferred load warnings
- keep original photo URLs so listing images resolve with correct content type

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e49b2b00832ea5d153b0454922ed