### PR TITLE
Add title and caching fixes for to-rent page

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -6,15 +6,8 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.logo}>
-        <Link href="/">
-          <img
-            src="https://aktonz.com/wp-content/uploads/2020/02/Milky-Black-Minimalist-Beauty-Logo-300x300.png"
-            alt="Aktonz"
-            width={40}
-            height={40}
-            referrerPolicy="no-referrer"
-          />
-
+        <Link href="/" className={styles.logoText}>
+          Aktonz
         </Link>
       </div>
       <nav className={styles.nav}>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,6 +79,21 @@ const staticHeaders = [
       },
     ],
   },
+  {
+    source: '/to-rent',
+    headers: [
+      {
+        source: '/to-rent',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store',
+          },
+        ],
+
+      },
+    ],
+  },
 ];
 
 const nextConfig = {

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -1,4 +1,5 @@
 
+import Head from 'next/head';
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import PropertyList from '../components/PropertyList';
@@ -65,9 +66,14 @@ export default function ToRent({ properties }) {
   );
 
   return (
-    <main className={styles.main}>
-      <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
-      <div className={styles.viewModeControls}>
+    <>
+      <Head>
+        <title>Properties to Rent</title>
+        <meta httpEquiv="Cache-Control" content="no-store, max-age=0" />
+      </Head>
+      <main className={styles.main}>
+        <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
+        <div className={styles.viewModeControls}>
         <button
           type="button"
           onClick={() => setViewMode('list')}
@@ -96,7 +102,8 @@ export default function ToRent({ properties }) {
       ) : (
         <PropertyMap properties={available} />
       )}
-    </main>
+      </main>
+    </>
   );
 }
 

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -20,6 +20,13 @@
   display: block;
 }
 
+.logoText {
+  display: block;
+  color: var(--color-background);
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+
 .nav {
   display: flex;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- add document title and caching meta for to-rent page
- replace external logo image with text branding to avoid binary assets
- configure no-store caching header for to-rent route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4eba5d5b8832ebbf8ee3a1e2e3a0e