### PR TITLE
Fix invisible property listings

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -16,14 +16,20 @@ export default function PropertyCard({ property }) {
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
       <div className="image-wrapper">
         {property.images && property.images.length > 0 ? (
-          <ImageSlider images={property.images} title={property.title} />
-
+          isArchived ? (
+            <img
+              src={property.images[0]}
+              alt={`Image of ${property.title}`}
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <ImageSlider images={property.images} title={property.title} />
+          )
         ) : (
           property.image && (
             <img
               src={property.image}
               alt={`Image of ${property.title}`}
-
               referrerPolicy="no-referrer"
             />
           )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,11 +17,11 @@ body {
   justify-content: center;
 }
 
+
 .property-list .property-link {
   text-decoration: none;
   color: inherit;
-  display: flex;
-  height: 100%;
+  display: block;
 }
 
 .property-card {
@@ -32,7 +32,6 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  height: 100%;
   transition: box-shadow 0.2s, transform 0.2s;
 }
 


### PR DESCRIPTION
## Summary
- Ensure property links and cards size naturally so listings are visible
- Render archived listings with a static preview image so they display correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4edc7b2c0832e9e8fb3c00168118e