### PR TITLE
feat: allow configuring book viewing API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ npm run dev
 
 Create a `.env.local` file and set `APEX27_API_KEY` (and optionally `APEX27_BRANCH_ID` for your branch) to fetch real property data from the Apex27 API. Without these variables, no listings will be shown.
 
+If the site is deployed to a static host where Next.js API routes are not
+available, set `NEXT_PUBLIC_BOOK_VIEWING_API` to the URL of a server capable of
+handling viewing requests (e.g. a deployment of `pages/api/book-viewing`).
+
 ## Build
 
 ```

--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -32,7 +32,10 @@ export default function ViewingForm({ propertyTitle }) {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch(`${router.basePath}/api/book-viewing`, {
+      const endpoint =
+        process.env.NEXT_PUBLIC_BOOK_VIEWING_API ||
+        `${router.basePath}/api/book-viewing`;
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...form, propertyTitle }),


### PR DESCRIPTION
## Summary
- make viewing form endpoint configurable via `NEXT_PUBLIC_BOOK_VIEWING_API`
- document new variable for static deployments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4f45038b4832eb059d65f7cf31d38