### PR TITLE
fix: target listing-specific Apex27 viewing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ npm run dev
 
 Create a `.env.local` file and set `APEX27_API_KEY` (and optionally `APEX27_BRANCH_ID` for your branch) to fetch real property data from the Apex27 API. Without these variables, no listings will be shown.
 
+If the site is deployed to a static host where Next.js API routes are not
+available, set `NEXT_PUBLIC_BOOK_VIEWING_API` to the base listings URL for
+viewing requests (e.g. `https://api.apex27.co.uk/listings`). The property ID and
+`/viewings` path will be appended automatically.
+
 ## Build
 
 ```

--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import styles from '../styles/ViewingForm.module.css';
 
-export default function ViewingForm({ propertyTitle }) {
+export default function ViewingForm({ propertyId, propertyTitle }) {
   const router = useRouter();
 
   const initialForm = {
@@ -32,10 +32,13 @@ export default function ViewingForm({ propertyTitle }) {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch(`${router.basePath}/api/book-viewing`, {
+      const endpoint = process.env.NEXT_PUBLIC_BOOK_VIEWING_API
+        ? `${process.env.NEXT_PUBLIC_BOOK_VIEWING_API.replace(/\/$/, '')}/${propertyId}/viewings`
+        : `${router.basePath}/api/book-viewing`;
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...form, propertyTitle }),
+        body: JSON.stringify({ ...form, propertyId, propertyTitle }),
       });
       if (!res.ok) throw new Error('Request failed');
       setSent(true);

--- a/pages/api/book-viewing.js
+++ b/pages/api/book-viewing.js
@@ -26,29 +26,30 @@ export default async function handler(req, res) {
     return;
   }
 
-  const { name, email, phone, date, time, propertyTitle } = req.body || {};
-  if (!email || !propertyTitle) {
+  const {
+    name,
+    email,
+    phone,
+    date,
+    time,
+    propertyId,
+    propertyTitle,
+  } = req.body || {};
+  if (!email || !propertyId) {
     res.status(400).json({ error: 'Missing required fields' });
     return;
   }
 
   try {
     if (process.env.APEX27_API_KEY) {
-      await fetch('https://api.apex27.co.uk/viewings', {
+      await fetch(`https://api.apex27.co.uk/listings/${propertyId}/viewings`, {
         method: 'POST',
         headers: {
           'x-api-key': process.env.APEX27_API_KEY,
           'Content-Type': 'application/json',
           accept: 'application/json',
         },
-        body: JSON.stringify({
-          name,
-          email,
-          phone,
-          property: propertyTitle,
-          date,
-          time,
-        }),
+        body: JSON.stringify({ name, email, phone, date, time }),
       });
     }
 

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -83,7 +83,10 @@ export default function Property({ property, recommendations }) {
           )}
           <div className={styles.actions}>
             <OfferDrawer propertyId={property.id} propertyTitle={property.title} />
-            <ViewingForm propertyTitle={property.title} />
+            <ViewingForm
+              propertyId={property.id}
+              propertyTitle={property.title}
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- append property ID when building book-viewing API URL
- forward backend requests to `https://api.apex27.co.uk/listings/{id}/viewings`
- document new environment variable usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f45038b4832eb059d65f7cf31d38