### PR TITLE
Make header mobile responsive with hamburger menu

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,31 +1,57 @@
+import { useState } from 'react';
 import Link from 'next/link';
 import { FaHome, FaKey, FaHeart, FaUser } from 'react-icons/fa';
 import styles from '../styles/Header.module.css';
 
 export default function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
+  const closeMenu = () => setMenuOpen(false);
+
+  const navLinks = (
+    <>
+      <Link href="/for-sale" className={styles.navLink} onClick={closeMenu}>
+        <FaHome className={styles.icon} />
+        <span className={styles.label}>Buy</span>
+      </Link>
+      <Link href="/to-rent" className={styles.navLink} onClick={closeMenu}>
+        <FaKey className={styles.icon} />
+        <span className={styles.label}>Rent</span>
+      </Link>
+      <Link href="/favourites" className={styles.navLink} onClick={closeMenu}>
+        <FaHeart className={styles.icon} />
+        <span className={styles.label}>Favourites</span>
+      </Link>
+      <Link href="/account" className={styles.navLink} onClick={closeMenu}>
+        <FaUser className={styles.icon} />
+        <span className={styles.label}>Account</span>
+      </Link>
+    </>
+  );
+
   return (
     <header className={styles.header}>
       <div className={styles.logo}>
         <Link href="/">Aktonz</Link>
-
       </div>
-      <nav className={styles.nav}>
-        <Link href="/for-sale" className={styles.navLink}>
-          <FaHome className={styles.icon} />
-          <span className={styles.label}>Buy</span>
-        </Link>
-        <Link href="/to-rent" className={styles.navLink}>
-          <FaKey className={styles.icon} />
-          <span className={styles.label}>Rent</span>
-        </Link>
-        <Link href="/favourites" className={styles.navLink}>
-          <FaHeart className={styles.icon} />
-          <span className={styles.label}>Favourites</span>
-        </Link>
-        <Link href="/account" className={styles.navLink}>
-          <FaUser className={styles.icon} />
-          <span className={styles.label}>Account</span>
-        </Link>
+
+      <nav className={styles.nav}>{navLinks}</nav>
+
+      <button
+        className={styles.hamburger}
+        onClick={toggleMenu}
+        aria-label="Toggle menu"
+      >
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
+      <nav
+        className={`${styles.mobileMenu} ${menuOpen ? styles.menuOpen : ''}`}
+      >
+        {navLinks}
       </nav>
     </header>
   );

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -32,7 +32,7 @@
 }
 
 .nav {
-  display: flex;
+  display: none;
   gap: 1.5rem;
   margin: 0;
   padding: 0;
@@ -96,19 +96,29 @@
 }
 
 .mobileMenu {
-  position: absolute;
-  top: 100%;
+  position: fixed;
+  top: 0;
   right: 0;
+  height: 100vh;
   background: var(--color-primary);
   color: var(--color-background);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  box-shadow: -2px 0 8px rgba(0,0,0,0.1);
   width: 200px;
-  padding: var(--spacing-md);
+  padding: var(--spacing-lg) var(--spacing-md);
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  z-index: 1000;
+}
+
+.menuOpen {
+  transform: translateX(0);
 }
 
 .mobileMenu a {
   color: var(--color-background);
-
   text-decoration: none;
   font-size: 0.75rem;
 }
@@ -119,10 +129,34 @@
 
 .mobileMenu li {
   margin-bottom: var(--spacing-sm);
+}
 
+.navLink {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: var(--color-background);
+  font-size: 0.875rem;
+}
+
+.label {
+  margin-top: 0.25rem;
 }
 
 @media (min-width: 768px) {
+  .nav {
+    display: flex;
+  }
+
+  .hamburger {
+    display: none;
+  }
+
+  .mobileMenu {
+    display: none;
+  }
+
   .navLink {
     flex-direction: row;
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- Add mobile-friendly hamburger navigation that toggles slide-out menu
- Style header for responsive layout, showing desktop links above 768px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7477f58a0832e97d14ff34ded234a