### PR TITLE
Limit sales statuses and remove lettings archive

### DIFF
--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -62,7 +62,7 @@ export default function ForSale({ properties, agents }) {
   const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
   const isSold = (p) => {
     const status = normalize(p.status || '');
-    return status.includes('sold') || status.includes('sale_agreed');
+    return status === 'sold';
   };
   const available = filtered.filter((p) => !isSold(p));
   const archived = filtered.filter(isSold);
@@ -117,8 +117,7 @@ export default function ForSale({ properties, agents }) {
 
 export async function getStaticProps() {
   const raw = await fetchPropertiesByType('sale', {
-    statuses: ['available', 'under_offer', 'sold', 'sold_stc', 'sale_agreed'],
-
+    statuses: ['available', 'under_offer', 'sold'],
   });
 
   const properties = raw.slice(0, 50).map((p) => ({

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,7 @@ import Stats from '../components/Stats';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
-export default function Home({ sales, lettings, archiveSales, archiveLettings }) {
+export default function Home({ sales, lettings, archiveSales }) {
   return (
     <>
       <Head>
@@ -30,12 +30,6 @@ export default function Home({ sales, lettings, archiveSales, archiveLettings })
             <PropertyList properties={archiveSales} />
           </section>
         )}
-        {archiveLettings.length > 0 && (
-          <section className={styles.listings}>
-            <h2>Archive Lettings</h2>
-            <PropertyList properties={archiveLettings} />
-          </section>
-        )}
       </main>
     </>
   );
@@ -44,21 +38,16 @@ export default function Home({ sales, lettings, archiveSales, archiveLettings })
 export async function getStaticProps() {
   const [allSale, allRent] = await Promise.all([
     fetchPropertiesByType('sale', {
-      statuses: ['available', 'under_offer', 'sold', 'sold_stc', 'sale_agreed'],
+      statuses: ['available', 'under_offer', 'sold'],
     }),
     fetchPropertiesByType('rent', {
-      statuses: ['available', 'under_offer', 'let_agreed', 'let', 'let_stc', 'let_by'],
-
+      statuses: ['available', 'under_offer'],
     }),
   ]);
 
   const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  const soldStatuses = ['sold', 'sold_stc', 'sale_agreed'];
   const isAvailable = (p) => p.status && normalize(p.status) === 'available';
-  const isSold = (p) =>
-    p.status && soldStatuses.some((s) => normalize(p.status).includes(s));
-
-  const isLet = (p) => p.status && normalize(p.status).startsWith('let');
+  const isSold = (p) => p.status && normalize(p.status) === 'sold';
 
   const sales = allSale
     .filter((p) => isAvailable(p) && p.featured)
@@ -69,7 +58,6 @@ export async function getStaticProps() {
     .slice(0, 4);
 
   const archiveSales = allSale.filter(isSold).slice(0, 4);
-  const archiveLettings = allRent.filter(isLet).slice(0, 4);
 
-  return { props: { sales, lettings, archiveSales, archiveLettings } };
+  return { props: { sales, lettings, archiveSales } };
 }

--- a/pages/property/index.js
+++ b/pages/property/index.js
@@ -13,7 +13,9 @@ export default function PropertyArchive({ properties }) {
 
 export async function getStaticProps() {
   const [sale, rent] = await Promise.all([
-    fetchPropertiesByType('sale'),
+    fetchPropertiesByType('sale', {
+      statuses: ['available', 'under_offer', 'sold'],
+    }),
     fetchPropertiesByType('rent'),
   ]);
 

--- a/pages/sell.js
+++ b/pages/sell.js
@@ -13,7 +13,9 @@ export default function Sell({ properties }) {
 }
 
 export async function getStaticProps() {
-  const allSale = await fetchPropertiesByType('sale');
+  const allSale = await fetchPropertiesByType('sale', {
+    statuses: ['available', 'under_offer', 'sold'],
+  });
   const allowed = ['available', 'under_offer', 'sold'];
   const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
   const properties = allSale.filter(


### PR DESCRIPTION
## Summary
- Restrict sales queries across the app to `available`, `under_offer`, and `sold` statuses to exclude pending listings
- Drop archive lettings section from the homepage and trim rent status fetches accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c74b57eac0832e8bf53bc6e34c0cd1