### PR TITLE
feat: improve map property markers

### DIFF
--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,5 +1,13 @@
 import { useEffect } from 'react';
-export default function PropertyMap({ properties = [], center = [51.5, -0.1], zoom = 12 }) {
+import { useRouter } from 'next/router';
+import { formatRentFrequency } from '../lib/format.mjs';
+
+export default function PropertyMap({
+  properties = [],
+  center = [51.5, -0.1],
+  zoom = 12,
+}) {
+  const router = useRouter();
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
@@ -9,21 +17,52 @@ export default function PropertyMap({ properties = [], center = [51.5, -0.1], zo
 
       // Configure default icon paths so markers appear correctly
       L.Icon.Default.mergeOptions({
-        iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+        iconRetinaUrl:
+          'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
         iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
         shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
       });
 
+      const getIcon = (type) => {
+        const t = String(type || '').toLowerCase();
+        const isFlat = t.includes('flat') || t.includes('apartment');
+        const emoji = isFlat ? '🏢' : '🏠';
+        return L.divIcon({
+          className: '',
+          html: `<div style="font-size:24px;">${emoji}</div>`,
+          iconSize: [24, 24],
+          iconAnchor: [12, 24],
+        });
+      };
+
       map = L.map('property-map').setView(center, zoom);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       }).addTo(map);
 
-      properties.forEach((p) => {
-        if (typeof p.lat === 'number' && typeof p.lng === 'number') {
-          L.marker([p.lat, p.lng]).addTo(map).bindPopup(`<strong>${p.title}</strong>`);
-        }
-      });
+        properties.forEach((p) => {
+          if (typeof p.lat === 'number' && typeof p.lng === 'number') {
+            const marker = L.marker([p.lat, p.lng], {
+              icon: getIcon(p.propertyType),
+            }).addTo(map);
+
+            const priceText = p.price
+              ? p.rentFrequency
+                ? `${p.price} ${formatRentFrequency(p.rentFrequency)}`
+                : p.tenure
+                ? `${p.price} ${p.tenure}`
+                : p.price
+              : '';
+
+            const imgHtml = p.image
+              ? `<img src="${p.image}" alt="${p.title}" style="width:100px;height:auto;display:block;"/>`
+              : '';
+
+            const popupHtml = `<a href="${router.basePath}/property/${p.id}" style="text-decoration:none;">${imgHtml}<strong>${p.title}</strong><br/>${priceText}</a>`;
+            marker.bindPopup(popupHtml);
+          }
+        });
     }
 
     initMap();
@@ -31,7 +70,9 @@ export default function PropertyMap({ properties = [], center = [51.5, -0.1], zo
     return () => {
       if (map) map.remove();
     };
-  }, [properties, center, zoom]);
+  }, [properties, center, zoom, router.basePath]);
 
-  return <div id="property-map" style={{ height: 'var(--map-height)', width: '100%' }} />;
+  return (
+    <div id="property-map" style={{ height: 'var(--map-height)', width: '100%' }} />
+  );
 }

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -294,6 +294,7 @@ export async function fetchPropertiesByType(type, options = {}) {
       bedrooms: p.bedrooms ?? null,
       propertyType: p.propertyType ?? null,
       rentFrequency: p.rentFrequency ?? null,
+      tenure: p.tenure ?? null,
       image: trimmedImages[0] || null,
       images: trimmedImages,
       media: extractMedia(p),


### PR DESCRIPTION
## Summary
- show house/building icons for map listings based on property type
- make map markers link to property pages and show popups with thumbnail and price
- expose tenure field on fetched properties for richer map details
- fix map marker links to include Next.js base path for correct routing on GitHub Pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c74f9a3218832ea7ada409a075f838