### PR TITLE
Add property management page

### DIFF
--- a/pages/property-management.js
+++ b/pages/property-management.js
@@ -1,0 +1,131 @@
+import Head from 'next/head';
+import styles from '../styles/PropertyManagement.module.css';
+
+export default function PropertyManagement() {
+  return (
+    <main className={styles.main}>
+      <Head>
+        <title>Property Management</title>
+      </Head>
+      <section className={styles.hero}>
+        <h1>Property Management</h1>
+      </section>
+
+      <section className={styles.intro}>
+        <h2>Everything your let needs - leave it to us!</h2>
+        <div className={styles.features}>
+          <div className={styles.feature}>
+            <h3>Tenancy Support</h3>
+            <p>
+              From referencing to renewals, our team looks after every stage of
+              the tenancy so you can relax.
+            </p>
+          </div>
+          <div className={styles.feature}>
+            <h3>Property Services</h3>
+            <p>
+              We handle inspections, maintenance and repairs using vetted
+              contractors at competitive prices.
+            </p>
+          </div>
+          <div className={styles.feature}>
+            <h3>Compliance Tracking</h3>
+            <p>
+              Stay on top of certificates and legal requirements with our
+              proactive monitoring and reminders.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.included}>
+        <h2>What's included?</h2>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Service</th>
+              <th>Included</th>
+              <th>Additional</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Marketing on major portals</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Professional photography</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Tenant referencing</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Tenancy agreement drafting</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Deposit registration</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Rent collection</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>24/7 emergency line</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Maintenance coordination</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Routine inspections</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Compliance tracking</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Renewal negotiation</td>
+              <td>✓</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Inventory & check-in/out</td>
+              <td></td>
+              <td>✓</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section className={styles.testimonial}>
+        <blockquote>
+          “Aktonz handled everything for my rental – I couldn’t be happier.”
+        </blockquote>
+        <p className={styles.cite}>– Happy Landlord</p>
+      </section>
+
+      <section className={styles.cta}>
+        <h2>Choose Aktonz to manage your property</h2>
+        <a className={styles.ctaButton} href="/contact">
+          Get in touch
+        </a>
+      </section>
+    </main>
+  );
+}

--- a/styles/PropertyManagement.module.css
+++ b/styles/PropertyManagement.module.css
@@ -1,0 +1,99 @@
+.main {
+  padding: 0;
+}
+
+.hero {
+  background: url('https://images.unsplash.com/photo-1512917774080-9991f1c4c750?auto=format&fit=crop&w=1500&q=80')
+    no-repeat center/cover;
+  color: var(--color-background);
+  padding: var(--spacing-xl) var(--spacing-md);
+  text-align: center;
+  position: relative;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.hero h1 {
+  margin: 0;
+  position: relative;
+}
+
+.intro {
+  padding: var(--spacing-lg) var(--spacing-md);
+  text-align: center;
+}
+
+.features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-lg);
+  margin-top: var(--spacing-md);
+  justify-content: center;
+}
+
+.feature {
+  flex: 1;
+  min-width: 250px;
+}
+
+.included {
+  background: var(--color-surface);
+  padding: var(--spacing-lg) var(--spacing-md);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--spacing-md);
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--color-border-light);
+  padding: var(--spacing-sm);
+  text-align: center;
+}
+
+.table th:first-child,
+.table td:first-child {
+  text-align: left;
+}
+
+.testimonial {
+  padding: var(--spacing-lg) var(--spacing-md);
+  background: var(--color-surface-alt);
+  text-align: center;
+}
+
+.testimonial blockquote {
+  margin: 0;
+  font-style: italic;
+}
+
+.cite {
+  margin-top: var(--spacing-sm);
+  font-weight: bold;
+}
+
+.cta {
+  text-align: center;
+  padding: var(--spacing-lg) var(--spacing-md);
+  background: var(--color-surface-dark);
+}
+
+.ctaButton {
+  display: inline-block;
+  margin-top: var(--spacing-md);
+  background: var(--color-success);
+  color: var(--color-background);
+  padding: calc(var(--spacing-sm) * 1.5) calc(var(--spacing-md) * 1.5);
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- create property management page with service overview, inclusions table and call to action
- add corresponding styles for hero, features and testimonial sections
- expand "What's included?" table to list marketing, tenancy and compliance services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c755bdc940832e9054e8ae3cdeb3d1