### PR TITLE
Add landlords dropdown menu and pages

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -4,9 +4,54 @@ import styles from '../styles/Header.module.css';
 
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [landlordOpen, setLandlordOpen] = useState(false);
 
   const toggleMenu = () => setMenuOpen((prev) => !prev);
-  const closeMenu = () => setMenuOpen(false);
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setLandlordOpen(false);
+  };
+
+  const landlordMenu = (
+    <div
+      className={styles.dropdown}
+      onMouseEnter={() => setLandlordOpen(true)}
+      onMouseLeave={() => setLandlordOpen(false)}
+    >
+      <button
+        className={`${styles.navLink} ${styles.navButton}`}
+        onClick={() => setLandlordOpen((prev) => !prev)}
+      >
+        Landlords
+      </button>
+      <div
+        className={`${styles.dropdownMenu} ${landlordOpen ? styles.show : ''}`}
+      >
+        <Link href="/valuation" onClick={closeMenu}>
+          Get a valuation
+        </Link>
+        <Link href="/about" onClick={closeMenu}>
+          Why use Aktonz
+        </Link>
+        <Link href="/property-management" onClick={closeMenu}>
+          Property management
+        </Link>
+        <Link href="/landlords/rent-protection" onClick={closeMenu}>
+          Rent protection
+        </Link>
+        <Link
+          href="/landlords/help"
+          className={styles.arrow}
+          onClick={closeMenu}
+        >
+          Help for Landlords
+        </Link>
+        <Link href="/landlords/legal-compliance" onClick={closeMenu}>
+          Legal & Compliance
+        </Link>
+      </div>
+    </div>
+  );
 
   const navLinks = (
     <>
@@ -16,9 +61,7 @@ export default function Header() {
       <Link href="/to-rent" className={styles.navLink} onClick={closeMenu}>
         Rent
       </Link>
-      <Link href="/landlords" className={styles.navLink} onClick={closeMenu}>
-        Landlords
-      </Link>
+      {landlordMenu}
       <Link href="/sell" className={styles.navLink} onClick={closeMenu}>
         Sell
       </Link>

--- a/pages/landlords/help.js
+++ b/pages/landlords/help.js
@@ -1,0 +1,8 @@
+export default function LandlordHelp() {
+  return (
+    <main>
+      <h1>Help for Landlords</h1>
+      <p>Resources and support for landlords.</p>
+    </main>
+  );
+}

--- a/pages/landlords/legal-compliance.js
+++ b/pages/landlords/legal-compliance.js
@@ -1,0 +1,8 @@
+export default function LegalCompliance() {
+  return (
+    <main>
+      <h1>Legal & Compliance</h1>
+      <p>Guidance on legal and compliance matters for landlords.</p>
+    </main>
+  );
+}

--- a/pages/landlords/rent-protection.js
+++ b/pages/landlords/rent-protection.js
@@ -1,0 +1,8 @@
+export default function RentProtection() {
+  return (
+    <main>
+      <h1>Rent Protection</h1>
+      <p>Information about rent protection for landlords.</p>
+    </main>
+  );
+}

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -35,6 +35,50 @@
   font-size: 1rem;
 }
 
+.navButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+.dropdown {
+  position: relative;
+}
+
+.dropdownMenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--color-background);
+  border: 1px solid var(--color-border-mid);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  padding: var(--spacing-md) var(--spacing-lg);
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.dropdownMenu a {
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.dropdownMenu a:hover {
+  text-decoration: underline;
+}
+
+.show {
+  display: flex;
+}
+
+.arrow::after {
+  content: '\203A';
+  margin-left: var(--spacing-sm);
+}
+
 .actions {
   display: flex;
   align-items: center;
@@ -107,6 +151,17 @@
 .mobileMenu .login {
   display: block;
 
+}
+
+.mobileMenu .dropdown {
+  width: 100%;
+}
+
+.mobileMenu .dropdownMenu {
+  position: static;
+  border: none;
+  box-shadow: none;
+  padding: 0 0 0 var(--spacing-lg);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- add dropdown submenu for Landlords navigation
- create pages for rent protection, landlord help, and legal compliance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75a14decc832ea3c8d0960993b313