### PR TITLE
Add registration page

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -30,7 +30,7 @@ export default function Login() {
           <button type="submit" className={styles.button}>Sign in</button>
         </form>
         <p className={styles.createAccount}>
-          New to Aktonz? <Link href="#">Create Account</Link>
+          New to Aktonz? <Link href="/register">Create Account</Link>
         </p>
         <p className={styles.legal}>
           By signing in you agree to our <Link href="#">privacy policy</Link>.

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import styles from '../styles/Register.module.css';
+
+export default function Register() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.brandSection}>
+        <h1>Aktonz</h1>
+        <p>Insight. Information. Control. Wherever you are.</p>
+        <p className={styles.subtitle}>Stay on top of what's happening with your property.</p>
+      </div>
+      <div className={styles.formSection}>
+        <Link href="/">← Back</Link>
+        <h2>Create an account</h2>
+        <form>
+          <label htmlFor="email">Email address *</label>
+          <input id="email" name="email" type="email" autoComplete="email" required />
+          <label htmlFor="password">Password *</label>
+          <input id="password" name="password" type="password" autoComplete="new-password" required />
+          <label htmlFor="confirmPassword">Confirm Password *</label>
+          <input id="confirmPassword" name="confirmPassword" type="password" autoComplete="new-password" required />
+          <button type="submit" className={styles.button}>Register</button>
+        </form>
+        <p className={styles.signIn}>
+          Already have an account? <Link href="/login">Sign in</Link>
+        </p>
+        <p className={styles.legal}>
+          By registering you agree to our <Link href="#">privacy policy</Link>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/styles/Register.module.css
+++ b/styles/Register.module.css
@@ -1,0 +1,59 @@
+.container {
+  display: flex;
+  min-height: 100vh;
+}
+.brandSection {
+  flex: 1;
+  background: var(--color-primary);
+  color: var(--color-background);
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.brandSection h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin-bottom: var(--spacing-md);
+}
+.brandSection p {
+  margin-top: var(--spacing-md);
+}
+.subtitle {
+  margin-top: var(--spacing-md);
+}
+.formSection {
+  flex: 1;
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.formSection form {
+  display: flex;
+  flex-direction: column;
+}
+.formSection label {
+  margin-top: var(--spacing-md);
+}
+.formSection input {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+}
+.button {
+  margin-top: var(--spacing-md);
+  padding: calc(var(--spacing-sm) * 1.5);
+  background: var(--color-accent);
+  border: none;
+  cursor: pointer;
+}
+.signIn {
+  margin-top: var(--spacing-md);
+  text-align: center;
+}
+.legal {
+  margin-top: var(--spacing-sm);
+  font-size: 0.8rem;
+  color: var(--color-muted-text);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- Implement registration page with email, password and confirm password form
- Style new registration view matching brand layout
- Update login link to direct to registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c75cd07870832eab2d9f2791ca9993