### PR TITLE
feat: add interactive area guide map

### DIFF
--- a/components/AreaMap.js
+++ b/components/AreaMap.js
@@ -1,55 +1,113 @@
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import styles from '../styles/AreaGuides.module.css';
 
 export default function AreaMap({ regions }) {
   const router = useRouter();
+
   const findSlug = (name) => {
     const match = regions.find((r) => r.name.toLowerCase() === name.toLowerCase());
     return match ? match.slug : null;
   };
 
-  const shapes = [
-    { name: 'North London', x: 120, y: 0, w: 160, h: 80 },
-    { name: 'South London', x: 120, y: 120, w: 160, h: 80 },
-    { name: 'East London', x: 260, y: 80, w: 140, h: 80 },
-    { name: 'West London', x: 0, y: 80, w: 140, h: 80 },
-    { name: 'Central London', x: 150, y: 80, w: 100, h: 80 },
-  ];
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
 
-  return (
-    <svg viewBox="0 0 400 200" className={styles.map} role="img" aria-label="London areas map">
-      {shapes.map((s) => {
+    let map;
+
+    async function initMap() {
+      const L = (await import('leaflet')).default;
+
+      L.Icon.Default.mergeOptions({
+        iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+        iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+        shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+      });
+
+      map = L.map('area-map', {
+        zoomControl: false,
+        scrollWheelZoom: false,
+      }).setView([51.5, -0.1], 10);
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      }).addTo(map);
+
+      const shapes = [
+        {
+          name: 'North London',
+          coords: [
+            [51.7, -0.45],
+            [51.7, 0.1],
+            [51.56, 0.1],
+            [51.56, -0.45],
+          ],
+        },
+        {
+          name: 'South London',
+          coords: [
+            [51.56, -0.4],
+            [51.56, 0.1],
+            [51.3, 0.1],
+            [51.3, -0.4],
+          ],
+        },
+        {
+          name: 'East London',
+          coords: [
+            [51.56, 0.1],
+            [51.56, 0.3],
+            [51.4, 0.3],
+            [51.4, 0.1],
+          ],
+        },
+        {
+          name: 'West London',
+          coords: [
+            [51.56, -0.5],
+            [51.56, -0.2],
+            [51.3, -0.2],
+            [51.3, -0.5],
+          ],
+        },
+        {
+          name: 'Central London',
+          coords: [
+            [51.52, -0.15],
+            [51.52, 0.05],
+            [51.47, 0.05],
+            [51.47, -0.15],
+          ],
+        },
+      ];
+
+      shapes.forEach((s) => {
         const slug = findSlug(s.name);
-        if (!slug) return null;
-        const label = s.name.replace(/\s+London$/i, '');
-        return (
-          <g
-            key={s.name}
-            className={styles.mapRegion}
-            onClick={() => router.push(`/area-guides/${slug}`)}
-            role="button"
-            tabIndex={0}
-            aria-label={`View listings for ${s.name}`}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                router.push(`/area-guides/${slug}`);
-              }
-            }}
-          >
-            <rect x={s.x} y={s.y} width={s.w} height={s.h} />
-            <text
-              x={s.x + s.w / 2}
-              y={s.y + s.h / 2}
-              className={styles.mapLabel}
-              textAnchor="middle"
-              dominantBaseline="middle"
-            >
-              {label}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
-  );
+        if (!slug) return;
+
+        const polygon = L.polygon(s.coords, {
+          color: '#2262CC',
+          weight: 1,
+          fillOpacity: 0.2,
+        })
+          .addTo(map)
+          .on('click', () => router.push(`/area-guides/${slug}`));
+
+        polygon.bindTooltip(s.name.replace(/ London$/i, ''), {
+          permanent: true,
+          direction: 'center',
+          className: styles.mapTooltip,
+        });
+      });
+    }
+
+    initMap();
+
+    return () => {
+      if (map) map.remove();
+    };
+  }, [regions, router]);
+
+  return <div id="area-map" className={styles.map} />;
 }

--- a/styles/AreaGuides.module.css
+++ b/styles/AreaGuides.module.css
@@ -42,22 +42,14 @@
 .map {
   max-width: 600px;
   margin: 0 auto var(--spacing-lg);
-  display: block;
+  height: 400px;
 }
 
-.mapRegion {
-  fill: var(--color-neutral);
-  stroke: var(--color-background);
-  cursor: pointer;
-  transition: fill 0.2s;
-}
-
-.mapRegion:hover {
-  fill: var(--color-border);
-}
-
-.mapLabel {
+.mapTooltip {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: inherit;
   font-size: 0.75rem;
-  pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- replace static SVG map with Leaflet-based interactive map on area guides
- style area guide map container and tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c75e9858e8832e90b45bd425bc8d21