### PR TITLE
Add account dashboard page

### DIFF
--- a/pages/account/index.js
+++ b/pages/account/index.js
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import styles from '../../styles/Account.module.css';
+
+export default function AccountDashboard() {
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.heading}>Welcome to Aktonz</h1>
+      <p className={styles.subtitle}>Insights. Information. Control.</p>
+      <h2 className={styles.prompt}>Are you looking to...</h2>
+      <div className={styles.grid}>
+        <div className={styles.card}>
+          <h3>LET</h3>
+          <p>Manage your rental properties online</p>
+          <Link href="/landlords" className={styles.button}>
+            Get started now
+          </Link>
+        </div>
+        <div className={styles.card}>
+          <h3>SELL</h3>
+          <p>Stay in control of the sale of your home</p>
+          <Link href="/sell" className={styles.button}>
+            Get started now
+          </Link>
+        </div>
+        <div className={styles.card}>
+          <h3>RENT</h3>
+          <p>Rent a property online, start to finish</p>
+          <Link href="/to-rent" className={styles.button}>
+            Get started now
+          </Link>
+        </div>
+        <div className={styles.card}>
+          <h3>BUY</h3>
+          <p>See if you can stay ahead of other buyers</p>
+          <Link href="/for-sale" className={styles.button}>
+            Get started now
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/styles/Account.module.css
+++ b/styles/Account.module.css
@@ -1,0 +1,58 @@
+.main {
+  padding: var(--spacing-xl) var(--spacing-lg);
+  text-align: center;
+}
+
+.heading {
+  font-size: 2rem;
+  margin-bottom: var(--spacing-sm);
+}
+
+.subtitle {
+  color: var(--color-muted-text);
+  margin-bottom: var(--spacing-xl);
+}
+
+.prompt {
+  margin-bottom: var(--spacing-lg);
+}
+
+.grid {
+  display: grid;
+  gap: var(--spacing-lg);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.card {
+  background: #e6f7f7;
+  padding: var(--spacing-lg);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.card h3 {
+  margin-bottom: var(--spacing-md);
+}
+
+.card p {
+  flex-grow: 1;
+  margin-bottom: var(--spacing-md);
+}
+
+.button {
+  background: var(--color-accent);
+  color: var(--color-text);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.button:hover {
+  opacity: 0.85;
+}


### PR DESCRIPTION
## Summary
- add My Account dashboard featuring quick links for letting, selling, renting, and buying
- style dashboard cards and layout
- use `next/link` for in-app navigation and remove hard-coded user name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75d3ad820832e89c14d5a27e1a532