### PR TITLE
Exclude pending listings from for sale page

### DIFF
--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -28,6 +28,7 @@ export default function ForSale({ properties, agents }) {
       ? router.query.propertyType.toLowerCase()
       : null;
   const [viewMode, setViewMode] = useState('list');
+  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
 
   const filtered = useMemo(() => {
     return properties.filter((p) => {
@@ -54,12 +55,13 @@ export default function ForSale({ properties, agents }) {
       )
         return false;
 
+      const status = normalize(p.status || '');
+      if (status.includes('pending')) return false;
+
       return true;
     });
 
   }, [properties, search, minPrice, maxPrice, bedrooms, propertyType]);
-
-  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
   const isSold = (p) => {
     const status = normalize(p.status || '');
     return status.includes('sold') || status.includes('sale_agreed');


### PR DESCRIPTION
## Summary
- Normalize property status and remove pending listings from the For Sale page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77056e24c832e8f04c067b2937aa2