### PR TITLE
Ensure featured lettings display only available rentals

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -41,7 +41,7 @@ export async function getStaticProps() {
       statuses: ['available', 'under_offer', 'sold'],
     }),
     fetchPropertiesByType('rent', {
-      statuses: ['available', 'under_offer'],
+      statuses: ['available'],
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- Restrict homepage featured lettings to fetch only rental properties with status `available`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c77591310c832eb0c37dae3b9e5fec