### PR TITLE
Verify Apex27 contact creation

### DIFF
--- a/pages/register.js
+++ b/pages/register.js
@@ -1,12 +1,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 import styles from '../styles/Register.module.css';
 
 export default function Register() {
   const [status, setStatus] = useState('');
-  const router = useRouter();
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -18,46 +16,55 @@ export default function Register() {
       setStatus('Passwords do not match');
       return;
     }
+
+    const apiKey = process.env.NEXT_PUBLIC_APEX27_API_KEY;
+    const branchId = process.env.NEXT_PUBLIC_APEX27_BRANCH_ID;
+
+    const body = { email };
+    if (branchId) {
+      body.branchId = branchId;
+    }
+
     try {
       let res;
       try {
-        res = await fetch(`${router.basePath}/api/register`, {
+        res = await fetch('/api/register', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ email }),
         });
       } catch (_) {
-        // network failure, fall back if possible
+        // Network failures fall through to direct API fallback
       }
 
-      if (!res?.ok && process.env.NEXT_PUBLIC_APEX27_API_KEY) {
-        const body = { email };
-        if (process.env.NEXT_PUBLIC_APEX27_BRANCH_ID) {
-          body.branchId = process.env.NEXT_PUBLIC_APEX27_BRANCH_ID;
+      if (!res?.ok && apiKey) {
+        try {
+          res = await fetch('https://api.apex27.co.uk/contacts', {
+            method: 'POST',
+            headers: {
+              'x-api-key': apiKey,
+              accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+          });
+        } catch (_) {
+          // Network failures fall through to generic error handling
         }
-        res = await fetch('https://api.apex27.co.uk/contacts', {
-          method: 'POST',
-          headers: {
-            'x-api-key': process.env.NEXT_PUBLIC_APEX27_API_KEY,
-            accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(body),
-        });
       }
 
       if (res?.ok) {
-
         setStatus('Registration successful');
       } else {
         let data = {};
         try {
-          data = await res.json();
+          data = await res?.json();
         } catch (_) {
-          // Non-JSON response (e.g., 404/405 HTML)
+          // Non-JSON response or no response
         }
-
-        setStatus(data.error || 'Registration failed');
+        setStatus(data?.error || data?.message || 'Registration failed');
       }
     } catch (err) {
       console.error('Registration error', err);


### PR DESCRIPTION
## Summary
- Validate Apex27 API responses in the registration handler to avoid false successes
- Attempt backend registration before falling back to Apex27 directly, surfacing errors when contact creation fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77ce80da0832e90a2a6c3a53a00dd