### PR TITLE
Adjust homepage property grid to four columns

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,9 +21,9 @@ body {
 .property-list .property-link {
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
   width: 100%;
-
+  height: 100%;
 }
 
 .property-card {
@@ -36,6 +36,7 @@ body {
   flex-direction: column;
   transition: box-shadow 0.2s, transform 0.2s;
   width: 100%;
+  height: 100%;
 }
 
 .property-list .property-link:hover .property-card,
@@ -109,6 +110,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  flex-grow: 1;
 }
 
 .property-card .title {
@@ -153,7 +155,7 @@ body {
 
 @media (min-width: 1024px) {
   .property-list {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
   .property-card .image-wrapper {


### PR DESCRIPTION
## Summary
- Show four listings per row at desktop widths
- Ensure property cards stretch to equal heights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c796ba70d0832e93454fc0869bad6a