### PR TITLE
Filter Apex27 properties by transaction type

### DIFF
--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -25,6 +25,68 @@ async function fetchWithRetry(url, options, retries = 3) {
   }
 }
 
+function resolveTransactionType(listing) {
+  if (!listing || typeof listing !== 'object') return null;
+
+  const rentIndicators = new Set([
+    'rent',
+    'rents',
+    'rental',
+    'rentals',
+    'renting',
+    'letting',
+    'lettings',
+    'let',
+    'lease',
+    'leasing',
+    'tenancy',
+    'tenancies',
+  ]);
+  const saleIndicators = new Set(['sale', 'sales', 'sell', 'selling']);
+
+  const candidates = [
+    listing.transactionType,
+    listing.transaction_type,
+    listing.saleOrRent,
+    listing.sale_or_rent,
+    listing.saleRent,
+    listing.sale_rent,
+    listing.marketingType,
+    listing.marketing_type,
+    listing.transaction,
+    listing.transaction_category,
+    listing.channel,
+    listing.listingType,
+    listing.listing_type,
+  ];
+
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const value = String(raw).toLowerCase();
+    const tokens = value.split(/[^a-z]+/).filter(Boolean);
+    if (tokens.some((token) => rentIndicators.has(token))) {
+      return 'rent';
+    }
+    if (tokens.some((token) => saleIndicators.has(token))) {
+      return 'sale';
+    }
+  }
+
+  if (
+    listing.rentFrequency != null ||
+    listing.tenancyType != null ||
+    listing.rentalFlags != null
+  ) {
+    return 'rent';
+  }
+
+  if (listing.tenure != null || listing.sale != null || listing.saleFlags != null) {
+    return 'sale';
+  }
+
+  return null;
+}
+
 function slugify(str) {
   return String(str)
     .toLowerCase()
@@ -230,14 +292,38 @@ export async function fetchPropertiesByType(type, options = {}) {
     const results = [];
     for (const status of statuses) {
       const props = await fetchProperties({ transactionType, status });
-      results.push(props);
+      results.push(Array.isArray(props) ? props : []);
       await sleep(200);
     }
 
     properties = results.flat();
   } else {
-    properties = await fetchProperties(baseParams);
+    const props = await fetchProperties(baseParams);
+    properties = Array.isArray(props) ? props : [];
   }
+
+  const seenIds = new Set();
+  properties = properties.filter((p) => {
+    if (!p || typeof p !== 'object') {
+      return false;
+    }
+
+    const resolvedType = resolveTransactionType(p);
+    if (resolvedType !== transactionType) {
+      return false;
+    }
+
+    const rawId = p.id ?? p.listingId ?? p.listing_id;
+    if (rawId != null) {
+      const idStr = String(rawId);
+      if (seenIds.has(idStr)) {
+        return false;
+      }
+      seenIds.add(idStr);
+    }
+
+    return true;
+  });
 
   let list = properties;
   if (transactionType === 'rent') {


### PR DESCRIPTION
## Summary
- add a helper that derives a listing's transaction type across legacy field names
- filter and deduplicate fetched listings so only the requested transaction type remains before further processing

## Testing
- npm test
- node --input-type=module -e "import('./lib/apex27.mjs').then(async ({ fetchPropertiesByType }) => { const sale = await fetchPropertiesByType('sale', { statuses: ['available', 'under_offer', 'sold'] }); const rent = await fetchPropertiesByType('rent', { statuses: ['available', 'under_offer', 'let_agreed', 'let', 'let_stc', 'let_by'] }); const fs = await import('fs/promises'); const raw = JSON.parse(await fs.readFile('data/listings.json', 'utf8')); const map = new Map(raw.map((item) => { const id = item.id ?? item.listingId ?? item.listing_id; return [String(id), item.transactionType ?? item.transaction_type ?? null]; })); const saleInvalid = sale.filter((p) => map.get(String(p.id)) !== 'sale'); const rentInvalid = rent.filter((p) => map.get(String(p.id)) !== 'rent'); console.log('sale total', sale.length, 'invalid', saleInvalid.length); console.log('rent total', rent.length, 'invalid', rentInvalid.length); if (saleInvalid.length) { console.log('sale invalid ids', saleInvalid.map((p) => p.id)); } if (rentInvalid.length) { console.log('rent invalid ids', rentInvalid.map((p) => p.id)); } }).catch((err) => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68c9eb273e38832e97a655174b848be6