### PR TITLE
Add slider to property card images

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
 import FavoriteButton from './FavoriteButton';
 import { formatRentFrequency } from '../lib/format.mjs';
 import { FaBed, FaBath } from 'react-icons/fa';
+
+let SliderModule = null;
 
 export default function PropertyCard({ property }) {
   const rawStatus = property.status ? property.status.replace(/_/g, ' ') : null;
@@ -10,24 +13,77 @@ export default function PropertyCard({ property }) {
     normalized.includes('sale agreed') ||
     normalized.startsWith('let');
 
+  const title = property.title || 'Property';
+  const sliderKeyPrefix =
+    property.id || property.listingId || property.listing_id || title;
+
+  const [Slider, setSlider] = useState(() => SliderModule);
+  useEffect(() => {
+    let mounted = true;
+    if (!SliderModule) {
+      import('react-slick').then((mod) => {
+        const LoadedSlider = mod.default || mod;
+        SliderModule = LoadedSlider;
+        if (mounted) {
+          setSlider(() => LoadedSlider);
+        }
+      });
+    } else {
+      setSlider(() => SliderModule);
+    }
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const galleryImages = Array.isArray(property.images)
+    ? property.images.filter(Boolean)
+    : [];
+
+  const images =
+    galleryImages.length > 0
+      ? galleryImages
+      : property.image
+      ? [property.image]
+      : [];
+
+  const hasMultipleImages = images.length > 1;
+  const hasImages = images.length > 0;
+
+  const sliderSettings = {
+    dots: hasMultipleImages,
+    arrows: hasMultipleImages,
+    infinite: hasMultipleImages,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    adaptiveHeight: false,
+  };
+
   return (
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
       <div className="image-wrapper">
-        {property.images && property.images.length > 0 ? (
-          <img
-            src={property.images[0]}
-            alt={`Image of ${property.title}`}
-            referrerPolicy="no-referrer"
-          />
-
-        ) : (
-          property.image && (
-            <img
-              src={property.image}
-              alt={`Image of ${property.title}`}
-              referrerPolicy="no-referrer"
-            />
-          )
+        {hasImages && (
+          <div className="property-card-slider">
+            {Slider ? (
+              <Slider {...sliderSettings}>
+                {images.map((src, index) => (
+                  <div key={`${sliderKeyPrefix}-${index}`}>
+                    <img
+                      src={src}
+                      alt={`${title} image ${index + 1}`}
+                      referrerPolicy="no-referrer"
+                    />
+                  </div>
+                ))}
+              </Slider>
+            ) : (
+              <img
+                src={images[0]}
+                alt={`Image of ${title}`}
+                referrerPolicy="no-referrer"
+              />
+            )}
+          </div>
         )}
 
         {property.featured && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,9 +21,9 @@ body {
 .property-list .property-link {
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
   width: 100%;
-
+  height: 100%;
 }
 
 .property-card {
@@ -36,6 +36,7 @@ body {
   flex-direction: column;
   transition: box-shadow 0.2s, transform 0.2s;
   width: 100%;
+  height: 100%;
 }
 
 .property-list .property-link:hover .property-card,
@@ -54,11 +55,63 @@ body {
   height: 260px;
 }
 
+.property-card .property-card-slider,
+.property-card .property-card-slider .slick-slider,
+.property-card .property-card-slider .slick-list,
+.property-card .property-card-slider .slick-track,
+.property-card .property-card-slider .slick-slide,
+.property-card .property-card-slider .slick-slide > div {
+  height: 100%;
+}
+
+.property-card .property-card-slider .slick-slide > div {
+  display: flex;
+}
+
 .property-card img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+.property-card .property-card-slider .slick-prev,
+.property-card .property-card-slider .slick-next {
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+}
+
+.property-card .property-card-slider .slick-prev {
+  left: 8px;
+}
+
+.property-card .property-card-slider .slick-next {
+  right: 8px;
+}
+
+.property-card .property-card-slider .slick-prev:before,
+.property-card .property-card-slider .slick-next:before {
+  font-size: 18px;
+  color: var(--color-background);
+}
+
+.property-card .property-card-slider .slick-dots {
+  bottom: 8px;
+}
+
+.property-card .property-card-slider .slick-dots li button:before {
+  color: var(--color-background);
+  opacity: 0.5;
+}
+
+.property-card .property-card-slider .slick-dots li.slick-active button:before {
+  opacity: 1;
 }
 
 
@@ -109,6 +162,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  flex-grow: 1;
 }
 
 .property-card .title {
@@ -153,7 +207,7 @@ body {
 
 @media (min-width: 1024px) {
   .property-list {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
   .property-card .image-wrapper {


### PR DESCRIPTION
## Summary
- Show four listings per row at desktop widths
- Ensure property cards stretch to equal heights
- Turn property card media into a slick slider with multiple image support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c796ba70d0832e93454fc0869bad6a