### PR TITLE
Fix property card visibility by replacing slick slider

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -3,8 +3,6 @@ import FavoriteButton from './FavoriteButton';
 import { formatRentFrequency } from '../lib/format.mjs';
 import { FaBed, FaBath } from 'react-icons/fa';
 
-let SliderModule = null;
-
 export default function PropertyCard({ property }) {
   const rawStatus = property.status ? property.status.replace(/_/g, ' ') : null;
   const normalized = rawStatus ? rawStatus.toLowerCase() : '';
@@ -16,25 +14,6 @@ export default function PropertyCard({ property }) {
   const title = property.title || 'Property';
   const sliderKeyPrefix =
     property.id || property.listingId || property.listing_id || title;
-
-  const [Slider, setSlider] = useState(() => SliderModule);
-  useEffect(() => {
-    let mounted = true;
-    if (!SliderModule) {
-      import('react-slick').then((mod) => {
-        const LoadedSlider = mod.default || mod;
-        SliderModule = LoadedSlider;
-        if (mounted) {
-          setSlider(() => LoadedSlider);
-        }
-      });
-    } else {
-      setSlider(() => SliderModule);
-    }
-    return () => {
-      mounted = false;
-    };
-  }, []);
 
   const galleryImages = Array.isArray(property.images)
     ? property.images.filter(Boolean)
@@ -49,41 +28,76 @@ export default function PropertyCard({ property }) {
 
   const hasMultipleImages = images.length > 1;
   const hasImages = images.length > 0;
+  const [currentImage, setCurrentImage] = useState(0);
 
-  const sliderSettings = {
-    dots: hasMultipleImages,
-    arrows: hasMultipleImages,
-    infinite: hasMultipleImages,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-    adaptiveHeight: false,
+  useEffect(() => {
+    setCurrentImage(0);
+  }, [sliderKeyPrefix, images.length]);
+
+  const showPreviousImage = () => {
+    if (!hasMultipleImages) return;
+    setCurrentImage((prev) => (prev === 0 ? images.length - 1 : prev - 1));
   };
+
+  const showNextImage = () => {
+    if (!hasMultipleImages) return;
+    setCurrentImage((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+  };
+
+  const handleDotClick = (index) => {
+    if (!hasImages) return;
+    setCurrentImage(index);
+  };
+
+  const activeImage = hasImages ? images[currentImage] : null;
 
   return (
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
       <div className="image-wrapper">
-        {hasImages && (
-          <div className="property-card-slider">
-            {Slider ? (
-              <Slider {...sliderSettings}>
-                {images.map((src, index) => (
-                  <div key={`${sliderKeyPrefix}-${index}`}>
-                    <img
-                      src={src}
-                      alt={`${title} image ${index + 1}`}
-                      referrerPolicy="no-referrer"
-                    />
-                  </div>
-                ))}
-              </Slider>
-            ) : (
+        {hasImages ? (
+          <div className={`property-card-gallery${hasMultipleImages ? '' : ' single'}`}>
+            {activeImage && (
               <img
-                src={images[0]}
-                alt={`Image of ${title}`}
+                src={activeImage}
+                alt={`${title} image ${currentImage + 1}`}
                 referrerPolicy="no-referrer"
               />
             )}
+            {hasMultipleImages && (
+              <>
+                <button
+                  type="button"
+                  className="gallery-control prev"
+                  onClick={showPreviousImage}
+                  aria-label="View previous image"
+                >
+                  ‹
+                </button>
+                <button
+                  type="button"
+                  className="gallery-control next"
+                  onClick={showNextImage}
+                  aria-label="View next image"
+                >
+                  ›
+                </button>
+                <div className="gallery-dots" role="tablist" aria-label={`${title} gallery`}>
+                  {images.map((_, index) => (
+                    <button
+                      type="button"
+                      key={`${sliderKeyPrefix}-dot-${index}`}
+                      className={`gallery-dot${index === currentImage ? ' active' : ''}`}
+                      onClick={() => handleDotClick(index)}
+                      aria-label={`View image ${index + 1}`}
+                      aria-current={index === currentImage ? 'true' : undefined}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
           </div>
+        ) : (
+          <div className="image-placeholder">Image coming soon</div>
         )}
 
         {property.featured && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -55,63 +55,88 @@ body {
   height: 260px;
 }
 
-.property-card .property-card-slider,
-.property-card .property-card-slider .slick-slider,
-.property-card .property-card-slider .slick-list,
-.property-card .property-card-slider .slick-track,
-.property-card .property-card-slider .slick-slide,
-.property-card .property-card-slider .slick-slide > div {
+.property-card .property-card-gallery {
+  position: relative;
+  width: 100%;
   height: 100%;
+  background: var(--color-surface);
 }
 
-.property-card .property-card-slider .slick-slide > div {
-  display: flex;
-}
-
-.property-card img {
+.property-card .property-card-gallery img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.property-card .property-card-slider .slick-prev,
-.property-card .property-card-slider .slick-next {
-  z-index: 1;
+.property-card .gallery-control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   width: 32px;
   height: 32px;
   border-radius: 50%;
+  border: none;
   background: rgba(0, 0, 0, 0.4);
-  display: flex !important;
+  color: var(--color-background);
+  cursor: pointer;
+  display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 1.5rem;
 }
 
-.property-card .property-card-slider .slick-prev {
+.property-card .gallery-control.prev {
   left: 8px;
 }
 
-.property-card .property-card-slider .slick-next {
+.property-card .gallery-control.next {
   right: 8px;
 }
 
-.property-card .property-card-slider .slick-prev:before,
-.property-card .property-card-slider .slick-next:before {
-  font-size: 18px;
-  color: var(--color-background);
+.property-card .gallery-control:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
-.property-card .property-card-slider .slick-dots {
+.property-card .gallery-dots {
+  position: absolute;
+  left: 50%;
   bottom: 8px;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 6px;
 }
 
-.property-card .property-card-slider .slick-dots li button:before {
+.property-card .gallery-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+}
+
+.property-card .gallery-dot.active {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.property-card .gallery-dot:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.property-card .image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-muted-bg);
   color: var(--color-background);
-  opacity: 0.5;
-}
-
-.property-card .property-card-slider .slick-dots li.slick-active button:before {
-  opacity: 1;
+  height: 100%;
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  letter-spacing: 0.05em;
 }
 
 


### PR DESCRIPTION
## Summary
- replace the `react-slick` driven carousel in `PropertyCard` with an in-component gallery so property cards render correctly again
- add gallery styling and a graceful image placeholder to keep cards visible across the site

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9f3bdba28832e8a20ec25f2b77948