### PR TITLE
Limit property card description length

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -30,6 +30,21 @@ export default function PropertyCard({ property }) {
   const hasImages = images.length > 0;
   const [currentImage, setCurrentImage] = useState(0);
 
+  const normalizedDescription =
+    typeof property.description === 'string'
+      ? property.description.replace(/\s+/g, ' ').trim()
+      : '';
+
+  let truncatedDescription = normalizedDescription;
+
+  if (normalizedDescription.length > 160) {
+    const boundary = normalizedDescription.lastIndexOf(' ', 160);
+    const sliceIndex = boundary > 0 ? boundary : 160;
+    truncatedDescription = `${normalizedDescription
+      .slice(0, sliceIndex)
+      .trimEnd()}…`;
+  }
+
   
   useEffect(() => {
     setCurrentImage(0);
@@ -152,8 +167,8 @@ export default function PropertyCard({ property }) {
             )}
           </div>
         )}
-        {property.description && (
-          <p className="description">{property.description}</p>
+        {normalizedDescription && (
+          <p className="description">{truncatedDescription}</p>
         )}
         {property.id && <FavoriteButton propertyId={property.id} />}
       </div>


### PR DESCRIPTION
## Summary
- collapse excess whitespace in property descriptions before rendering
- truncate property card descriptions to roughly 160 characters and append an ellipsis when needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca04d41288832eb5d472cec16ce76c