### PR TITLE
style: restyle property action drawers

### DIFF
--- a/components/PropertyActionDrawer.js
+++ b/components/PropertyActionDrawer.js
@@ -1,0 +1,107 @@
+import { useId } from 'react';
+import { FaBath, FaBed, FaCouch } from 'react-icons/fa';
+import { formatRentFrequency } from '../lib/format.mjs';
+import styles from '../styles/PropertyActionDrawer.module.css';
+
+function formatPrice(property = {}) {
+  if (!property?.price) return '';
+  if (property?.rentFrequency) {
+    return `${property.price} ${formatRentFrequency(property.rentFrequency)}`;
+  }
+  return property.price;
+}
+
+export default function PropertyActionDrawer({
+  open,
+  onClose,
+  title,
+  description,
+  property,
+  children,
+}) {
+  const headingId = useId();
+  const summary = property ?? {};
+  const imageUrl = summary.images?.[0] || summary.image || null;
+  const transactionLabel = summary
+    ? summary.rentFrequency
+      ? 'To rent'
+      : 'For sale'
+    : '';
+  const priceLabel = formatPrice(summary);
+
+  return (
+    <>
+      {open && <div className={styles.overlay} onClick={onClose} />}
+      <aside
+        className={`${styles.drawer} ${open ? styles.open : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        aria-hidden={open ? 'false' : 'true'}
+      >
+        <div className={styles.inner}>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label="Close panel"
+          >
+            &times;
+          </button>
+          <div className={styles.summary}>
+            <div className={styles.imageWrapper}>
+              {imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt={summary.title || 'Property image'}
+                  referrerPolicy="no-referrer"
+                />
+              ) : (
+                <div className={styles.placeholder}>No image</div>
+              )}
+            </div>
+            <div className={styles.summaryContent}>
+              {transactionLabel && (
+                <span className={styles.transaction}>{transactionLabel}</span>
+              )}
+              <h3 className={styles.summaryTitle}>
+                {summary.title || 'Property details'}
+              </h3>
+              {summary.type && (
+                <p className={styles.summaryType}>{summary.type}</p>
+              )}
+              {priceLabel && <p className={styles.summaryPrice}>{priceLabel}</p>}
+              <ul className={styles.summaryMeta}>
+                {summary.bedrooms != null && (
+                  <li>
+                    <FaBed aria-hidden="true" />
+                    <span>{summary.bedrooms} beds</span>
+                  </li>
+                )}
+                {summary.bathrooms != null && (
+                  <li>
+                    <FaBath aria-hidden="true" />
+                    <span>{summary.bathrooms} baths</span>
+                  </li>
+                )}
+                {summary.receptions != null && (
+                  <li>
+                    <FaCouch aria-hidden="true" />
+                    <span>{summary.receptions} receptions</span>
+                  </li>
+                )}
+              </ul>
+            </div>
+          </div>
+          <div className={styles.content}>
+            <h2 id={headingId} className={styles.title}>
+              {title}
+            </h2>
+            {description && <p className={styles.description}>{description}</p>}
+            <div className={styles.body}>{children}</div>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -97,11 +97,8 @@ export default function Property({ property, recommendations }) {
             </p>
           )}
           <div className={styles.actions}>
-            <OfferDrawer propertyId={property.id} propertyTitle={property.title} />
-            <ViewingForm
-              propertyId={property.id}
-              propertyTitle={property.title}
-            />
+            <OfferDrawer property={property} />
+            <ViewingForm property={property} />
           </div>
         </div>
       </section>

--- a/styles/OfferDrawer.module.css
+++ b/styles/OfferDrawer.module.css
@@ -1,71 +1,125 @@
-.offerButton {
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-secondary);
+.trigger {
+  padding: 0.85rem 1.9rem;
+  background: var(--color-secondary);
   color: var(--color-background);
   border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-}
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
-}
-
-
-.drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 320px;
-  max-width: 100%;
-  height: 100vh;
-  background: var(--color-background);
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
-  transform: translateX(100%);
-  transition: transform 0.3s ease;
-  display: flex;
-  flex-direction: column;
-  padding: var(--spacing-md);
-}
-
-.drawer.open {
-  transform: translateX(0);
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  display: inline-flex;
   align-items: center;
-  margin-bottom: var(--spacing-md);
+  gap: 0.5rem;
 }
 
-.close {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
+.trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+}
+
+.trigger:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+.trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
+  display: grid;
+  gap: var(--spacing-md);
 }
 
-.address {
-  margin-bottom: var(--spacing-sm);
-  font-weight: bold;
+.fieldRow {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+@media (min-width: 640px) {
+  .fieldRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--color-muted-text);
+}
+
+.field input,
+.field select {
+  border-radius: 12px;
+  border: 1px solid var(--color-border-light);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(0, 112, 243, 0.18);
+  outline: none;
 }
 
 .submit {
-  margin-top: var(--spacing-md);
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-secondary);
-  color: var(--color-background);
+  margin-top: var(--spacing-sm);
+  padding: 0.9rem 1rem;
   border: none;
+  border-radius: 999px;
+  background: var(--color-secondary);
+  color: var(--color-background);
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+}
+
+.submit:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.success {
+  color: var(--color-success);
+}
+
+.error {
+  color: var(--color-error);
 }

--- a/styles/PropertyActionDrawer.module.css
+++ b/styles/PropertyActionDrawer.module.css
@@ -1,0 +1,217 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 900;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(480px, 100%);
+  max-width: 100%;
+  background: var(--color-background);
+  box-shadow: -24px 0 40px rgba(15, 23, 42, 0.18);
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+  z-index: 901;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer.open {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.closeButton {
+  position: absolute;
+  top: var(--spacing-sm);
+  right: var(--spacing-sm);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 2;
+}
+
+.closeButton:hover {
+  transform: translateY(-1px);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.summary {
+  background: linear-gradient(135deg, var(--color-primary), #1a1a1a);
+  color: var(--color-background);
+  padding: calc(var(--spacing-lg) + var(--spacing-md)) var(--spacing-lg) var(--spacing-md);
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+@media (min-width: 640px) {
+  .summary {
+    grid-template-columns: 140px 1fr;
+    align-items: center;
+  }
+}
+
+.imageWrapper {
+  width: 120px;
+  height: 120px;
+  border-radius: 18px;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  margin: 0 auto;
+}
+
+.imageWrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+.summaryContent {
+  display: grid;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  .summaryContent {
+    text-align: left;
+  }
+}
+
+.transaction {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.summaryTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.summaryType {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.summaryPrice {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.summaryMeta {
+  list-style: none;
+  padding: 0;
+  margin: var(--spacing-sm) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+
+@media (min-width: 640px) {
+  .summaryMeta {
+    justify-content: flex-start;
+  }
+}
+
+.summaryMeta li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.summaryMeta svg {
+  font-size: 1rem;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-lg);
+  background: var(--color-background);
+}
+
+@media (max-width: 639px) {
+  .content {
+    padding: var(--spacing-lg) var(--spacing-md);
+  }
+}
+
+.title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: 1.75rem;
+  color: var(--color-primary);
+  line-height: 1.2;
+}
+
+.description {
+  margin: 0 0 var(--spacing-lg);
+  color: var(--color-muted-text);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.body {
+  display: block;
+}
+
+.body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.body::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+}

--- a/styles/ViewingForm.module.css
+++ b/styles/ViewingForm.module.css
@@ -1,80 +1,158 @@
-.viewingButton {
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-secondary);
+.trigger {
+  padding: 0.85rem 1.9rem;
+  background: var(--color-secondary);
   color: var(--color-background);
   border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-}
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: 320px;
-  max-width: 100%;
-  height: 100vh;
-  background: var(--color-background);
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
-  transform: translateX(100%);
-  transition: transform 0.3s ease;
-  display: flex;
-  flex-direction: column;
-  padding: var(--spacing-md);
-}
-
-.open {
-  transform: translateX(0);
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  display: inline-flex;
   align-items: center;
-  margin-bottom: var(--spacing-md);
+  gap: 0.5rem;
 }
 
-.close {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
+.trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+}
+
+.trigger:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
 }
 
 .form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
+  display: grid;
+  gap: var(--spacing-md);
 }
 
-.address {
-  font-weight: bold;
-  margin-bottom: var(--spacing-sm);
+.fieldRow {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+@media (min-width: 640px) {
+  .fieldRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--color-muted-text);
+}
+
+.field input,
+.field select,
+.field textarea {
+  border-radius: 12px;
+  border: 1px solid var(--color-border-light);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(0, 112, 243, 0.18);
+  outline: none;
 }
 
 .submit {
-  margin-top: var(--spacing-md);
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-secondary);
-  color: var(--color-background);
+  margin-top: var(--spacing-sm);
+  padding: 0.9rem 1rem;
   border: none;
+  border-radius: 999px;
+  background: var(--color-secondary);
+  color: var(--color-background);
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.success {
-  text-align: center;
-  padding: var(--spacing-md) 0;
+.submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.2);
+}
+
+.submit:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .error {
   color: var(--color-error);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.feedback {
+  background: var(--color-surface);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  text-align: center;
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.feedback h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--color-primary);
+}
+
+.feedback p {
+  margin: 0;
+  color: var(--color-muted-text);
+  line-height: 1.6;
+}
+
+.feedbackButton {
+  justify-self: center;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background: var(--color-secondary);
+  color: var(--color-background);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feedbackButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+}
+
+.feedbackButton:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 4px;
 }


### PR DESCRIPTION
## Summary
- create a shared slide-in PropertyActionDrawer component with property overview styling
- restyle the make-offer and book-viewing forms to use the new drawer design with responsive fields
- wire the property page buttons to pass full listing details into the drawers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca0ce2bfcc832e89296cd3f1eedeaa