### PR TITLE
Format property prices without decimals

### DIFF
--- a/__tests__/format.test.js
+++ b/__tests__/format.test.js
@@ -1,7 +1,8 @@
 let formatRentFrequency;
+let formatPriceGBP;
 
 beforeAll(async () => {
-  ({ formatRentFrequency } = await import('../lib/format.mjs'));
+  ({ formatRentFrequency, formatPriceGBP } = await import('../lib/format.mjs'));
 });
 
 describe('formatRentFrequency', () => {
@@ -18,5 +19,20 @@ describe('formatRentFrequency', () => {
 
   test('returns empty string for falsy input', () => {
     expect(formatRentFrequency()).toBe('');
+  });
+});
+
+describe('formatPriceGBP', () => {
+  test('rounds up to the nearest pound for rent prices', () => {
+    expect(formatPriceGBP('950.10')).toBe('£951');
+  });
+
+  test('adds thousand separators for sale prices', () => {
+    expect(formatPriceGBP('450000.01', { isSale: true })).toBe('£450,001');
+  });
+
+  test('returns empty string for invalid values', () => {
+    expect(formatPriceGBP(null)).toBe('');
+    expect(formatPriceGBP('')).toBe('');
   });
 });

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -3,6 +3,7 @@ import {
   resolvePropertyIdentifier,
   normalizePropertyIdentifierForComparison,
 } from './property-id.mjs';
+import { formatPriceGBP } from './format.mjs';
 
 const API_URL = 'https://api.apex27.co.uk/listings';
 const REGIONS_URL = 'https://api.apex27.co.uk/search-regions';
@@ -466,6 +467,9 @@ export async function fetchPropertiesByType(type, options = {}) {
     const normalizedImages = normalizeImages(p.images || []);
     const trimmedImages =
       typeof maxImages === 'number' ? normalizedImages.slice(0, maxImages) : normalizedImages;
+    const resolvedType = resolveTransactionType(p);
+    const isSale = resolvedType === 'sale' || (!resolvedType && !p.rentFrequency);
+
     acc.push({
       id: String(id),
       agentId:
@@ -481,7 +485,7 @@ export async function fetchPropertiesByType(type, options = {}) {
       price:
         p.price != null
           ? p.priceCurrency === 'GBP'
-            ? `£${p.price}`
+            ? formatPriceGBP(p.price, { isSale })
             : p.price
           : null,
       priceValue: p.price != null ? Number(p.price) : null,

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -8,3 +8,21 @@ export function formatRentFrequency(freq) {
   };
   return map[freq] || freq;
 }
+
+function normalizePriceAmount(value) {
+  if (value == null) return null;
+  const cleaned = String(value).replace(/[^0-9.]/g, '');
+  if (!cleaned) return null;
+  const numeric = Number(cleaned);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.ceil(numeric);
+}
+
+export function formatPriceGBP(value, { isSale = false } = {}) {
+  const amount = normalizePriceAmount(value);
+  if (amount == null) return '';
+  const formattedNumber = isSale
+    ? amount.toLocaleString('en-GB')
+    : String(amount);
+  return `£${formattedNumber}`;
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -20,7 +20,7 @@ import {
 } from '../../lib/property-id.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
-import { formatRentFrequency } from '../../lib/format.mjs';
+import { formatRentFrequency, formatPriceGBP } from '../../lib/format.mjs';
 
 function parsePriceNumber(value) {
   return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
@@ -175,6 +175,7 @@ export async function getStaticProps({ params }) {
   let formatted = null;
   if (rawProperty) {
     const imgList = normalizeImages(rawProperty.images || []);
+    const isSalePrice = rawProperty.rentFrequency == null;
     formatted = {
       id: resolvePropertyIdentifier(rawProperty) ?? String(params.id),
       title:
@@ -186,7 +187,7 @@ export async function getStaticProps({ params }) {
       price:
         rawProperty.price != null
           ? rawProperty.priceCurrency === 'GBP'
-            ? `£${rawProperty.price}`
+            ? formatPriceGBP(rawProperty.price, { isSale: isSalePrice })
             : rawProperty.price
           : null,
       rentFrequency: rawProperty.rentFrequency ?? null,


### PR DESCRIPTION
## Summary
- add a GBP price formatter that rounds amounts up and formats sale prices with grouping
- use the formatter when normalising property data for listings and property detail pages
- extend format unit tests to cover the new price formatting behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0744dc374832e9eb986ec15748f72