### PR TITLE
Adjust property card image sizing

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -52,7 +52,8 @@ body {
 .property-card .image-wrapper {
   position: relative;
   width: 100%;
-  height: 260px;
+  aspect-ratio: 4 / 3;
+  height: auto;
 }
 
 .property-card .property-card-gallery {
@@ -226,7 +227,7 @@ body {
   }
 
   .property-card .image-wrapper {
-    height: 320px;
+    aspect-ratio: 4 / 3;
   }
 }
 
@@ -236,7 +237,8 @@ body {
   }
 
   .property-card .image-wrapper {
-    height: 400px;
+    aspect-ratio: auto;
+    height: 300px;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep property card images responsive on small screens using aspect-ratio sizing
- fix property card image height to 300px on desktop layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d080b488ac832e855ef86f78b354ab