### PR TITLE
Revamp sell experience

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,10 +1,17 @@
 import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import styles from '../styles/Header.module.css';
 
 export default function Header() {
+  const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [landlordOpen, setLandlordOpen] = useState(false);
+
+  const isPathActive = (href) => router.pathname === href;
+  const isSectionActive = (href) =>
+    router.pathname === href || router.pathname.startsWith(`${href}/`);
+  const isLandlordsActive = isSectionActive('/landlords');
 
   const toggleMenu = () => setMenuOpen((prev) => !prev);
   const closeMenu = () => {
@@ -20,7 +27,9 @@ export default function Header() {
     >
       <button
         type="button"
-        className={`${styles.navLink} ${styles.navButton}`}
+        className={`${styles.navLink} ${styles.navButton} ${
+          isLandlordsActive ? styles.active : ''
+        }`}
         onClick={() => setLandlordOpen((prev) => !prev)}
       >
         Landlords
@@ -56,20 +65,55 @@ export default function Header() {
 
   const navLinks = (
     <>
-      <Link href="/for-sale" className={styles.navLink} onClick={closeMenu}>
+      <Link
+        href="/for-sale"
+        className={`${styles.navLink} ${
+          isPathActive('/for-sale') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/for-sale') ? 'page' : undefined}
+      >
         Buy
       </Link>
-      <Link href="/to-rent" className={styles.navLink} onClick={closeMenu}>
+      <Link
+        href="/to-rent"
+        className={`${styles.navLink} ${
+          isPathActive('/to-rent') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/to-rent') ? 'page' : undefined}
+      >
         Rent
       </Link>
-      {landlordMenu}
-      <Link href="/sell" className={styles.navLink} onClick={closeMenu}>
+      <Link
+        href="/sell"
+        className={`${styles.navLink} ${
+          isPathActive('/sell') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/sell') ? 'page' : undefined}
+      >
         Sell
       </Link>
-      <Link href="/discover" className={styles.navLink} onClick={closeMenu}>
-        Discover
+      {landlordMenu}
+      <Link
+        href="/about"
+        className={`${styles.navLink} ${
+          isPathActive('/about') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/about') ? 'page' : undefined}
+      >
+        About
       </Link>
-      <Link href="/contact" className={styles.navLink} onClick={closeMenu}>
+      <Link
+        href="/contact"
+        className={`${styles.navLink} ${
+          isPathActive('/contact') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/contact') ? 'page' : undefined}
+      >
         Contact
       </Link>
     </>

--- a/pages/sell.js
+++ b/pages/sell.js
@@ -1,25 +1,239 @@
-import PropertyList from '../components/PropertyList';
-import { fetchPropertiesByType } from '../lib/apex27.mjs';
-import styles from '../styles/Home.module.css';
+import Link from 'next/link';
+import styles from '../styles/Sell.module.css';
 
-export default function Sell({ properties }) {
+const stats = [
+  {
+    value: '102%',
+    label: 'Average asking price achieved across our network*',
+  },
+  {
+    value: '12,000+',
+    label: 'Verified buyers currently registered with Aktonz',
+  },
+  {
+    value: '9.4/10',
+    label: 'Seller satisfaction score for the last 12 months',
+  },
+];
+
+const reachBullets = [
+  'Your listing appears instantly across aktonz.com and leading portals.',
+  'Dedicated social campaigns promote your property to high-intent buyers.',
+  'Professional photography and floorplans included as standard.',
+];
+
+const controlTiles = [
+  {
+    title: 'Real-time updates',
+    description:
+      'Track enquiries, viewings, offers and feedback in real time with the My Aktonz portal.',
+  },
+  {
+    title: 'Secure document hub',
+    description:
+      'Access valuation reports, compliance documents and key milestones whenever you need them.',
+  },
+  {
+    title: 'Collaborative decisions',
+    description:
+      'Approve marketing, confirm viewings and respond to offers with a single tap on mobile or desktop.',
+  },
+];
+
+const expertCards = [
+  {
+    title: 'Dedicated local valuer',
+    copy:
+      'Your Aktonz expert understands the nuance of your neighbourhood and uses live market data to set the right strategy.',
+  },
+  {
+    title: 'Progression specialists',
+    copy:
+      'Our sales progression team keeps solicitors, buyers and chains aligned so you move on schedule.',
+  },
+  {
+    title: 'In-house marketing studio',
+    copy:
+      'From videography to targeted advertising, our creatives showcase your home at its very best.',
+  },
+];
+
+const testimonials = [
+  {
+    quote:
+      'Aktonz kept us updated every step and negotiated a brilliant result – we exchanged within eight weeks of listing.',
+    author: 'Sophie & Daniel, Clapham',
+  },
+  {
+    quote:
+      'The My Aktonz portal meant no chasing for updates. We could see every viewing request and offer in one place.',
+    author: 'Michael, Shoreditch',
+  },
+];
+
+export default function Sell() {
   return (
-    <main className={styles.main}>
-      <h1>Sell Your Property</h1>
-      <p>Let us help you market your property effectively.</p>
-      <PropertyList properties={properties} />
+    <main className={styles.sellPage}>
+      <section className={`${styles.section} ${styles.hero}`}>
+        <div className={`${styles.constrained} ${styles.heroInner}`}>
+          <div className={styles.heroMedia}>
+            <img
+              src="https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80"
+              alt="Townhouses on a sunny London street"
+              loading="lazy"
+            />
+          </div>
+          <div className={styles.heroContent}>
+            <p className={styles.heroKicker}>Sell with Aktonz</p>
+            <h1 className={styles.heroTitle}>
+              Want to know how Aktonz simplifies the selling process?
+            </h1>
+            <p className={styles.heroDescription}>
+              From strategic pricing advice to dedicated progression support, we combine local expertise
+              with market-leading technology so you can sell with confidence.
+            </p>
+            <div className={styles.ctaGroup}>
+              <Link href="/valuation" className={styles.primaryCta}>
+                Book a valuation
+              </Link>
+              <Link href="/contact" className={styles.secondaryCta}>
+                Request a call back
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.valuationSection}`}>
+        <div className={`${styles.constrained} ${styles.valuationInner}`}>
+          <div>
+            <h2 className={styles.valuationTitle}>
+              Want to know what your property is worth?
+            </h2>
+            <p className={styles.valuationCopy}>
+              Arrange a free, no-obligation valuation with an Aktonz expert. We combine real-time buyer demand
+              data with decades of neighbourhood experience to deliver recommendations tailored to your goals.
+            </p>
+            <div className={styles.ctaGroup}>
+              <Link href="/valuation" className={styles.primaryCta}>
+                Get your valuation
+              </Link>
+              <Link href="/about" className={styles.secondaryCta}>
+                Discover our approach
+              </Link>
+            </div>
+          </div>
+          <div className={styles.statGrid}>
+            {stats.map((item) => (
+              <article key={item.label} className={styles.statCard}>
+                <span className={styles.statValue}>{item.value}</span>
+                <p className={styles.statLabel}>{item.label}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+        <p className={styles.disclaimer}>*Based on Aktonz sales completed between Jan–Dec 2023.</p>
+      </section>
+
+      <section className={styles.section}>
+        <div className={`${styles.constrained} ${styles.twoColumn}`}>
+          <div>
+            <h2 className={styles.sectionTitle}>Reach the right buyers with Aktonz</h2>
+            <p className={styles.sectionLead}>
+              Your property is promoted across our award-winning digital channels the moment it hits the market.
+              We match motivated buyers to your listing through personalised alerts, targeted campaigns and
+              curated viewings.
+            </p>
+            <ul className={styles.checkList}>
+              {reachBullets.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+          <div className={styles.sectionMedia}>
+            <img
+              src="https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80"
+              alt="Aktonz agent capturing marketing photography"
+              loading="lazy"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.constrained}>
+          <div className={styles.twoColumn}>
+            <div className={styles.sectionMedia}>
+              <img
+                src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"
+                alt="Seller reviewing the My Aktonz dashboard on a tablet"
+                loading="lazy"
+              />
+            </div>
+            <div>
+              <h2 className={styles.sectionTitle}>Take control of your sale with My Aktonz</h2>
+              <p className={styles.sectionLead}>
+                Manage your sale from anywhere. Our secure portal keeps you informed and in control, whether
+                you are reviewing feedback or approving the latest marketing assets.
+              </p>
+              <div className={styles.tileGrid}>
+                {controlTiles.map((tile) => (
+                  <article key={tile.title} className={styles.tile}>
+                    <h3>{tile.title}</h3>
+                    <p>{tile.description}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.constrained}>
+          <h2 className={styles.sectionTitle}>Connect with our experts</h2>
+          <p className={styles.sectionLead}>
+            When you instruct Aktonz, you gain a team of specialists focused on every stage of your sale.
+          </p>
+          <div className={styles.expertGrid}>
+            {expertCards.map((card) => (
+              <article key={card.title} className={styles.expertCard}>
+                <h3>{card.title}</h3>
+                <p>{card.copy}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.constrained}>
+          <div className={styles.ctaBand}>
+            <h2>Get a free property valuation with a local expert</h2>
+            <p>
+              Book an appointment in minutes and receive a tailored marketing strategy designed to secure
+              the best possible price.
+            </p>
+            <Link href="/valuation" className={styles.primaryCta}>
+              Book your valuation
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.constrained}>
+          <h2 className={styles.sectionTitle}>Testimonials</h2>
+          <div className={styles.testimonials}>
+            {testimonials.map((item) => (
+              <article key={item.author} className={styles.testimonialCard}>
+                <p className={styles.quote}>{item.quote}</p>
+                <p className={styles.citation}>{item.author}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
     </main>
   );
-}
-
-export async function getStaticProps() {
-  const allSale = await fetchPropertiesByType('sale', {
-    statuses: ['available', 'under_offer', 'sold'],
-  });
-  const allowed = ['available', 'under_offer', 'sold'];
-  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  const properties = allSale.filter(
-    (p) => p.status && allowed.includes(normalize(p.status))
-  );
-  return { props: { properties } };
 }

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -33,6 +33,8 @@
   text-decoration: none;
   color: var(--color-primary);
   font-size: 1rem;
+  position: relative;
+  padding-bottom: var(--spacing-xs);
 }
 
 .navButton {
@@ -41,6 +43,23 @@
   cursor: pointer;
   font: inherit;
   padding: 0;
+  position: relative;
+}
+
+.active {
+  color: #0b6b67;
+  font-weight: 600;
+}
+
+.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 3px;
+  border-radius: 999px;
+  background: #0b6b67;
 }
 
 .dropdown {

--- a/styles/Sell.module.css
+++ b/styles/Sell.module.css
@@ -1,0 +1,395 @@
+.sellPage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+  padding: 0;
+}
+
+.section {
+  padding: var(--spacing-xl) var(--spacing-lg);
+}
+
+.constrained {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero {
+  background: linear-gradient(135deg, #f3f7f9 0%, #ffffff 65%);
+  padding-top: calc(var(--spacing-xl) * 1.2);
+}
+
+.heroInner {
+  display: grid;
+  gap: var(--spacing-xl);
+  align-items: center;
+}
+
+.heroMedia {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
+  min-height: 260px;
+}
+
+.heroMedia img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.heroContent {
+  max-width: 520px;
+}
+
+.heroKicker {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: #0b6b67;
+  margin-bottom: var(--spacing-sm);
+  font-weight: 600;
+}
+
+.heroTitle {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 var(--spacing-md);
+  line-height: 1.1;
+}
+
+.heroDescription {
+  color: var(--color-muted-text);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin-bottom: var(--spacing-lg);
+}
+
+.ctaGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryCta {
+  background: #0b6b67;
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(11, 107, 103, 0.25);
+}
+
+.primaryCta:hover,
+.primaryCta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(11, 107, 103, 0.3);
+}
+
+.secondaryCta {
+  background: #e5f4f3;
+  color: #0b6b67;
+  border: 1px solid rgba(11, 107, 103, 0.25);
+}
+
+.secondaryCta:hover,
+.secondaryCta:focus-visible {
+  transform: translateY(-1px);
+  border-color: #0b6b67;
+}
+
+.valuationSection {
+  background: #005c59;
+  color: #ffffff;
+  text-align: center;
+}
+
+.valuationInner {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.valuationTitle {
+  font-size: clamp(1.8rem, 3.5vw, 2.4rem);
+  margin: 0;
+}
+
+.valuationCopy {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0 auto;
+  max-width: 700px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.statGrid {
+  display: grid;
+  gap: var(--spacing-lg);
+  justify-content: center;
+}
+
+.statCard {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  min-width: 220px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.15);
+}
+
+.statValue {
+  display: block;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: var(--spacing-sm);
+}
+
+.statLabel {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.sectionTitle {
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+  margin-bottom: var(--spacing-md);
+}
+
+.sectionLead {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-muted-text);
+  max-width: 680px;
+  margin-bottom: var(--spacing-lg);
+}
+
+.twoColumn {
+  display: grid;
+  gap: var(--spacing-xl);
+  align-items: center;
+}
+
+.sectionMedia {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.12);
+  min-height: 220px;
+}
+
+.sectionMedia img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.checkList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.checkList li {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--color-muted-text);
+}
+
+.checkList li::before {
+  content: '\2713';
+  font-weight: 700;
+  color: #0b6b67;
+  margin-top: 0.1rem;
+}
+
+.tileGrid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.tile {
+  background: var(--color-surface);
+  border-radius: 16px;
+  padding: var(--spacing-lg);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+}
+
+.tile h3 {
+  margin-top: 0;
+  margin-bottom: var(--spacing-sm);
+  font-size: 1.3rem;
+}
+
+.tile p {
+  margin: 0;
+  color: var(--color-muted-text);
+  line-height: 1.6;
+}
+
+.expertGrid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.expertCard {
+  background: #0f7f7a;
+  color: #ffffff;
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  box-shadow: 0 18px 36px rgba(15, 127, 122, 0.25);
+}
+
+.expertCard h3 {
+  margin: 0 0 var(--spacing-sm);
+}
+
+.expertCard p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.6;
+}
+
+.ctaBand {
+  background: linear-gradient(120deg, #0f7f7a 0%, #0b6b67 100%);
+  color: #ffffff;
+  text-align: center;
+  border-radius: 24px;
+  padding: calc(var(--spacing-xl) * 0.8) var(--spacing-lg);
+  box-shadow: 0 20px 40px rgba(11, 107, 103, 0.25);
+}
+
+.ctaBand h2 {
+  margin: 0 0 var(--spacing-sm);
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.ctaBand p {
+  margin: 0 0 var(--spacing-lg);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.05rem;
+}
+
+.ctaBand .primaryCta {
+  box-shadow: none;
+}
+
+.testimonials {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.testimonialCard {
+  background: var(--color-background);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--color-border-light);
+}
+
+.quote {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin: 0 0 var(--spacing-md);
+  font-style: italic;
+}
+
+.quote::before,
+.quote::after {
+  color: #0b6b67;
+  font-weight: 700;
+}
+
+.quote::before {
+  content: '\201C';
+  margin-right: 0.2rem;
+}
+
+.quote::after {
+  content: '\201D';
+  margin-left: 0.2rem;
+}
+
+.citation {
+  font-weight: 600;
+  color: var(--color-muted-text);
+}
+
+.disclaimer {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: calc(var(--spacing-md) * 0.5);
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .heroInner,
+  .valuationInner,
+  .tileGrid,
+  .expertGrid,
+  .testimonials {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .twoColumn {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .heroInner {
+    grid-template-columns: 1.2fr 1fr;
+  }
+
+  .tileGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .expertGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .testimonials {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .section {
+    padding: var(--spacing-lg);
+  }
+
+  .hero {
+    padding-top: var(--spacing-xl);
+  }
+
+  .heroContent {
+    max-width: none;
+  }
+
+  .primaryCta,
+  .secondaryCta {
+    width: 100%;
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- overhaul the Sell landing page with marketing-focused content, imagery, testimonials, and calls-to-action that mirror the provided reference
- introduce a dedicated Sell page stylesheet to support the new responsive layout and styling accents
- highlight active navigation items (including Sell) and update the main menu to match the requested structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08e05c6e4832e99ce873f685b4996