### PR TITLE
Create styled Sell dropdown navigation menu

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -6,18 +6,64 @@ import styles from '../styles/Header.module.css';
 export default function Header() {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [sellOpen, setSellOpen] = useState(false);
   const [landlordOpen, setLandlordOpen] = useState(false);
 
   const isPathActive = (href) => router.pathname === href;
   const isSectionActive = (href) =>
     router.pathname === href || router.pathname.startsWith(`${href}/`);
+  const isSellActive = isSectionActive('/sell');
   const isLandlordsActive = isSectionActive('/landlords');
 
   const toggleMenu = () => setMenuOpen((prev) => !prev);
   const closeMenu = () => {
     setMenuOpen(false);
+    setSellOpen(false);
     setLandlordOpen(false);
   };
+
+  const sellMenu = (
+    <div
+      className={styles.dropdown}
+      onMouseEnter={() => setSellOpen(true)}
+      onMouseLeave={() => setSellOpen(false)}
+    >
+      <button
+        type="button"
+        className={`${styles.navLink} ${styles.navButton} ${
+          isSellActive ? styles.active : ''
+        }`}
+        onClick={() => setSellOpen((prev) => !prev)}
+        aria-haspopup="true"
+        aria-expanded={sellOpen}
+        aria-current={isSellActive ? 'page' : undefined}
+      >
+        Sell
+      </button>
+      <div
+        className={`${styles.dropdownMenu} ${styles.sellDropdownMenu} ${
+          sellOpen ? styles.show : ''
+        }`}
+      >
+        <Link href="/valuation" onClick={closeMenu}>
+          Get a valuation
+        </Link>
+        <Link href="/sell" onClick={closeMenu}>
+          Sell your home
+        </Link>
+        <Link href="/sell#auctions" onClick={closeMenu}>
+          Auctions
+        </Link>
+        <Link
+          href="/sell#seller-help"
+          className={`${styles.arrow} ${styles.sellArrow}`}
+          onClick={closeMenu}
+        >
+          Help for sellers
+        </Link>
+      </div>
+    </div>
+  );
 
   const landlordMenu = (
     <div
@@ -31,6 +77,9 @@ export default function Header() {
           isLandlordsActive ? styles.active : ''
         }`}
         onClick={() => setLandlordOpen((prev) => !prev)}
+        aria-haspopup="true"
+        aria-expanded={landlordOpen}
+        aria-current={isLandlordsActive ? 'page' : undefined}
       >
         Landlords
       </button>
@@ -85,16 +134,7 @@ export default function Header() {
       >
         Rent
       </Link>
-      <Link
-        href="/sell"
-        className={`${styles.navLink} ${
-          isPathActive('/sell') ? styles.active : ''
-        }`}
-        onClick={closeMenu}
-        aria-current={isPathActive('/sell') ? 'page' : undefined}
-      >
-        Sell
-      </Link>
+      {sellMenu}
       {landlordMenu}
       <Link
         href="/about"

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -89,6 +89,29 @@
   text-decoration: underline;
 }
 
+.sellDropdownMenu {
+  background: var(--color-surface-alt);
+  border: none;
+  box-shadow: none;
+  border-radius: 12px;
+  padding: var(--spacing-lg);
+  min-width: 220px;
+  gap: var(--spacing-md);
+}
+
+.sellDropdownMenu a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  text-decoration: none;
+  color: var(--color-primary);
+}
+
+.sellDropdownMenu a:hover {
+  text-decoration: none;
+}
+
 .show {
   display: flex;
 }
@@ -96,6 +119,11 @@
 .arrow::after {
   content: '\203A';
   margin-left: var(--spacing-sm);
+}
+
+.sellArrow::after {
+  font-size: 1.25rem;
+  color: var(--color-muted-text);
 }
 
 .actions {
@@ -181,6 +209,16 @@
   border: none;
   box-shadow: none;
   padding: 0 0 0 var(--spacing-lg);
+}
+
+.mobileMenu .sellDropdownMenu {
+  background: none;
+  border-radius: 0;
+  gap: var(--spacing-sm);
+}
+
+.mobileMenu .sellDropdownMenu a {
+  justify-content: flex-start;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- add a Sell dropdown to the header navigation with the requested submenu items
- style the Sell submenu with a soft background, spacing, and arrow indicator to match the provided design
- improve dropdown accessibility with aria attributes for Sell and Landlords toggles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d09182ba88832e86d0dfbcc2af0c57