### PR TITLE
Add careers page inspired by Foxtons

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -147,6 +147,16 @@ export default function Header() {
         About
       </Link>
       <Link
+        href="/jobs"
+        className={`${styles.navLink} ${
+          isPathActive('/jobs') ? styles.active : ''
+        }`}
+        onClick={closeMenu}
+        aria-current={isPathActive('/jobs') ? 'page' : undefined}
+      >
+        Careers
+      </Link>
+      <Link
         href="/contact"
         className={`${styles.navLink} ${
           isPathActive('/contact') ? styles.active : ''

--- a/pages/jobs.js
+++ b/pages/jobs.js
@@ -1,0 +1,369 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import styles from '../styles/Careers.module.css';
+
+const highlights = [
+  {
+    value: '60+',
+    label: 'Neighbourhood specialists supporting buyers, sellers and renters across London.',
+  },
+  {
+    value: '94%',
+    label: 'Of our people say they receive actionable coaching every single week.',
+  },
+  {
+    value: '24/7',
+    label: 'Digital tools and data science helping you deliver standout customer service.',
+  },
+];
+
+const values = [
+  {
+    title: 'Learn fast, stay curious',
+    description:
+      'Structured academies, weekly masterclasses and personal mentors accelerate your growth from day one.',
+  },
+  {
+    title: 'Bring the energy',
+    description:
+      'We are bold, ambitious and collaborative. We celebrate big wins and rally together when the market shifts.',
+  },
+  {
+    title: 'Own every customer moment',
+    description:
+      'Aktonz teams blend best-in-class tech with real relationships so every client feels championed.',
+  },
+];
+
+const teams = [
+  {
+    name: 'Sales & Lettings',
+    description:
+      'Lead negotiations, source instructions and guide clients with confidence backed by real-time market intelligence.',
+    vacancies: 14,
+    focus: 'Progress from Associate to Senior Negotiator in as little as 18 months.',
+  },
+  {
+    name: 'Property Management',
+    description:
+      'Create wow moments for landlords and residents while handling compliance, maintenance and renewals flawlessly.',
+    vacancies: 9,
+    focus: 'Be supported by specialist legal and repairs teams so you can focus on people.',
+  },
+  {
+    name: 'New Business & Marketing',
+    description:
+      'Shape the Aktonz brand, deliver campaigns that convert, and unlock partnerships across London.',
+    vacancies: 5,
+    focus: 'Cross-functional squads give you ownership from concept to launch.',
+  },
+  {
+    name: 'Operations & Data',
+    description:
+      'Optimise our platform, design smart processes and keep our offices and tech performing at pace.',
+    vacancies: 4,
+    focus: 'Experiment with automation and analytics that power thousands of transactions.',
+  },
+  {
+    name: 'Customer Experience',
+    description:
+      'Be the reassuring voice guiding movers through valuations, offers, referencing and move-in day.',
+    vacancies: 7,
+    focus: 'Hybrid teams offer flexible scheduling with premium customer tooling.',
+  },
+  {
+    name: 'Graduates & Interns',
+    description:
+      'Kick-start your property career with rotational placements, mentors and leadership exposure.',
+    vacancies: 12,
+    focus: 'Fast-track programmes include ARLA and RICS accreditation support.',
+  },
+];
+
+const vacancies = [
+  {
+    title: 'Senior Sales Negotiator',
+    location: 'Canary Wharf',
+    type: 'Full-time',
+    closing: 'Applications close 8 November 2024',
+    email: 'talent@aktonz.co.uk',
+  },
+  {
+    title: 'Property Manager',
+    location: 'Shoreditch',
+    type: 'Hybrid',
+    closing: 'Interviews ongoing — apply today',
+    email: 'talent@aktonz.co.uk',
+  },
+  {
+    title: 'Lettings Associate (Graduate)',
+    location: 'South Kensington',
+    type: 'Full-time',
+    closing: 'January 2025 intake',
+    email: 'graduates@aktonz.co.uk',
+  },
+  {
+    title: 'Customer Experience Partner',
+    location: 'Chiswick Support Centre',
+    type: 'Flexible shifts',
+    closing: 'Closes 22 November 2024',
+    email: 'talent@aktonz.co.uk',
+  },
+  {
+    title: 'Marketing Campaign Manager',
+    location: 'London Bridge',
+    type: 'Hybrid',
+    closing: 'Closes 29 November 2024',
+    email: 'talent@aktonz.co.uk',
+  },
+  {
+    title: 'Technology Delivery Lead',
+    location: 'Remote-first, London hub',
+    type: 'Full-time',
+    closing: 'Closes 15 December 2024',
+    email: 'talent@aktonz.co.uk',
+  },
+];
+
+const benefits = [
+  'Uncapped commission structure with quarterly accelerators and recognition trips.',
+  'Private medical cover, wellbeing allowance and access to mental health first aiders.',
+  'Industry qualifications paid for — ARLA, CeMAP, NFoPP and leadership coaching.',
+  'Electric company car scheme, cycle to work and travel season ticket loans.',
+  'Recharge days, enhanced parental leave and support for returning to work.',
+  'Volunteering days to back the communities we serve across London.',
+];
+
+const process = [
+  {
+    title: 'Apply in minutes',
+    description: 'Share your CV or LinkedIn profile — no cover letter needed. We review every application personally.',
+  },
+  {
+    title: 'Chat with Talent',
+    description: 'A 20-minute call to understand your ambitions, strengths and what makes you unstoppable.',
+  },
+  {
+    title: 'Show us your impact',
+    description: 'Role-specific interview and a practical scenario so you can demonstrate how you deliver for customers.',
+  },
+  {
+    title: 'Meet the team',
+    description: 'Spend time in branch or at HQ to feel the pace, meet future teammates and ask anything.',
+  },
+];
+
+const testimonials = [
+  {
+    quote:
+      'I joined as a lettings associate and now lead a sales team. The pace is intense but the coaching and data at our fingertips make every day exciting.',
+    name: 'Safiya Mensah',
+    role: 'Sales Manager, East London',
+  },
+  {
+    quote:
+      'Aktonz backed me through my ARLA exams and gave me the confidence to own a portfolio of 400 homes. You are trusted quickly here.',
+    name: 'Luca Romano',
+    role: 'Senior Property Manager',
+  },
+];
+
+export default function Careers() {
+  return (
+    <>
+      <Head>
+        <title>Careers at Aktonz</title>
+        <meta
+          name="description"
+          content="Explore careers at Aktonz. Join ambitious teams redefining the London property experience with data-led service and unstoppable energy."
+        />
+      </Head>
+      <main className={styles.careers}>
+        <section className={styles.hero}>
+          <div className={styles.heroContent}>
+            <span className={styles.heroKicker}>Careers</span>
+            <h1 className={styles.heroTitle}>Make it with us</h1>
+            <p className={styles.heroSubtitle}>
+              We have a reputation for nurturing driven, ambitious professionals. Bring the hunger to succeed and we will match it
+              with world-class coaching, technology and a network that opens doors all across London.
+            </p>
+            <div className={styles.heroActions}>
+              <Link href="#vacancies" className={`${styles.button} ${styles.primaryButton}`}>
+                View open roles
+              </Link>
+              <Link href="/register" className={`${styles.button} ${styles.secondaryButton}`}>
+                Join our talent network
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.highlightStrip} aria-label="Aktonz career highlights">
+          {highlights.map((item) => (
+            <div className={styles.highlight} key={item.label}>
+              <span className={styles.highlightValue}>{item.value}</span>
+              <span className={styles.highlightLabel}>{item.label}</span>
+            </div>
+          ))}
+        </section>
+
+        <section className={styles.section} aria-labelledby="careers-intro">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-intro" className={styles.sectionTitle}>
+              A growth mindset from day one
+            </h2>
+            <p className={styles.sectionIntro}>
+              A career with Aktonz is for people who love the buzz of London property, thrive on accountability and want to see
+              their effort rewarded. We combine in-branch expertise with a digital backbone so you can focus on relationships while
+              the platform handles the rest.
+            </p>
+          </div>
+          <div className={styles.valuesGrid}>
+            {values.map((value) => (
+              <article className={styles.valueCard} key={value.title}>
+                <h3 className={styles.valueHeading}>{value.title}</h3>
+                <p className={styles.valueText}>{value.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section} id="teams" aria-labelledby="careers-teams">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-teams" className={styles.sectionTitle}>
+              Getting it done: Our teams
+            </h2>
+            <p className={styles.sectionIntro}>
+              Choose the path that matches your strengths. Wherever you start, clear progression routes, transparent goals and a
+              supportive leadership team keep you moving forward.
+            </p>
+          </div>
+          <div className={styles.teamsGrid}>
+            {teams.map((team) => (
+              <article className={styles.teamCard} key={team.name}>
+                <div className={styles.teamMeta}>
+                  <h3 className={styles.teamTitle}>{team.name}</h3>
+                  <span className={styles.teamVacancies}>{team.vacancies} vacancies</span>
+                </div>
+                <p className={styles.teamDescription}>{team.description}</p>
+                <p className={styles.teamDescription}>{team.focus}</p>
+                <Link href="#vacancies" className={styles.teamLink}>
+                  See current roles
+                </Link>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section} id="vacancies" aria-labelledby="careers-vacancies">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-vacancies" className={styles.sectionTitle}>
+              Latest vacancies
+            </h2>
+            <p className={styles.sectionIntro}>
+              We recruit on a rolling basis. If you cannot see the perfect role, send us your details and we will reach out when
+              the right opportunity lands.
+            </p>
+          </div>
+          <div className={styles.vacanciesGrid}>
+            {vacancies.map((vacancy) => (
+              <article className={styles.vacancyCard} key={vacancy.title}>
+                <h3 className={styles.vacancyTitle}>{vacancy.title}</h3>
+                <div className={styles.vacancyMeta}>
+                  <span>{vacancy.location}</span>
+                  <span>{vacancy.type}</span>
+                  <span>{vacancy.closing}</span>
+                </div>
+                <div className={styles.vacancyAction}>
+                  <a
+                    className={`${styles.button} ${styles.secondaryButton}`}
+                    href={`mailto:${vacancy.email}?subject=${encodeURIComponent(`Application: ${vacancy.title}`)}`}
+                  >
+                    Apply now
+                  </a>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section} aria-labelledby="careers-benefits">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-benefits" className={styles.sectionTitle}>
+              Benefits that back your ambition
+            </h2>
+            <p className={styles.sectionIntro}>
+              Being unstoppable takes energy. From wellbeing to recognition, we invest in what keeps you performing at your best.
+            </p>
+          </div>
+          <ul className={styles.benefitsList}>
+            {benefits.map((benefit) => (
+              <li className={styles.benefitItem} key={benefit}>
+                {benefit}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className={styles.section} aria-labelledby="careers-process">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-process" className={styles.sectionTitle}>
+              The Aktonz hiring experience
+            </h2>
+            <p className={styles.sectionIntro}>
+              We keep things transparent, timely and human. Expect honest feedback at every step.
+            </p>
+          </div>
+          <div className={styles.processSteps}>
+            {process.map((step) => (
+              <article className={styles.step} key={step.title}>
+                <h3 className={styles.stepHeading}>{step.title}</h3>
+                <p className={styles.stepText}>{step.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section} aria-labelledby="careers-voices">
+          <div className={styles.sectionHeader}>
+            <h2 id="careers-voices" className={styles.sectionTitle}>
+              Voices from the team
+            </h2>
+            <p className={styles.sectionIntro}>
+              Real stories from people who chose Aktonz and now shape the future of London property with us.
+            </p>
+          </div>
+          <div className={styles.testimonialsGrid}>
+            {testimonials.map((testimonial) => (
+              <figure className={styles.testimonial} key={testimonial.name}>
+                <blockquote className={styles.testimonialQuote}>{testimonial.quote}</blockquote>
+                <figcaption>
+                  <p className={styles.testimonialName}>{testimonial.name}</p>
+                  <p className={styles.testimonialRole}>{testimonial.role}</p>
+                </figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.ctaSection} aria-labelledby="careers-cta">
+          <h2 id="careers-cta" className={styles.ctaTitle}>
+            Ready to get it done with Aktonz?
+          </h2>
+          <p className={styles.ctaText}>
+            Email talent@aktonz.co.uk or call 0200 123 4000 for a confidential chat. Tell us where you want to go — we will help
+            you get there.
+          </p>
+          <div className={styles.ctaActions}>
+            <a className={`${styles.button} ${styles.primaryButton}`} href="mailto:talent@aktonz.co.uk">
+              Send your CV
+            </a>
+            <Link href="/contact" className={`${styles.button} ${styles.secondaryButton}`}>
+              Talk to our talent team
+            </Link>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/styles/Careers.module.css
+++ b/styles/Careers.module.css
@@ -1,0 +1,448 @@
+.careers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--spacing-sm) calc(var(--spacing-xl) * 1.5);
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #0b6b67 0%, #022d2a 100%);
+  color: var(--color-background);
+  padding: calc(var(--spacing-xl) * 1.4) var(--spacing-lg);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 229, 0, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(0, 176, 155, 0.35), transparent 55%);
+  pointer-events: none;
+}
+
+.heroContent {
+  position: relative;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.heroKicker {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.heroTitle {
+  font-size: 2.4rem;
+  margin: 0;
+  line-height: 1.1;
+}
+
+.heroSubtitle {
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.heroActions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm) calc(var(--spacing-md) * 1.5);
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton {
+  background: var(--color-accent);
+  color: var(--color-text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.primaryButton:hover,
+.primaryButton:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
+}
+
+.secondaryButton {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: var(--color-background);
+  background: transparent;
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--color-background);
+}
+
+.highlightStrip {
+  display: grid;
+  gap: var(--spacing-md);
+  background: var(--color-surface-dark);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+}
+
+.highlight {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  text-align: left;
+}
+
+.highlightValue {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0b6b67;
+}
+
+.highlightLabel {
+  color: var(--color-muted-text);
+  font-size: 0.95rem;
+}
+
+.section {
+  background: var(--color-background);
+  border-radius: 18px;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.05);
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.sectionIntro {
+  color: var(--color-muted-text);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.valuesGrid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.valueCard {
+  padding: var(--spacing-lg);
+  border-radius: 16px;
+  background: var(--color-surface-dark);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.valueHeading {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.valueText {
+  margin: 0;
+  color: var(--color-muted-text);
+  line-height: 1.5;
+}
+
+.teamsGrid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.teamCard {
+  background: var(--color-surface);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  border: 1px solid var(--color-border-light);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.teamCard:hover,
+.teamCard:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.08);
+}
+
+.teamMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  color: var(--color-muted-text);
+}
+
+.teamTitle {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.teamDescription {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--color-muted-text);
+}
+
+.teamVacancies {
+  font-weight: 600;
+  color: #0b6b67;
+}
+
+.teamLink {
+  align-self: flex-start;
+  margin-top: var(--spacing-sm);
+  font-weight: 600;
+  color: #0b6b67;
+  text-decoration: none;
+}
+
+.teamLink:hover,
+.teamLink:focus-visible {
+  text-decoration: underline;
+}
+
+.vacanciesGrid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.vacancyCard {
+  border: 1px solid var(--color-border-light);
+  border-radius: 16px;
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.vacancyTitle {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.vacancyMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  color: var(--color-muted-text);
+  font-size: 0.95rem;
+}
+
+.vacancyAction {
+  align-self: flex-start;
+}
+
+.benefitsList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.benefitItem {
+  background: var(--color-surface);
+  border-radius: 16px;
+  padding: var(--spacing-lg);
+  border: 1px solid var(--color-border-light);
+  line-height: 1.5;
+}
+
+.processSteps {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.step {
+  border-left: 4px solid #0b6b67;
+  padding: var(--spacing-md);
+  background: var(--color-surface);
+  border-radius: 12px;
+}
+
+.stepHeading {
+  margin: 0 0 var(--spacing-xs) 0;
+  font-weight: 600;
+}
+
+.stepText {
+  margin: 0;
+  color: var(--color-muted-text);
+  line-height: 1.5;
+}
+
+.testimonialsGrid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.testimonial {
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+  border-radius: 18px;
+  border: 1px solid var(--color-border-light);
+  position: relative;
+}
+
+.testimonialQuote {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.testimonialName {
+  margin-top: var(--spacing-md);
+  font-weight: 600;
+}
+
+.testimonialRole {
+  color: var(--color-muted-text);
+  font-size: 0.95rem;
+}
+
+.ctaSection {
+  background: linear-gradient(135deg, #ffe500, #ffd100);
+  border-radius: 20px;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  text-align: center;
+}
+
+.ctaTitle {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.ctaText {
+  margin: 0;
+  color: var(--color-muted-text);
+  font-size: 1.05rem;
+}
+
+.ctaActions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+
+@media (min-width: 600px) {
+  .heroTitle {
+    font-size: 3rem;
+  }
+
+  .heroActions {
+    flex-direction: row;
+  }
+
+  .highlightStrip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .valuesGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .teamsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .vacanciesGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .benefitsList {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .processSteps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .testimonialsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ctaSection {
+    text-align: left;
+  }
+
+  .ctaActions {
+    flex-direction: row;
+  }
+}
+
+@media (min-width: 992px) {
+  .careers {
+    padding: calc(var(--spacing-xl) * 1.2) var(--spacing-lg) calc(var(--spacing-xl) * 2);
+  }
+
+  .hero {
+    padding: calc(var(--spacing-xl) * 1.6) calc(var(--spacing-xl) * 1.4);
+  }
+
+  .highlightStrip {
+    gap: calc(var(--spacing-lg));
+  }
+
+  .teamsGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .vacanciesGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .benefitsList {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .processSteps {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .teamCard {
+    transition: none;
+  }
+
+  .teamCard:hover,
+  .teamCard:focus-within {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- create a rich careers experience at `/jobs` with hero messaging, team highlights, live vacancy cards, benefits, hiring process and testimonials inspired by Foxtons
- add a dedicated `Careers.module.css` with responsive layouts, accent styling and CTA treatments to match the new page
- expose the new careers destination in the global header navigation for quick access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0b6459ad8832eb36ea2162330dc9d