### PR TITLE
Revamp to-rent experience with lettings layout

### DIFF
--- a/components/ListingFilters.js
+++ b/components/ListingFilters.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import styles from '../styles/ListingFilters.module.css';
 
-const PRICE_OPTIONS = [
+const DEFAULT_MIN_PRICE_OPTIONS = [
   { label: 'No minimum', value: '' },
   { label: '£100,000', value: '100000' },
   { label: '£250,000', value: '250000' },
@@ -12,7 +12,7 @@ const PRICE_OPTIONS = [
   { label: '£1,500,000', value: '1500000' },
 ];
 
-const MAX_PRICE_OPTIONS = [
+const DEFAULT_MAX_PRICE_OPTIONS = [
   { label: 'No maximum', value: '' },
   { label: '£350,000', value: '350000' },
   { label: '£500,000', value: '500000' },
@@ -22,7 +22,7 @@ const MAX_PRICE_OPTIONS = [
   { label: '£2,000,000', value: '2000000' },
 ];
 
-const BEDROOM_OPTIONS = [
+const DEFAULT_BEDROOM_OPTIONS = [
   { label: 'Any beds', value: '' },
   { label: '1+', value: '1' },
   { label: '2+', value: '2' },
@@ -58,6 +58,19 @@ export default function ListingFilters({
   sortOrder = 'recommended',
   onSortChange,
   propertyTypes,
+  priceOptions = DEFAULT_MIN_PRICE_OPTIONS,
+  maxPriceOptions = DEFAULT_MAX_PRICE_OPTIONS,
+  bedroomOptions = DEFAULT_BEDROOM_OPTIONS,
+  resultNoun = 'home',
+  resultPluralNoun = 'homes',
+  submitLabel = 'Show homes',
+  searchPlaceholder = 'e.g. Canary Wharf, garden',
+  sortLabel = 'Sort by',
+  searchLabel = 'Search location or keyword',
+  minPriceLabel = 'Min price',
+  maxPriceLabel = 'Max price',
+  bedroomsLabel = 'Bedrooms',
+  propertyTypeLabel = 'Property type',
 }) {
   const [formState, setFormState] = useState(() => ({
     search: initialFilters?.search ?? '',
@@ -114,10 +127,10 @@ export default function ListingFilters({
       <div className={styles.headerRow}>
         <p className={styles.resultCount}>
           <strong>{totalResults}</strong>{' '}
-          {totalResults === 1 ? 'home' : 'homes'} available
+          {totalResults === 1 ? resultNoun : resultPluralNoun} available
         </p>
         <label className={styles.sortControl}>
-          <span>Sort by</span>
+          <span>{sortLabel}</span>
           <select
             name="sortOrder"
             value={sortOrder}
@@ -134,20 +147,20 @@ export default function ListingFilters({
 
       <div className={styles.controls}>
         <label className={styles.control}>
-          <span>Search location or keyword</span>
+          <span>{searchLabel}</span>
           <input
             type="search"
             name="search"
-            placeholder="e.g. Canary Wharf, garden"
+            placeholder={searchPlaceholder}
             value={formState.search}
             onChange={handleChange}
           />
         </label>
 
         <label className={styles.control}>
-          <span>Min price</span>
+          <span>{minPriceLabel}</span>
           <select name="minPrice" value={formState.minPrice} onChange={handleChange}>
-            {PRICE_OPTIONS.map((option) => (
+            {priceOptions.map((option) => (
               <option key={option.label} value={option.value}>
                 {option.label}
               </option>
@@ -156,9 +169,9 @@ export default function ListingFilters({
         </label>
 
         <label className={styles.control}>
-          <span>Max price</span>
+          <span>{maxPriceLabel}</span>
           <select name="maxPrice" value={formState.maxPrice} onChange={handleChange}>
-            {MAX_PRICE_OPTIONS.map((option) => (
+            {maxPriceOptions.map((option) => (
               <option key={option.label} value={option.value}>
                 {option.label}
               </option>
@@ -167,9 +180,9 @@ export default function ListingFilters({
         </label>
 
         <label className={styles.control}>
-          <span>Bedrooms</span>
+          <span>{bedroomsLabel}</span>
           <select name="bedrooms" value={formState.bedrooms} onChange={handleChange}>
-            {BEDROOM_OPTIONS.map((option) => (
+            {bedroomOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -178,7 +191,7 @@ export default function ListingFilters({
         </label>
 
         <label className={styles.control}>
-          <span>Property type</span>
+          <span>{propertyTypeLabel}</span>
           <select
             name="propertyType"
             value={formState.propertyType}
@@ -195,7 +208,7 @@ export default function ListingFilters({
 
       <div className={styles.actions}>
         <button type="submit" className={styles.applyButton}>
-          Show homes
+          {submitLabel}
         </button>
         <button type="button" className={styles.resetButton} onClick={handleReset}>
           Reset filters

--- a/components/ListingInsights.js
+++ b/components/ListingInsights.js
@@ -10,41 +10,79 @@ function formatLabel(value) {
     .join(' ');
 }
 
-export default function ListingInsights({ stats, searchTerm }) {
+export default function ListingInsights({ stats, searchTerm, variant = 'sale' }) {
   if (!stats) return null;
 
   const { averagePrice, medianPrice, propertyTypes, topAreas, averageBedrooms } = stats;
 
+  const isRent = variant === 'rent';
+
+  const headingText = isRent
+    ? `Market insights ${searchTerm ? `for “${searchTerm}” rentals` : 'for our lettings portfolio'}`
+    : `Market insights ${searchTerm ? `for “${searchTerm}”` : 'for our sales portfolio'}`;
+
+  const introText = isRent
+    ? 'See how our rental homes perform across price brackets, property styles and the areas tenants ask for most.'
+    : 'Understand how our listings compare across price points, property styles and the neighbourhoods buyers are looking at right now.';
+
+  const averagePriceLabel = isRent
+    ? averagePrice
+      ? `${formatPriceGBP(averagePrice)} pcm`
+      : '—'
+    : averagePrice
+    ? formatPriceGBP(averagePrice, { isSale: true })
+    : '—';
+
+  const medianPriceLabel = isRent
+    ? medianPrice
+      ? `Median: ${formatPriceGBP(medianPrice)} pcm`
+      : 'Median rent unavailable'
+    : medianPrice
+    ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })}`
+    : 'Median price unavailable';
+
+  const averagePriceTitle = isRent ? 'Typical monthly rent' : 'Typical sale price';
+  const averagePriceMeta = isRent
+    ? 'Average asking rent across available homes.'
+    : 'Average asking price across available homes.';
+
+  const bedroomsTitle = isRent ? 'Space renters expect' : 'Space buyers expect';
+  const bedroomsMeta = isRent
+    ? 'Average bedroom count across current rentals.'
+    : 'Average bedroom count across current listings.';
+
+  const propertyTitle = isRent
+    ? 'Most requested rental styles'
+    : 'Most requested property styles';
+
+  const areaTitle = isRent ? 'Where tenants want to live' : 'In-demand neighbourhoods';
+  const areaEmpty = isRent
+    ? 'We’ll update this as more renters enquire.'
+    : 'We’ll update this as more buyers enquire.';
+
   return (
     <section className={styles.insights}>
       <div className={styles.heading}>
-        <h2>Market insights {searchTerm ? `for “${searchTerm}”` : 'for our sales portfolio'}</h2>
-        <p>
-          Understand how our listings compare across price points, property styles and the
-          neighbourhoods buyers are looking at right now.
-        </p>
+        <h2>{headingText}</h2>
+        <p>{introText}</p>
       </div>
 
       <div className={styles.grid}>
         <article className={styles.card}>
-          <h3>Typical sale price</h3>
-          <p className={styles.figure}>{averagePrice ? formatPriceGBP(averagePrice, { isSale: true }) : '—'}</p>
-          <p className={styles.meta}>Average asking price across available homes.</p>
-          <p className={styles.subFigure}>
-            {medianPrice
-              ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })}`
-              : 'Median price unavailable'}
-          </p>
+          <h3>{averagePriceTitle}</h3>
+          <p className={styles.figure}>{averagePriceLabel}</p>
+          <p className={styles.meta}>{averagePriceMeta}</p>
+          <p className={styles.subFigure}>{medianPriceLabel}</p>
         </article>
 
         <article className={styles.card}>
-          <h3>Space buyers expect</h3>
+          <h3>{bedroomsTitle}</h3>
           <p className={styles.figure}>{averageBedrooms ? `${averageBedrooms.toFixed(1)} bedrooms` : '—'}</p>
-          <p className={styles.meta}>Average bedroom count across current listings.</p>
+          <p className={styles.meta}>{bedroomsMeta}</p>
         </article>
 
         <article className={styles.card}>
-          <h3>Most requested property styles</h3>
+          <h3>{propertyTitle}</h3>
           <ul>
             {propertyTypes.slice(0, 4).map((item) => (
               <li key={item.value}>
@@ -56,7 +94,7 @@ export default function ListingInsights({ stats, searchTerm }) {
         </article>
 
         <article className={styles.card}>
-          <h3>In-demand neighbourhoods</h3>
+          <h3>{areaTitle}</h3>
           {topAreas.length > 0 ? (
             <ul>
               {topAreas.slice(0, 5).map((area) => (
@@ -67,7 +105,7 @@ export default function ListingInsights({ stats, searchTerm }) {
               ))}
             </ul>
           ) : (
-            <p className={styles.meta}>We’ll update this as more buyers enquire.</p>
+            <p className={styles.meta}>{areaEmpty}</p>
           )}
         </article>
       </div>

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -1,15 +1,173 @@
-
+import { useMemo } from 'react';
 import Head from 'next/head';
-import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import PropertyList from '../components/PropertyList';
 import PropertyMap from '../components/PropertyMap';
+import ListingFilters from '../components/ListingFilters';
+import ListingInsights from '../components/ListingInsights';
+import AgentCard from '../components/AgentCard';
 import { fetchPropertiesByType } from '../lib/apex27.mjs';
-import styles from '../styles/Home.module.css';
+import agentsData from '../data/agents.json';
+import homeStyles from '../styles/Home.module.css';
+import rentStyles from '../styles/ToRent.module.css';
+import { formatPriceGBP, formatRentFrequency } from '../lib/format.mjs';
 
-export default function ToRent({ properties }) {
+function normalizeStatus(value) {
+  return String(value || '').toLowerCase().replace(/\s+/g, '_');
+}
+
+function normalizeType(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, '_');
+}
+
+function formatTypeLabel(value) {
+  return String(value || 'Other')
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function toTimestamp(value) {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function getRecencyValue(property) {
+  const updated = toTimestamp(property?.updatedAt);
+  if (updated != null) return updated;
+  const created = toTimestamp(property?.createdAt);
+  if (created != null) return created;
+  const numericId = Number(property?.id);
+  return Number.isFinite(numericId) ? numericId : 0;
+}
+
+function getPriceValue(property) {
+  if (typeof property?.priceValue === 'number' && Number.isFinite(property.priceValue)) {
+    return property.priceValue;
+  }
+  const numeric = Number(String(property?.price ?? '').replace(/[^0-9.]/g, ''));
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function computeMedian(values) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function computeStats(properties) {
+  if (!Array.isArray(properties) || properties.length === 0) {
+    return {
+      averagePrice: null,
+      medianPrice: null,
+      propertyTypes: [],
+      topAreas: [],
+      averageBedrooms: null,
+    };
+  }
+
+  const priceValues = properties
+    .map((property) => getPriceValue(property))
+    .filter((value) => value > 0);
+
+  const averagePrice = priceValues.length
+    ? priceValues.reduce((sum, value) => sum + value, 0) / priceValues.length
+    : null;
+
+  const medianPrice = computeMedian(priceValues);
+
+  const bedroomValues = properties
+    .map((property) => {
+      const numeric = Number(property?.bedrooms);
+      return Number.isFinite(numeric) ? numeric : null;
+    })
+    .filter((value) => value != null);
+
+  const averageBedrooms = bedroomValues.length
+    ? bedroomValues.reduce((sum, value) => sum + value, 0) / bedroomValues.length
+    : null;
+
+  const typeCounts = new Map();
+  properties.forEach((property) => {
+    const normalized = normalizeType(property?.propertyType || 'other');
+    const label = property?.propertyType ? formatTypeLabel(property.propertyType) : 'Other';
+    const existing = typeCounts.get(normalized) || { value: normalized, label, count: 0 };
+    existing.count += 1;
+    typeCounts.set(normalized, existing);
+  });
+
+  const propertyTypes = Array.from(typeCounts.values()).sort((a, b) => b.count - a.count);
+
+  const areaCounts = new Map();
+  properties.forEach((property) => {
+    const candidates = [property?.city, property?.county];
+    if (Array.isArray(property?.matchingRegions)) {
+      candidates.push(...property.matchingRegions);
+    }
+    candidates
+      .map((candidate) => (candidate ? String(candidate).trim() : ''))
+      .filter(Boolean)
+      .forEach((candidate) => {
+        const key = candidate.toLowerCase();
+        const existing = areaCounts.get(key) || { name: candidate, count: 0 };
+        existing.count += 1;
+        areaCounts.set(key, existing);
+      });
+  });
+
+  const topAreas = Array.from(areaCounts.values()).sort((a, b) => b.count - a.count);
+
+  return {
+    averagePrice,
+    medianPrice,
+    propertyTypes,
+    topAreas,
+    averageBedrooms,
+  };
+}
+
+function collectPropertyTypes(properties) {
+  const counts = new Map();
+  properties.forEach((property) => {
+    if (!property?.propertyType) return;
+    const normalized = normalizeType(property.propertyType);
+    const label = formatTypeLabel(property.propertyType);
+    const existing = counts.get(normalized) || { value: normalized, label, count: 0 };
+    existing.count += 1;
+    counts.set(normalized, existing);
+  });
+  return Array.from(counts.values()).sort((a, b) => b.count - a.count);
+}
+
+const RENT_MIN_PRICE_OPTIONS = [
+  { label: 'No minimum', value: '' },
+  { label: '£800 pcm', value: '800' },
+  { label: '£1,000 pcm', value: '1000' },
+  { label: '£1,250 pcm', value: '1250' },
+  { label: '£1,500 pcm', value: '1500' },
+  { label: '£2,000 pcm', value: '2000' },
+  { label: '£2,500 pcm', value: '2500' },
+  { label: '£3,000 pcm', value: '3000' },
+];
+
+const RENT_MAX_PRICE_OPTIONS = [
+  { label: 'No maximum', value: '' },
+  { label: '£1,500 pcm', value: '1500' },
+  { label: '£2,000 pcm', value: '2000' },
+  { label: '£2,500 pcm', value: '2500' },
+  { label: '£3,000 pcm', value: '3000' },
+  { label: '£3,500 pcm', value: '3500' },
+  { label: '£4,000 pcm', value: '4000' },
+  { label: '£5,000 pcm', value: '5000' },
+];
+
+export default function ToRent({ properties, agents }) {
   const router = useRouter();
-  const search = typeof router.query.search === 'string' ? router.query.search : '';
+  const search = typeof router.query.search === 'string' ? router.query.search.trim() : '';
   const minPrice =
     router.query.minPrice && !Array.isArray(router.query.minPrice)
       ? Number(router.query.minPrice)
@@ -24,84 +182,320 @@ export default function ToRent({ properties }) {
       : null;
   const propertyType =
     router.query.propertyType && !Array.isArray(router.query.propertyType)
-      ? router.query.propertyType.toLowerCase()
+      ? normalizeType(router.query.propertyType)
       : null;
-  const [viewMode, setViewMode] = useState('list');
+  const sortOrder =
+    router.query.sort && !Array.isArray(router.query.sort)
+      ? router.query.sort
+      : 'recommended';
+
+  const searchTerm = search.toLowerCase();
+
   const filtered = useMemo(() => {
-    return properties.filter((p) => {
-      if (search) {
-        const lower = search.toLowerCase();
-        if (
-          !p.title.toLowerCase().includes(lower) &&
-          !(p.description && p.description.toLowerCase().includes(lower))
-        ) {
+    return properties.filter((property) => {
+      if (searchTerm) {
+        const haystack = [
+          property.title,
+          property.description,
+          property.city,
+          property.county,
+          ...(Array.isArray(property.matchingRegions) ? property.matchingRegions : []),
+        ]
+          .filter(Boolean)
+          .map((value) => String(value).toLowerCase());
+        if (!haystack.some((value) => value.includes(searchTerm))) {
           return false;
         }
       }
 
-      const price = p.price ?? 0;
-      if (minPrice !== null && price < minPrice) return false;
-      if (maxPrice !== null && price > maxPrice) return false;
+      const priceValue = getPriceValue(property);
+      if (minPrice != null && priceValue < minPrice) return false;
+      if (maxPrice != null && priceValue > maxPrice) return false;
 
-      const beds = Number(p.bedrooms || 0);
-      if (bedrooms !== null && beds < bedrooms) return false;
+      const beds = Number(property?.bedrooms ?? 0);
+      if (bedrooms != null && (!Number.isFinite(beds) || beds < bedrooms)) return false;
 
-      if (
-        propertyType &&
-        (p.propertyType || '').toLowerCase() !== propertyType
-      )
-        return false;
+      if (propertyType) {
+        const type = normalizeType(property?.propertyType || '');
+        if (type !== propertyType) return false;
+      }
+
+      const status = normalizeStatus(property?.status || '');
+      if (status.includes('pending')) return false;
 
       return true;
     });
+  }, [properties, searchTerm, minPrice, maxPrice, bedrooms, propertyType]);
 
-  }, [properties, search, minPrice, maxPrice, bedrooms, propertyType]);
+  const sorted = useMemo(() => {
+    const items = [...filtered];
+    const comparePriceAsc = (a, b) => getPriceValue(a) - getPriceValue(b);
+    const comparePriceDesc = (a, b) => getPriceValue(b) - getPriceValue(a);
 
-  const normalize = (s) => s.toLowerCase().replace(/\s+/g, '_');
-  const available = filtered.filter(
-    (p) => !p.status || !normalize(p.status).startsWith('let')
+    switch (sortOrder) {
+      case 'price_asc':
+        return items.sort(comparePriceAsc);
+      case 'price_desc':
+        return items.sort(comparePriceDesc);
+      case 'newest':
+        return items.sort((a, b) => getRecencyValue(b) - getRecencyValue(a));
+      case 'recommended':
+      default:
+        return items.sort((a, b) => {
+          if (a.featured && !b.featured) return -1;
+          if (!a.featured && b.featured) return 1;
+          return getRecencyValue(b) - getRecencyValue(a);
+        });
+    }
+  }, [filtered, sortOrder]);
+
+  const isLet = (property) => {
+    const status = normalizeStatus(property?.status || '');
+    return status.includes('let');
+  };
+
+  const available = useMemo(() => sorted.filter((property) => !isLet(property)), [sorted]);
+  const archived = useMemo(() => sorted.filter(isLet), [sorted]);
+
+  const insights = useMemo(() => computeStats(available), [available]);
+  const propertyTypeOptions = useMemo(() => collectPropertyTypes(properties), [properties]);
+
+  const activeFilters = useMemo(() => {
+    const chips = [];
+    if (search) {
+      chips.push(`Keyword: “${search}”`);
+    }
+    if (minPrice != null) {
+      chips.push(`Min ${formatPriceGBP(minPrice)} pcm`);
+    }
+    if (maxPrice != null) {
+      chips.push(`Max ${formatPriceGBP(maxPrice)} pcm`);
+    }
+    if (bedrooms != null) {
+      chips.push(`${bedrooms}+ bedrooms`);
+    }
+    if (propertyType) {
+      const selected = propertyTypeOptions.find((option) => option.value === propertyType);
+      if (selected) {
+        chips.push(`Property type: ${selected.label}`);
+      }
+    }
+    return chips;
+  }, [search, minPrice, maxPrice, bedrooms, propertyType, propertyTypeOptions]);
+
+  const currentFilters = useMemo(
+    () => ({
+      search,
+      minPrice: minPrice != null ? String(minPrice) : '',
+      maxPrice: maxPrice != null ? String(maxPrice) : '',
+      bedrooms: bedrooms != null ? String(bedrooms) : '',
+      propertyType: propertyType ?? '',
+    }),
+    [search, minPrice, maxPrice, bedrooms, propertyType]
   );
-  const archived = filtered.filter(
-    (p) => p.status && normalize(p.status).startsWith('let')
-  );
+
+  const updateQuery = (filters, nextSort = sortOrder) => {
+    if (!router.isReady) return;
+    const query = {};
+    if (filters.search && filters.search.trim()) query.search = filters.search.trim();
+    if (filters.minPrice) query.minPrice = filters.minPrice;
+    if (filters.maxPrice) query.maxPrice = filters.maxPrice;
+    if (filters.bedrooms) query.bedrooms = filters.bedrooms;
+    if (filters.propertyType) query.propertyType = filters.propertyType;
+    if (nextSort && nextSort !== 'recommended') query.sort = nextSort;
+    router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+  };
+
+  const handleApplyFilters = (nextFilters) => {
+    updateQuery(nextFilters);
+  };
+
+  const handleResetFilters = () => {
+    updateQuery(
+      { search: '', minPrice: '', maxPrice: '', bedrooms: '', propertyType: '' },
+      'recommended'
+    );
+  };
+
+  const handleSortChange = (nextSort) => {
+    updateQuery(currentFilters, nextSort);
+  };
+
+  const heroAreaCount = insights.topAreas.length;
+  const heroAverageRent = insights.averagePrice
+    ? `${formatPriceGBP(insights.averagePrice)} pcm`
+    : '—';
+  const heroPopularType = insights.propertyTypes[0]?.label
+    ? insights.propertyTypes[0].label
+    : 'Varied stock';
+
+  const heroRentFrequency = (() => {
+    const counts = new Map();
+    available.forEach((property) => {
+      const freq = property?.rentFrequency ? formatRentFrequency(property.rentFrequency) : null;
+      if (!freq) return;
+      const existing = counts.get(freq) ?? 0;
+      counts.set(freq, existing + 1);
+    });
+    const [topFrequency] = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])[0] || [];
+    return topFrequency || 'pcm';
+  })();
 
   return (
     <>
       <Head>
-        <title>Properties to Rent</title>
-        <meta httpEquiv="Cache-Control" content="no-store, max-age=0" />
+        <title>Properties to Rent | Aktonz</title>
+        <meta
+          name="description"
+          content="Explore Aktonz rental homes with refined search tools, interactive maps and lettings specialists ready to help."
+        />
       </Head>
-      <main className={styles.main}>
-        <h1>{search ? `Search results for "${search}"` : 'Properties to Rent'}</h1>
-        <div className={styles.viewModeControls}>
-        <button
-          type="button"
-          onClick={() => setViewMode('list')}
-          disabled={viewMode === 'list'}
-        >
-          List
-        </button>{' '}
-        <button
-          type="button"
-          onClick={() => setViewMode('map')}
-          disabled={viewMode === 'map'}
-        >
-          Map
-        </button>
-      </div>
-      {viewMode === 'list' ? (
-        <>
-          <PropertyList properties={available} />
-          {archived.length > 0 && (
-            <>
-              <h2>Let Properties</h2>
-              <PropertyList properties={archived} />
-            </>
+      <main className={`${homeStyles.main} ${rentStyles.page}`}>
+        <section className={rentStyles.hero}>
+          <div className={rentStyles.heroContent}>
+            <p className={rentStyles.breadcrumbs}>Home / To Rent</p>
+            <h1 className={rentStyles.heroTitle}>
+              {search ? `Properties to rent around “${search}”` : 'Properties to Rent'}
+            </h1>
+            <p className={rentStyles.heroSubtitle}>
+              Find design-led rentals{search ? ` in and around ${search}` : ''} with live pricing, neighbourhood
+              insight and appointments arranged by our lettings team.
+            </p>
+            <div className={rentStyles.heroStats}>
+              <div className={rentStyles.heroStat}>
+                <span className={rentStyles.heroStatValue}>{heroAverageRent}</span>
+                <span>Average monthly rent</span>
+              </div>
+              <div className={rentStyles.heroStat}>
+                <span className={rentStyles.heroStatValue}>{available.length}</span>
+                <span>Homes available now</span>
+              </div>
+              <div className={rentStyles.heroStat}>
+                <span className={rentStyles.heroStatValue}>{heroAreaCount || '—'}</span>
+                <span>Neighbourhoods covered</span>
+              </div>
+              <div className={rentStyles.heroStat}>
+                <span className={rentStyles.heroStatValue}>{heroPopularType}</span>
+                <span>Most requested style</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className={rentStyles.content}>
+          <section className={rentStyles.filtersSection}>
+            <div className={rentStyles.filtersInner}>
+              <ListingFilters
+                totalResults={available.length}
+                initialFilters={currentFilters}
+                onApply={handleApplyFilters}
+                onReset={handleResetFilters}
+                sortOrder={sortOrder}
+                onSortChange={handleSortChange}
+                propertyTypes={propertyTypeOptions}
+                priceOptions={RENT_MIN_PRICE_OPTIONS}
+                maxPriceOptions={RENT_MAX_PRICE_OPTIONS}
+                submitLabel="Show rentals"
+                searchPlaceholder="e.g. Shoreditch, balcony"
+                minPriceLabel="Min rent"
+                maxPriceLabel="Max rent"
+                resultPluralNoun="homes"
+                resultNoun="home"
+              />
+              {activeFilters.length > 0 && (
+                <div className={rentStyles.activeFilters}>
+                  {activeFilters.map((chip) => (
+                    <span key={chip} className={rentStyles.filterChip}>
+                      {chip}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <div className={rentStyles.resultsLayout}>
+            <div className={rentStyles.listColumn}>
+              <div className={rentStyles.resultsHeader}>
+                <h2>
+                  {available.length} {available.length === 1 ? 'rental' : 'rentals'} ready to view
+                </h2>
+                <p>
+                  Sorted by{' '}
+                  {sortOrder === 'recommended'
+                    ? 'our lettings recommendation'
+                    : sortOrder.replace(/_/g, ' ')}
+                  {search ? ` for “${search}”` : ''}.
+                </p>
+              </div>
+              <PropertyList properties={available} />
+              {archived.length > 0 && (
+                <section className={rentStyles.archivedSection}>
+                  <h3>Recently let</h3>
+                  <p>These homes have just been matched with tenants through Aktonz.</p>
+                  <PropertyList properties={archived} />
+                </section>
+              )}
+            </div>
+            <aside className={rentStyles.mapColumn}>
+              <div className={rentStyles.mapCard}>
+                <PropertyMap properties={available} />
+              </div>
+              <div className={rentStyles.mapSummary}>
+                <h3>Explore on the map</h3>
+                <p>
+                  Pan and zoom to discover homes in your preferred postcodes. Each pin reveals live pricing, key
+                  amenities and viewing availability.
+                </p>
+                <ul>
+                  <li>
+                    <span>Live rentals</span>
+                    <strong>{available.length}</strong>
+                  </li>
+                  <li>
+                    <span>Average rent</span>
+                    <strong>{heroAverageRent}</strong>
+                  </li>
+                  <li>
+                    <span>Typical frequency</span>
+                    <strong>{heroRentFrequency}</strong>
+                  </li>
+                </ul>
+              </div>
+            </aside>
+          </div>
+
+          <ListingInsights stats={insights} searchTerm={search} variant="rent" />
+
+          {agents && agents.length > 0 && (
+            <section className={rentStyles.agentsSection}>
+              <h2>Talk to a lettings specialist</h2>
+              <div className="agent-list">
+                {agents.map((agent) => (
+                  <AgentCard key={agent.id} agent={agent} />
+                ))}
+              </div>
+            </section>
           )}
-        </>
-      ) : (
-        <PropertyMap properties={available} />
-      )}
+
+          <section className={rentStyles.ctaSection}>
+            <div>
+              <h2>Need help finding the right rental?</h2>
+              <p>
+                Register with Aktonz to receive tailored alerts, arrange accompanied viewings and secure the tenancy
+                that suits your lifestyle.
+              </p>
+            </div>
+            <div className={rentStyles.ctaButtons}>
+              <Link href="/register" className={rentStyles.primaryCta}>
+                Register for alerts
+              </Link>
+              <Link href="/contact" className={rentStyles.secondaryCta}>
+                Speak to our team
+              </Link>
+            </div>
+          </section>
+        </div>
       </main>
     </>
   );
@@ -110,14 +504,15 @@ export default function ToRent({ properties }) {
 export async function getStaticProps() {
   const raw = await fetchPropertiesByType('rent', {
     statuses: ['available', 'under_offer', 'let_agreed', 'let', 'let_stc', 'let_by'],
-
   });
 
-  const properties = raw.slice(0, 50).map((p) => ({
-    ...p,
-    images: (p.images || []).slice(0, 3),
-    description: p.description ? p.description.slice(0, 200) : '',
+  const properties = raw.slice(0, 50).map((property) => ({
+    ...property,
+    images: (property.images || []).slice(0, 3),
+    description: property.description ? property.description.slice(0, 200) : '',
   }));
 
-  return { props: { properties } };
+  const agents = agentsData;
+
+  return { props: { properties, agents } };
 }

--- a/styles/ToRent.module.css
+++ b/styles/ToRent.module.css
@@ -1,0 +1,269 @@
+.page {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.hero {
+  position: relative;
+  background: linear-gradient(135deg, rgba(6, 45, 72, 0.92), rgba(16, 104, 120, 0.85)),
+    url('https://images.unsplash.com/photo-1480074568708-e7b720bb3f09?auto=format&fit=crop&w=1600&q=80')
+      center/cover no-repeat;
+  color: var(--color-background);
+  padding: calc(var(--spacing-xl) * 1.5) var(--spacing-lg);
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(6, 45, 72, 0.75) 0%, rgba(16, 104, 120, 0.4) 60%);
+}
+
+.heroContent {
+  position: relative;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.breadcrumbs {
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.heroTitle {
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.heroSubtitle {
+  margin: 0;
+  max-width: 560px;
+  line-height: 1.5;
+  opacity: 0.9;
+}
+
+.heroStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-md);
+}
+
+.heroStat {
+  background: rgba(255, 255, 255, 0.12);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: 12px;
+  min-width: 160px;
+}
+
+.heroStat span {
+  display: block;
+}
+
+.heroStatValue {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.content {
+  padding: 0 var(--spacing-lg) var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.filtersSection {
+  position: relative;
+  margin-top: calc(-1 * var(--spacing-xl));
+}
+
+.filtersInner {
+  position: relative;
+  z-index: 1;
+  margin-top: -4rem;
+}
+
+.activeFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: var(--spacing-sm);
+}
+
+.filterChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  background: rgba(12, 60, 96, 0.1);
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.resultsLayout {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.listColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.resultsHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.archivedSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.mapColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.mapCard {
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 36px rgba(12, 36, 58, 0.08);
+  --map-height: 520px;
+}
+
+.mapCard :global(.leaflet-container) {
+  min-height: var(--map-height);
+}
+
+.mapSummary {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  box-shadow: 0 12px 28px rgba(12, 36, 58, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.mapSummary h3 {
+  margin: 0;
+}
+
+.mapSummary p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.mapSummary ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.mapSummary li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.mapSummary span {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.agentsSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.ctaSection {
+  background: linear-gradient(120deg, rgba(12, 60, 96, 0.92), rgba(27, 108, 123, 0.85));
+  color: var(--color-background);
+  border-radius: 18px;
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-md);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: center;
+}
+
+.ctaSection h2 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.ctaSection p {
+  margin: 0;
+  opacity: 0.9;
+}
+
+.ctaButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.primaryCta,
+.secondaryCta {
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.primaryCta {
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.secondaryCta {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: var(--color-background);
+}
+
+@media (min-width: 960px) {
+  .resultsLayout {
+    grid-template-columns: minmax(0, 3fr) minmax(320px, 2fr);
+    align-items: start;
+  }
+
+  .mapColumn {
+    position: sticky;
+    top: 6rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: var(--spacing-xl) var(--spacing-md);
+  }
+
+  .content {
+    padding: 0 var(--spacing-md) var(--spacing-xl);
+  }
+
+  .filtersInner {
+    margin-top: -3rem;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the to-rent page with a hero, configurable filters, list-and-map layout, and lettings insights
- add a dedicated styling module for the rental listings experience including sticky map and CTA blocks
- extend shared listing filters and insights components to support lettings-specific copy and pricing options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0c3f05468832eb03410e9a6ac522d