### PR TITLE
Set property card dimensions to requested size

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,8 +35,8 @@ body {
   display: flex;
   flex-direction: column;
   transition: box-shadow 0.2s, transform 0.2s;
-  width: 100%;
-  height: 100%;
+  width: 323px;
+  height: auto;
 }
 
 .property-list .property-link:hover .property-card,


### PR DESCRIPTION
## Summary
- update the property card styling to use a fixed 323px width while letting the height size automatically so the cards stay compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0ca2858d4832e97437b3fdb138457