### PR TITLE
Fix property card layout to match request

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -30,22 +30,6 @@ export default function PropertyCard({ property }) {
   const hasImages = images.length > 0;
   const [currentImage, setCurrentImage] = useState(0);
 
-  const normalizedDescription =
-    typeof property.description === 'string'
-      ? property.description.replace(/\s+/g, ' ').trim()
-      : '';
-
-  let truncatedDescription = normalizedDescription;
-
-  if (normalizedDescription.length > 160) {
-    const boundary = normalizedDescription.lastIndexOf(' ', 160);
-    const sliceIndex = boundary > 0 ? boundary : 160;
-    truncatedDescription = `${normalizedDescription
-      .slice(0, sliceIndex)
-      .trimEnd()}…`;
-  }
-
-
   useEffect(() => {
     setCurrentImage(0);
   }, [sliderKeyPrefix, images.length]);
@@ -165,9 +149,6 @@ export default function PropertyCard({ property }) {
               </span>
             )}
           </div>
-        )}
-        {normalizedDescription && (
-          <p className="description">{truncatedDescription}</p>
         )}
         {property.id && <FavoriteButton propertyId={property.id} />}
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,8 +35,8 @@ body {
   display: flex;
   flex-direction: column;
   transition: box-shadow 0.2s, transform 0.2s;
-  width: 100%;
-  height: 100%;
+  width: 323px;
+  height: 993px;
 }
 
 .property-list .property-link:hover .property-card,


### PR DESCRIPTION
## Summary
- set property cards to use the requested 323px width and 993px height
- remove the description text from property cards so only the key details remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ca2858d4832e97437b3fdb138457