### PR TITLE
Fix Scraye property links

### DIFF
--- a/components/PropertyList.js
+++ b/components/PropertyList.js
@@ -40,25 +40,11 @@ export default function PropertyList({ properties }) {
           );
         }
 
-        if (externalUrl && property.source === 'scraye') {
-          return (
-            <a
-              key={key}
-              href={externalUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="property-link property-card-wrapper"
-            >
-              <PropertyCard property={cardProps} />
-            </a>
-          );
-        }
-
         return (
           <Link
             href={`/property/${encodeURIComponent(propertyId)}`}
             key={key}
-            className="property-link"
+            className="property-link property-card-wrapper"
           >
             <PropertyCard property={cardProps} />
           </Link>


### PR DESCRIPTION
## Summary
- remove the special-case that sent Scraye listings to their external URL
- ensure Scraye property cards use the internal Aktonz property detail route while keeping wrapper styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f8a4564c832e8b579e7a120e11a7