### PR TITLE
Show Apex27 property type labels

### DIFF
--- a/components/PropertyActionDrawer.js
+++ b/components/PropertyActionDrawer.js
@@ -1,6 +1,7 @@
 import { useId } from 'react';
 import { FaBath, FaBed, FaCouch } from 'react-icons/fa';
 import { formatRentFrequency } from '../lib/format.mjs';
+import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 import styles from '../styles/PropertyActionDrawer.module.css';
 
 function formatPrice(property = {}) {
@@ -28,6 +29,10 @@ export default function PropertyActionDrawer({
       : 'For sale'
     : '';
   const priceLabel = formatPrice(summary);
+  const typeLabel =
+    summary.typeLabel ??
+    summary.propertyTypeLabel ??
+    formatPropertyTypeLabel(summary.propertyType ?? summary.type ?? null);
 
   return (
     <>
@@ -67,9 +72,7 @@ export default function PropertyActionDrawer({
               <h3 className={styles.summaryTitle}>
                 {summary.title || 'Property details'}
               </h3>
-              {summary.type && (
-                <p className={styles.summaryType}>{summary.type}</p>
-              )}
+              {typeLabel && <p className={styles.summaryType}>{typeLabel}</p>}
               {priceLabel && <p className={styles.summaryPrice}>{priceLabel}</p>}
               <ul className={styles.summaryMeta}>
                 {summary.bedrooms != null && (

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { formatRentFrequency } from '../lib/format.mjs';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
+import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 
 export default function PropertyCard({ property }) {
   const rawStatus = property.status ? property.status.replace(/_/g, ' ') : null;
@@ -96,6 +97,10 @@ export default function PropertyCard({ property }) {
   if (town) locationParts.push(town);
   if (postcode) locationParts.push(postcode);
   const locationText = locationParts.join(' · ');
+  const typeLabel =
+    property.propertyTypeLabel ??
+    property.typeLabel ??
+    formatPropertyTypeLabel(property.propertyType ?? property.type ?? null);
 
   return (
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
@@ -159,6 +164,7 @@ export default function PropertyCard({ property }) {
       </div>
       <div className="details">
         <h3 className="title">{property.title}</h3>
+        {typeLabel && <p className="type">{typeLabel}</p>}
         {locationText && <p className="location">{locationText}</p>}
         {property.price && (
           <p className="price">

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -3,6 +3,7 @@ import {
   resolvePropertyIdentifier,
   normalizePropertyIdentifierForComparison,
 } from './property-id.mjs';
+import { resolvePropertyTypeLabel } from './property-type.mjs';
 import { formatPriceGBP } from './format.mjs';
 import {
   loadScrayeListingsByType,
@@ -455,6 +456,7 @@ export async function fetchPropertiesByType(type, options = {}) {
         bedrooms: item.bedrooms ?? null,
         bathrooms: item.bathrooms ?? null,
         propertyType: item.propertyType ?? null,
+        propertyTypeLabel: resolvePropertyTypeLabel(item) ?? null,
         status: item.status ?? null,
         featured: Boolean(item.featured),
         latitude: item.latitude ?? item.lat ?? null,
@@ -563,6 +565,7 @@ export async function fetchPropertiesByType(type, options = {}) {
       bedrooms: p.bedrooms ?? null,
       receptions: p.receptions ?? p.receptionRooms ?? p.reception_rooms ?? null,
       propertyType: p.propertyType ?? null,
+      propertyTypeLabel: resolvePropertyTypeLabel(p) ?? null,
       rentFrequency: p.rentFrequency ?? null,
       tenure: p.tenure ?? null,
       image: trimmedImages[0] || null,

--- a/lib/property-type.mjs
+++ b/lib/property-type.mjs
@@ -1,0 +1,146 @@
+function normalizeFieldKey(value) {
+  if (!value) return '';
+  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function coerceString(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function humanize(value) {
+  const str = coerceString(value);
+  if (!str) return null;
+  return str
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function extractFromFieldCollection(collection) {
+  if (!Array.isArray(collection)) return null;
+  for (const entry of collection) {
+    if (!entry || typeof entry !== 'object') continue;
+    const keyCandidates = [
+      entry.field,
+      entry.fieldName,
+      entry.field_name,
+      entry.name,
+      entry.id,
+      entry.key,
+      entry.meta,
+      entry.identifier,
+    ]
+      .map((value) => normalizeFieldKey(value))
+      .filter(Boolean);
+
+    if (!keyCandidates.some((key) => key.includes('propertytype'))) {
+      continue;
+    }
+
+    const labelCandidates = [
+      entry.fieldLabel,
+      entry.field_label,
+      entry.valueLabel,
+      entry.value_label,
+      entry.displayValue,
+      entry.display_value,
+      entry.displayLabel,
+      entry.display_label,
+      entry.label,
+      entry.text,
+      entry.value,
+    ];
+
+    for (const candidate of labelCandidates) {
+      const str = coerceString(candidate);
+      if (str) return str;
+    }
+  }
+  return null;
+}
+
+function extractFromObjectMap(mapLike) {
+  if (!mapLike || typeof mapLike !== 'object') return null;
+  const direct =
+    mapLike.propertyType ??
+    mapLike.property_type ??
+    mapLike.propertytype ??
+    mapLike.type ??
+    null;
+  return coerceString(direct);
+}
+
+export function resolvePropertyTypeLabel(listing) {
+  if (!listing || typeof listing !== 'object') {
+    return null;
+  }
+
+  const directKeys = [
+    'propertyTypeLabel',
+    'property_type_label',
+    'propertyTypeName',
+    'property_type_name',
+    'propertyTypeDisplay',
+    'property_type_display',
+    'displayPropertyType',
+    'display_property_type',
+    'propertyTypeText',
+    'property_type_text',
+  ];
+
+  for (const key of directKeys) {
+    const value = coerceString(listing[key]);
+    if (value) return value;
+  }
+
+  const mapCandidates = [
+    listing.fieldLabels,
+    listing.field_labels,
+    listing.fieldLabel,
+    listing.field_label,
+    listing.labels,
+  ];
+
+  for (const candidate of mapCandidates) {
+    const extracted = extractFromObjectMap(candidate);
+    if (extracted) return extracted;
+  }
+
+  const collections = [];
+  if (Array.isArray(listing.fields)) {
+    collections.push(listing.fields);
+  } else if (listing.fields && typeof listing.fields === 'object') {
+    collections.push(Object.values(listing.fields));
+  }
+  if (Array.isArray(listing.metadata)) {
+    collections.push(listing.metadata);
+  }
+  if (Array.isArray(listing.customFields)) {
+    collections.push(listing.customFields);
+  }
+  if (Array.isArray(listing.custom_fields)) {
+    collections.push(listing.custom_fields);
+  }
+
+  for (const collection of collections) {
+    const extracted = extractFromFieldCollection(collection);
+    if (extracted) return extracted;
+  }
+
+  const fallback =
+    listing.displayPropertyType ??
+    listing.display_property_type ??
+    listing.propertyType ??
+    listing.property_type ??
+    listing.type ??
+    null;
+
+  return humanize(fallback);
+}
+
+export function formatPropertyTypeLabel(value) {
+  return humanize(value);
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -21,6 +21,10 @@ import {
   resolvePropertyIdentifier,
   propertyMatchesIdentifier,
 } from '../../lib/property-id.mjs';
+import {
+  resolvePropertyTypeLabel,
+  formatPropertyTypeLabel,
+} from '../../lib/property-type.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatRentFrequency, formatPriceGBP } from '../../lib/format.mjs';
@@ -59,6 +63,10 @@ export default function Property({ property, recommendations }) {
     );
   }
   const features = Array.isArray(property.features) ? property.features : [];
+  const displayType =
+    property.typeLabel ??
+    property.propertyTypeLabel ??
+    formatPropertyTypeLabel(property.propertyType ?? property.type ?? null);
   const hasLocation =
     property.latitude != null && property.longitude != null;
   const mapProperties = useMemo(
@@ -72,7 +80,7 @@ export default function Property({ property, recommendations }) {
           rentFrequency: property.rentFrequency,
           tenure: property.tenure ?? null,
           image: property.image ?? null,
-          propertyType: property.type ?? null,
+          propertyType: property.propertyType ?? property.type ?? null,
           lat: property.latitude,
           lng: property.longitude,
         },
@@ -88,6 +96,7 @@ export default function Property({ property, recommendations }) {
       property.rentFrequency,
       property.tenure,
       property.title,
+      property.propertyType,
       property.type,
     ]
   );
@@ -115,7 +124,7 @@ export default function Property({ property, recommendations }) {
               />
             )}
           </div>
-          {property.type && <p className={styles.type}>{property.type}</p>}
+          {displayType && <p className={styles.type}>{displayType}</p>}
           <div className={styles.stats}>
             {property.receptions != null && (
               <span>
@@ -234,6 +243,15 @@ export async function getStaticProps({ params }) {
   if (rawProperty) {
     const imgList = normalizeImages(rawProperty.images || []);
     const isSalePrice = rawProperty.rentFrequency == null;
+    const propertyTypeValue =
+      rawProperty.propertyType ||
+      rawProperty.type ||
+      rawProperty.property_type ||
+      rawProperty.property_type_code ||
+      '';
+    const propertyTypeLabel =
+      resolvePropertyTypeLabel(rawProperty) ??
+      formatPropertyTypeLabel(propertyTypeValue);
     const rawOutcode =
       rawProperty.outcode ??
       rawProperty.postcode ??
@@ -290,7 +308,10 @@ export async function getStaticProps({ params }) {
         }
         return [];
       })(),
-      type: rawProperty.propertyType || rawProperty.type || '',
+      propertyType: propertyTypeValue || null,
+      propertyTypeLabel: propertyTypeLabel ?? null,
+      type: propertyTypeValue || '',
+      typeLabel: propertyTypeLabel ?? null,
       receptions:
         rawProperty.receptionRooms ?? rawProperty.receptions ?? null,
       bedrooms: rawProperty.bedrooms ?? rawProperty.beds ?? null,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -196,6 +196,12 @@ body {
   font-size: 1rem;
 }
 
+.property-card .type {
+  margin: 0;
+  color: var(--color-muted-text);
+  font-size: 0.9rem;
+}
+
 .property-card .location {
   margin: 0;
   margin-top: var(--spacing-xs);


### PR DESCRIPTION
## Summary
- surface Apex27 property type labels across property cards, detail pages, and action drawers
- add a utility to resolve Apex27 property type labels with fallbacks to human-readable formatting
- persist both the raw and display property type values when normalizing Apex27 listings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d206adfd50832eae833c222bd7edda