### PR TITLE
Show five featured properties on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -51,13 +51,13 @@ export async function getStaticProps() {
 
   const sales = allSale
     .filter((p) => isAvailable(p) && p.featured)
-    .slice(0, 4);
+    .slice(0, 5);
 
   const lettings = allRent
     .filter((p) => isAvailable(p) && p.featured)
-    .slice(0, 4);
+    .slice(0, 5);
 
-  const archiveSales = allSale.filter(isSold).slice(0, 4);
+  const archiveSales = allSale.filter(isSold).slice(0, 5);
 
   return { props: { sales, lettings, archiveSales } };
 }


### PR DESCRIPTION
## Summary
- show five featured property cards for sales and lettings so the homepage grid matches the sizing used elsewhere

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20b036ec0832e945450ce1285d00c