### PR TITLE
Display sale price prefixes after price

### DIFF
--- a/__tests__/format.test.js
+++ b/__tests__/format.test.js
@@ -1,8 +1,11 @@
 let formatRentFrequency;
 let formatPriceGBP;
+let formatPricePrefix;
 
 beforeAll(async () => {
-  ({ formatRentFrequency, formatPriceGBP } = await import('../lib/format.mjs'));
+  ({ formatRentFrequency, formatPriceGBP, formatPricePrefix } = await import(
+    '../lib/format.mjs'
+  ));
 });
 
 describe('formatRentFrequency', () => {
@@ -34,5 +37,20 @@ describe('formatPriceGBP', () => {
   test('returns empty string for invalid values', () => {
     expect(formatPriceGBP(null)).toBe('');
     expect(formatPriceGBP('')).toBe('');
+  });
+});
+
+describe('formatPricePrefix', () => {
+  test('maps known prefixes', () => {
+    expect(formatPricePrefix('offers_invited')).toBe('Offers invited');
+    expect(formatPricePrefix('oiro')).toBe('OIRO');
+  });
+
+  test('formats unknown prefixes', () => {
+    expect(formatPricePrefix('best_and_final')).toBe('Best And Final');
+  });
+
+  test('returns empty string for falsy input', () => {
+    expect(formatPricePrefix(null)).toBe('');
   });
 });

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { formatRentFrequency } from '../lib/format.mjs';
+import { formatRentFrequency, formatPricePrefix } from '../lib/format.mjs';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 
@@ -102,6 +102,11 @@ export default function PropertyCard({ property }) {
     property.typeLabel ??
     formatPropertyTypeLabel(property.propertyType ?? property.type ?? null);
 
+  const pricePrefixLabel =
+    !property.rentFrequency && property.pricePrefix
+      ? formatPricePrefix(property.pricePrefix)
+      : '';
+
   return (
     <div className={`property-card${isArchived ? ' archived' : ''}`}>
       <div className="image-wrapper">
@@ -169,6 +174,7 @@ export default function PropertyCard({ property }) {
         {property.price && (
           <p className="price">
             {property.price}
+            {pricePrefixLabel && ` ${pricePrefixLabel}`}
             {property.rentFrequency &&
               ` ${formatRentFrequency(property.rentFrequency)}`}
           </p>

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -450,6 +450,7 @@ export async function fetchPropertiesByType(type, options = {}) {
         price: item.priceValue ?? null,
         priceCurrency: item.priceCurrency ?? 'GBP',
         rentFrequency: item.rentFrequency ?? null,
+        pricePrefix: item.pricePrefix ?? item.price_prefix ?? null,
         displayAddress: item.title ?? '',
         description: item.description ?? '',
         summary: item.description ?? '',
@@ -562,6 +563,7 @@ export async function fetchPropertiesByType(type, options = {}) {
             : p.price
           : null,
       priceValue: p.price != null ? Number(p.price) : null,
+      pricePrefix: p.pricePrefix ?? p.price_prefix ?? null,
       bedrooms: p.bedrooms ?? null,
       receptions: p.receptions ?? p.receptionRooms ?? p.reception_rooms ?? null,
       propertyType: p.propertyType ?? null,

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -9,6 +9,42 @@ export function formatRentFrequency(freq) {
   return map[freq] || freq;
 }
 
+export function formatPricePrefix(prefix) {
+  if (!prefix) return '';
+
+  const normalized = String(prefix).trim().toLowerCase().replace(/\s+/g, '_');
+  if (!normalized) return '';
+
+  const map = {
+    guide_price: 'Guide price',
+    offers_invited: 'Offers invited',
+    offers_in_excess_of: 'Offers in excess of',
+    offers_in_region_of: 'Offers in region of',
+    offers_in_the_region_of: 'Offers in the region of',
+    offers_over: 'Offers over',
+    offers_around: 'Offers around',
+    offers_from: 'Offers from',
+    asking_price: 'Asking price',
+    fixed_price: 'Fixed price',
+    price_on_application: 'Price on application',
+    poa: 'POA',
+    oiro: 'OIRO',
+    starting_bid: 'Starting bid',
+    from: 'From',
+    shared_ownership: 'Shared ownership',
+  };
+
+  if (map[normalized]) {
+    return map[normalized];
+  }
+
+  return normalized
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 function normalizePriceAmount(value) {
   if (value == null) return null;
   const cleaned = String(value).replace(/[^0-9.]/g, '');

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -27,7 +27,11 @@ import {
 } from '../../lib/property-type.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
-import { formatRentFrequency, formatPriceGBP } from '../../lib/format.mjs';
+import {
+  formatRentFrequency,
+  formatPriceGBP,
+  formatPricePrefix,
+} from '../../lib/format.mjs';
 
 function parsePriceNumber(value) {
   return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
@@ -69,6 +73,10 @@ export default function Property({ property, recommendations }) {
     formatPropertyTypeLabel(property.propertyType ?? property.type ?? null);
   const hasLocation =
     property.latitude != null && property.longitude != null;
+  const pricePrefixLabel =
+    !property.rentFrequency && property.pricePrefix
+      ? formatPricePrefix(property.pricePrefix)
+      : '';
   const mapProperties = useMemo(
     () => {
       if (!hasLocation) return [];
@@ -145,6 +153,7 @@ export default function Property({ property, recommendations }) {
           {property.price && (
             <p className={styles.price}>
               {property.price}
+              {pricePrefixLabel && ` ${pricePrefixLabel}`}
               {property.rentFrequency &&
                 ` ${formatRentFrequency(property.rentFrequency)}`}
             </p>
@@ -287,6 +296,7 @@ export async function getStaticProps({ params }) {
             ? formatPriceGBP(rawProperty.price, { isSale: isSalePrice })
             : rawProperty.price
           : null,
+      pricePrefix: rawProperty.pricePrefix ?? rawProperty.price_prefix ?? null,
       rentFrequency: rawProperty.rentFrequency ?? null,
       image: imgList[0] || null,
       images: imgList,


### PR DESCRIPTION
## Summary
- add a formatter to present price prefixes with user-friendly labels
- surface pricePrefix data for sale listings on cards and property details
- cover the new formatter with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20be2df38832eb957e5dad2279d01