### PR TITLE
Refresh account area layout

### DIFF
--- a/components/account/AccountLayout.js
+++ b/components/account/AccountLayout.js
@@ -1,0 +1,183 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import styles from '../../styles/AccountLayout.module.css';
+
+const PRIMARY_NAV_ITEMS = [
+  {
+    label: 'My Aktonz',
+    href: '/account',
+  },
+  {
+    label: 'My lettings search',
+    href: '/account',
+    match: (pathname) => pathname.startsWith('/account'),
+  },
+  {
+    label: 'My sales search',
+    disabled: true,
+  },
+  {
+    label: 'Lettings',
+    href: '/to-rent',
+  },
+  {
+    label: 'Selling',
+    href: '/sell',
+  },
+];
+
+export const DEFAULT_ACCOUNT_TABS = [
+  {
+    label: 'Overview',
+    href: '/account',
+  },
+  {
+    label: 'My profile',
+    href: '/account/profile',
+  },
+  {
+    label: 'Saved searches',
+    href: '/account/saved-searches',
+  },
+  {
+    label: 'Offers & viewings',
+    disabled: true,
+  },
+  {
+    label: 'Documents',
+    disabled: true,
+  },
+];
+
+export default function AccountLayout({
+  heroSubtitle,
+  heroTitle,
+  heroDescription,
+  heroCta,
+  tabs = DEFAULT_ACCOUNT_TABS,
+  children,
+}) {
+  const router = useRouter();
+
+  function isActive(path) {
+    if (!path) return false;
+    return router.pathname === path || router.pathname.startsWith(`${path}/`);
+  }
+
+  return (
+    <div className={styles.accountPage}>
+      <header className={styles.header}>
+        <div className={styles.topBar}>
+          <Link href="/" className={styles.brand}>
+            <span className={styles.brandMark}>A</span>
+            <span className={styles.brandText}>Aktonz</span>
+          </Link>
+
+          <nav className={styles.primaryNav} aria-label="Account sections">
+            {PRIMARY_NAV_ITEMS.map((item) => {
+              const active = item.disabled ? false : item.match ? item.match(router.pathname) : isActive(item.href);
+              const className = [
+                styles.primaryNavItem,
+                active ? styles.primaryNavItemActive : '',
+                item.disabled ? styles.primaryNavItemDisabled : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              if (item.disabled || !item.href) {
+                return (
+                  <span key={item.label} className={className} aria-disabled="true">
+                    {item.label}
+                  </span>
+                );
+              }
+
+              return (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className={className}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className={styles.userMenu}>
+            <span className={styles.userInitial}>JT</span>
+            <div className={styles.userDetails}>
+              <span className={styles.userName}>Juliet Taphouse</span>
+              <span className={styles.userStatus}>Logged in</span>
+            </div>
+            <button type="button" className={styles.userCaret} aria-label="Account menu" />
+          </div>
+        </div>
+
+        <div className={styles.hero}>
+          <div className={styles.heroContent}>
+            {heroSubtitle ? <p className={styles.heroEyebrow}>{heroSubtitle}</p> : null}
+            {heroTitle ? <h1 className={styles.heroTitle}>{heroTitle}</h1> : null}
+            {heroDescription ? (
+              <p className={styles.heroDescription}>{heroDescription}</p>
+            ) : null}
+            {heroCta ? (
+              <div className={styles.heroActions}>
+                <Link href={heroCta.href} className={styles.heroButton}>
+                  {heroCta.label}
+                </Link>
+                {heroCta.secondary ? (
+                  <Link href={heroCta.secondary.href} className={styles.heroLink}>
+                    {heroCta.secondary.label}
+                  </Link>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {tabs?.length ? (
+          <nav className={styles.tabNav} aria-label="My Aktonz menu">
+            {tabs.map((tab) => {
+              const active =
+                tab.href &&
+                (tab.match
+                  ? tab.match(router.pathname)
+                  : router.pathname === tab.href || router.pathname.startsWith(`${tab.href}/`));
+              const className = [
+                styles.tabNavItem,
+                active ? styles.tabNavItemActive : '',
+                tab.disabled ? styles.tabNavItemDisabled : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              if (!tab.href || tab.disabled) {
+                return (
+                  <span key={tab.label} className={className} aria-disabled="true">
+                    {tab.label}
+                  </span>
+                );
+              }
+
+              return (
+                <Link
+                  key={tab.label}
+                  href={tab.href}
+                  className={className}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </nav>
+        ) : null}
+      </header>
+
+      <main className={styles.content}>{children}</main>
+    </div>
+  );
+}

--- a/pages/account/index.js
+++ b/pages/account/index.js
@@ -1,49 +1,123 @@
 import Link from 'next/link';
 
+import AccountLayout from '../../components/account/AccountLayout';
 import styles from '../../styles/Account.module.css';
+
+const REGISTRATION_CARDS = [
+  {
+    label: 'Rent up to',
+    value: '£1,800 pcm',
+  },
+  {
+    label: 'Bedrooms',
+    value: '2-3',
+  },
+  {
+    label: 'Preferred areas',
+    value: 'Shoreditch, Hackney, Highbury',
+  },
+  {
+    label: 'Move in from',
+    value: 'April 2025',
+  },
+];
+
+const FEATURE_CARDS = [
+  {
+    title: 'Personal search team',
+    copy:
+      'Dedicated specialists shortlist the homes that match your wish list and arrange everything for your viewings.',
+  },
+  {
+    title: 'Access to sneak peeks',
+    copy:
+      'See new listings before they reach the portals and secure a viewing slot that works around your schedule.',
+  },
+  {
+    title: 'Access to price reductions',
+    copy:
+      'Be the first to hear when a property changes price so you can move quickly and beat the competition.',
+  },
+  {
+    title: 'Email alerts',
+    copy:
+      'Tailored updates land in your inbox as soon as properties launch so you never miss the perfect place.',
+  },
+];
 
 export default function AccountDashboard() {
   return (
-    <main className={styles.main}>
-      <h1 className={styles.heading}>Welcome to Aktonz</h1>
-
-      <p className={styles.subtitle}>Insights. Information. Control.</p>
-      <h2 className={styles.prompt}>Are you looking to...</h2>
-      <div className={styles.grid}>
-        <div className={styles.card}>
-          <h3>LET</h3>
-          <p>Manage your rental properties online</p>
-          <Link href="/landlords" className={styles.button}>
-            Get started now
+    <AccountLayout
+      heroSubtitle="Insights. Information. Control."
+      heroTitle="My lettings search"
+      heroDescription="London lettings is competitive but we are here to give you an advantage."
+      heroCta={{
+        label: "Let's get started",
+        href: '/to-rent',
+        secondary: { label: 'Talk to my team', href: '/contact' },
+      }}
+    >
+      <section className={styles.introCard}>
+        <div className={styles.introHeader}>
+          <div>
+            <h2>Register with us to jump the queue</h2>
+            <p>
+              Share a few details about the property you want so we can prioritise the homes that genuinely match what
+              you are searching for.
+            </p>
+          </div>
+          <Link href="/account/profile" className={styles.editLink}>
+            Update my preferences
           </Link>
-
         </div>
-        <div className={styles.card}>
-          <h3>SELL</h3>
-          <p>Stay in control of the sale of your home</p>
-          <Link href="/sell" className={styles.button}>
-            Get started now
-          </Link>
-
+        <div className={styles.registrationGrid}>
+          {REGISTRATION_CARDS.map((card) => (
+            <article key={card.label} className={styles.registrationTile}>
+              <span className={styles.fieldLabel}>{card.label}</span>
+              <span className={styles.fieldValue}>{card.value}</span>
+            </article>
+          ))}
         </div>
-        <div className={styles.card}>
-          <h3>RENT</h3>
-          <p>Rent a property online, start to finish</p>
-          <Link href="/to-rent" className={styles.button}>
-            Get started now
-          </Link>
+      </section>
 
+      <section className={styles.featureSection}>
+        <h3>Ready to get ahead of other tenants?</h3>
+        <div className={styles.featureGrid}>
+          {FEATURE_CARDS.map((card) => (
+            <article key={card.title} className={styles.featureCard}>
+              <h4 className={styles.featureTitle}>{card.title}</h4>
+              <p className={styles.featureDescription}>{card.copy}</p>
+              <Link href="/contact" className={styles.featureLink}>
+                Speak to an expert
+              </Link>
+            </article>
+          ))}
         </div>
-        <div className={styles.card}>
-          <h3>BUY</h3>
-          <p>See if you can stay ahead of other buyers</p>
-          <Link href="/for-sale" className={styles.button}>
-            Get started now
-          </Link>
+      </section>
 
+      <section className={styles.secondarySection}>
+        <div className={styles.secondaryContent}>
+          <h3>Not ready to make a move yet?</h3>
+          <p>
+            Save interesting properties and we will keep them close to hand. When the timing is right, you will have a
+            shortlist ready to view.
+          </p>
+          <div className={styles.secondaryActions}>
+            <Link href="/favourites" className={styles.secondaryButton}>
+              View my favourites
+            </Link>
+            <Link href="/for-sale" className={styles.secondaryLink}>
+              Browse homes for sale
+            </Link>
+          </div>
         </div>
-      </div>
-    </main>
+        <div className={styles.secondaryPanel}>
+          <div className={styles.secondaryBadge}>Tip</div>
+          <p className={styles.secondaryPanelText}>
+            Save at least three properties to help us spot similar homes and send smarter alerts.
+          </p>
+        </div>
+      </section>
+    </AccountLayout>
   );
 }
-

--- a/pages/account/profile.js
+++ b/pages/account/profile.js
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import Head from 'next/head';
+
+import AccountLayout from '../../components/account/AccountLayout';
 import styles from '../../styles/Profile.module.css';
 
 export default function Profile() {
@@ -15,41 +17,52 @@ export default function Profile() {
       <Head>
         <title>Update your contact details | Aktonz</title>
       </Head>
-      <main className={styles.main}>
-        <h1 className={styles.heading}>Update your contact details</h1>
-        <form onSubmit={handleSubmit} className={styles.form}>
-          <label htmlFor="title">Title</label>
-          <input id="title" name="title" type="text" />
+      <AccountLayout
+        heroSubtitle="Account settings"
+        heroTitle="Update your contact details"
+        heroDescription="Keep your details up to date so your Aktonz team can reach you quickly with the latest updates."
+        heroCta={{
+          label: 'View saved searches',
+          href: '/account/saved-searches',
+        }}
+      >
+        <section className={styles.profileCard}>
+          <h2 className={styles.heading}>Contact details</h2>
+          <form onSubmit={handleSubmit} className={styles.form}>
+            <label htmlFor="title">Title</label>
+            <input id="title" name="title" type="text" placeholder="Ms" />
 
-          <label htmlFor="firstName">First name</label>
-          <input id="firstName" name="firstName" type="text" />
+            <label htmlFor="firstName">First name</label>
+            <input id="firstName" name="firstName" type="text" placeholder="Juliet" />
 
-          <label htmlFor="surname">Surname</label>
-          <input id="surname" name="surname" type="text" />
+            <label htmlFor="surname">Surname</label>
+            <input id="surname" name="surname" type="text" placeholder="Taphouse" />
 
-          <label htmlFor="postcode">Postcode</label>
-          <input id="postcode" name="postcode" type="text" />
+            <label htmlFor="postcode">Postcode</label>
+            <input id="postcode" name="postcode" type="text" placeholder="E2 8AA" />
 
-          <label htmlFor="address">Address</label>
-          <input id="address" name="address" type="text" />
+            <label htmlFor="address">Address</label>
+            <input id="address" name="address" type="text" placeholder="Flat 3, 14 Vyner Street" />
 
-          <label htmlFor="mobilePhone">Mobile phone</label>
-          <input id="mobilePhone" name="mobilePhone" type="tel" />
+            <label htmlFor="mobilePhone">Mobile phone</label>
+            <input id="mobilePhone" name="mobilePhone" type="tel" placeholder="07 000 000000" />
 
-          <label htmlFor="homePhone">Home phone</label>
-          <input id="homePhone" name="homePhone" type="tel" />
+            <label htmlFor="homePhone">Home phone</label>
+            <input id="homePhone" name="homePhone" type="tel" placeholder="020 0000 0000" />
 
-          <label htmlFor="workPhone">Work phone</label>
-          <input id="workPhone" name="workPhone" type="tel" />
+            <label htmlFor="workPhone">Work phone</label>
+            <input id="workPhone" name="workPhone" type="tel" placeholder="020 0000 0000" />
 
-          <label htmlFor="email">Email address</label>
-          <input id="email" name="email" type="email" />
+            <label htmlFor="email">Email address</label>
+            <input id="email" name="email" type="email" placeholder="juliet@example.com" />
 
-          <button type="submit" className={styles.button}>Update contact details</button>
-        </form>
-        {status && <p className={styles.status}>{status}</p>}
-      </main>
+            <button type="submit" className={styles.button}>
+              Update contact details
+            </button>
+          </form>
+          {status ? <p className={styles.status}>{status}</p> : null}
+        </section>
+      </AccountLayout>
     </>
   );
 }
-

--- a/pages/account/saved-searches.js
+++ b/pages/account/saved-searches.js
@@ -1,4 +1,38 @@
-import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+import AccountLayout from '../../components/account/AccountLayout';
+import styles from '../../styles/SavedSearches.module.css';
+
+function humaniseKey(key = '') {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function normaliseValue(value) {
+  if (value === null || value === undefined || value === '') {
+    return 'Any';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normaliseValue(item)).join(', ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value)
+      .map(([k, v]) => `${humaniseKey(k)}: ${normaliseValue(v)}`)
+      .join(', ');
+  }
+  if (typeof value === 'number') {
+    return new Intl.NumberFormat('en-GB').format(value);
+  }
+  return String(value);
+}
 
 export default function SavedSearchesPage() {
   const [searches, setSearches] = useState([]);
@@ -34,23 +68,82 @@ export default function SavedSearchesPage() {
     }
   }
 
-  if (loading) return <p>Loading...</p>;
+  const content = useMemo(() => {
+    if (loading) {
+      return (
+        <div className={styles.stateCard}>
+          <p>Loading your saved searches...</p>
+        </div>
+      );
+    }
 
-  if (searches.length === 0) return <p>No saved searches</p>;
+    if (!searches.length) {
+      return (
+        <div className={styles.stateCard}>
+          <h2>No saved searches yet</h2>
+          <p>
+            Set your filters and save a search to receive alerts as soon as matching properties go live. You can create
+            as many searches as you like.
+          </p>
+          <Link href="/to-rent" className={styles.stateButton}>
+            Create a lettings search
+          </Link>
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.list}>
+        {searches.map((search) => {
+          const entries = Object.entries(search.params || {});
+          return (
+            <article key={search.id} className={styles.searchCard}>
+              <div className={styles.cardHeader}>
+                <h2>Lettings search</h2>
+                <span className={styles.savedOn}>Saved {new Date(Number(search.id)).toLocaleDateString('en-GB')}</span>
+              </div>
+              {entries.length ? (
+                <ul className={styles.paramList}>
+                  {entries.map(([key, value]) => (
+                    <li key={key} className={styles.paramBadge}>
+                      <span className={styles.paramKey}>{humaniseKey(key)}</span>
+                      <span className={styles.paramValue}>{normaliseValue(value)}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={styles.emptyParams}>We will use your default preferences for this search.</p>
+              )}
+              <div className={styles.cardActions}>
+                <Link href="/to-rent" className={styles.viewButton}>
+                  View matching homes
+                </Link>
+                <button
+                  type="button"
+                  className={styles.deleteButton}
+                  onClick={() => handleDelete(search.id)}
+                >
+                  Delete search
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    );
+  }, [loading, searches]);
 
   return (
-    <div>
-      <h1>Saved Searches</h1>
-      <ul>
-        {searches.map((s) => (
-          <li key={s.id}>
-            <code>{JSON.stringify(s.params)}</code>
-            <button type="button" onClick={() => handleDelete(s.id)}>
-              Delete
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <AccountLayout
+      heroSubtitle="My activity"
+      heroTitle="Saved searches"
+      heroDescription="Jump straight back into your favourite filters or tidy up the searches you no longer need."
+      heroCta={{
+        label: 'Create a new search',
+        href: '/to-rent',
+      }}
+    >
+      {content}
+    </AccountLayout>
   );
 }

--- a/styles/Account.module.css
+++ b/styles/Account.module.css
@@ -1,59 +1,251 @@
-.main {
-  padding: var(--spacing-xl) var(--spacing-lg);
-  text-align: center;
-}
-
-.heading {
-  font-size: 2rem;
-  margin-bottom: var(--spacing-sm);
-}
-
-
-.subtitle {
-  color: var(--color-muted-text);
-  margin-bottom: var(--spacing-xl);
-}
-
-.prompt {
-  margin-bottom: var(--spacing-lg);
-}
-
-.grid {
-  display: grid;
-  gap: var(--spacing-lg);
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  max-width: 1000px;
-  margin: 0 auto;
-}
-
-.card {
-  background: #e6f7f7;
-  padding: var(--spacing-lg);
-  border-radius: 8px;
+.introCard {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
-.card h3 {
-  margin-bottom: var(--spacing-md);
+.introHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
-.card p {
-  flex-grow: 1;
-  margin-bottom: var(--spacing-md);
+.introHeader h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 3vw, 1.95rem);
+  color: #16312d;
 }
 
-.button {
-  background: var(--color-accent);
-  color: var(--color-text);
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: 4px;
+.introHeader p {
+  margin: 0;
+  color: #486561;
+  max-width: 620px;
+  line-height: 1.6;
+}
+
+.editLink {
+  align-self: center;
+  background: #0b7c6d;
+  color: #ffffff;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
   text-decoration: none;
-  font-weight: bold;
+  box-shadow: 0 18px 30px rgba(11, 124, 109, 0.18);
+  transition: background 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
 }
 
-.button:hover {
-  opacity: 0.85;
+.editLink:hover,
+.editLink:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
+}
+
+.registrationGrid {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.registrationTile {
+  background: linear-gradient(135deg, #f4fbf9 0%, #ebf7f4 100%);
+  border-radius: 16px;
+  padding: 1.15rem;
+  border: 1px solid #cde4e0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fieldLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  color: #6f8f89;
+  font-weight: 600;
+}
+
+.fieldValue {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #1d3834;
+}
+
+.featureSection {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+}
+
+.featureSection h3 {
+  margin: 0 0 1.75rem;
+  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
+  color: #16312d;
+}
+
+.featureGrid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.featureCard {
+  background: linear-gradient(150deg, rgba(11, 124, 109, 0.09) 0%, rgba(236, 248, 245, 0.9) 100%);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(11, 124, 109, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 220px;
+}
+
+.featureTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #16312d;
+}
+
+.featureDescription {
+  margin: 0;
+  color: #486561;
+  line-height: 1.6;
+  flex-grow: 1;
+}
+
+.featureLink {
+  color: #0b7c6d;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.featureLink::after {
+  content: ' →';
+}
+
+.secondarySection {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  align-items: center;
+}
+
+.secondaryContent h3 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  color: #16312d;
+}
+
+.secondaryContent p {
+  margin: 0 0 1.5rem;
+  color: #486561;
+  line-height: 1.6;
+}
+
+.secondaryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+}
+
+.secondaryButton {
+  background: #0b7c6d;
+  color: #ffffff;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
+}
+
+.secondaryLink {
+  color: #0b7c6d;
+  font-weight: 600;
+  text-decoration: none;
+  align-self: center;
+}
+
+.secondaryLink::after {
+  content: ' →';
+}
+
+.secondaryPanel {
+  background: #f3fbf9;
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px dashed #0b7c6d;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.secondaryBadge {
+  background: #0b7c6d;
+  color: #ffffff;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.secondaryPanelText {
+  margin: 0;
+  color: #16312d;
+  line-height: 1.6;
+}
+
+@media (max-width: 960px) {
+  .secondarySection {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .introHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .editLink {
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .featureCard {
+    min-height: 0;
+  }
+
+  .secondaryActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .secondaryButton {
+    text-align: center;
+  }
 }

--- a/styles/AccountLayout.module.css
+++ b/styles/AccountLayout.module.css
@@ -1,0 +1,322 @@
+.accountPage {
+  min-height: 100vh;
+  background: #eef7f6;
+  color: #1e3a37;
+}
+
+.header {
+  background: #ffffff;
+  border-bottom: 1px solid #d3e5e2;
+  box-shadow: 0 8px 24px rgba(13, 86, 75, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topBar {
+  display: flex;
+  align-items: center;
+  gap: 2.5rem;
+  padding: 1.25rem clamp(1.5rem, 5vw, 3.5rem);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  font-weight: 700;
+  color: #0b7c6d;
+  font-size: 1.125rem;
+}
+
+.brandMark {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: #0b7c6d;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.brandText {
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.primaryNav {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2.25rem);
+  flex: 1;
+  min-width: 0;
+}
+
+.primaryNavItem {
+  display: inline-flex;
+  align-items: center;
+  height: 48px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #3c5d58;
+  text-decoration: none;
+  border-bottom: 3px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+}
+
+.primaryNavItem:hover,
+.primaryNavItem:focus-visible {
+  color: #0b7c6d;
+}
+
+.primaryNavItemActive {
+  color: #0b7c6d;
+  border-bottom-color: #0b7c6d;
+}
+
+.primaryNavItemDisabled {
+  color: #9bb5b1;
+  cursor: not-allowed;
+}
+
+.userMenu {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #f1faf8;
+  padding: 0.5rem 0.9rem 0.5rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid #cbe3df;
+}
+
+.userInitial {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #0b7c6d;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.userDetails {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.userName {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f3834;
+}
+
+.userStatus {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #6d8e88;
+}
+
+.userCaret {
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: none;
+  position: relative;
+  cursor: pointer;
+}
+
+.userCaret::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid #3c5d58;
+  border-bottom: 2px solid #3c5d58;
+  transform: translate(-50%, -25%) rotate(45deg);
+}
+
+.hero {
+  background: linear-gradient(135deg, #e3f5f3 0%, #f5fbf9 100%);
+  border-top: 1px solid #d3e5e2;
+  border-bottom: 1px solid #d3e5e2;
+}
+
+.heroContent {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 5vw, 3.5rem);
+}
+
+.heroEyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #0b7c6d;
+  margin-bottom: 0.75rem;
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.75rem);
+  color: #16312d;
+}
+
+.heroDescription {
+  margin: 0.75rem 0 1.5rem;
+  max-width: 580px;
+  color: #41635d;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.heroButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b7c6d;
+  color: #ffffff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 15px 30px rgba(11, 124, 109, 0.2);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.heroButton:hover,
+.heroButton:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
+}
+
+.heroLink {
+  color: #0b7c6d;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.heroLink::after {
+  content: ' →';
+}
+
+.tabNav {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 4vw, 2.5rem);
+  padding: 0 clamp(1.5rem, 5vw, 3.5rem);
+  overflow-x: auto;
+  background: #ffffff;
+}
+
+.tabNavItem {
+  display: inline-flex;
+  align-items: center;
+  height: 62px;
+  font-weight: 600;
+  color: #4f6d67;
+  border-bottom: 3px solid transparent;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.tabNavItem:hover,
+.tabNavItem:focus-visible {
+  color: #0b7c6d;
+}
+
+.tabNavItemActive {
+  color: #0b7c6d;
+  border-bottom-color: #0b7c6d;
+}
+
+.tabNavItemDisabled {
+  color: #9bb5b1;
+  cursor: not-allowed;
+}
+
+.content {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.5rem) clamp(1.5rem, 5vw, 3.5rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+@media (max-width: 960px) {
+  .topBar {
+    flex-wrap: wrap;
+    gap: 1.25rem;
+  }
+
+  .primaryNav {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
+
+  .userMenu {
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .primaryNav {
+    gap: 1.25rem;
+  }
+
+  .primaryNavItem {
+    height: 42px;
+    font-size: 0.9rem;
+  }
+
+  .heroContent {
+    text-align: left;
+  }
+
+  .heroTitle {
+    font-size: clamp(1.75rem, 8vw, 2.2rem);
+  }
+
+  .heroActions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .userMenu {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 480px) {
+  .topBar {
+    padding: 1rem 1.25rem;
+  }
+
+  .content {
+    padding-bottom: 3rem;
+  }
+}

--- a/styles/Profile.module.css
+++ b/styles/Profile.module.css
@@ -1,28 +1,81 @@
-.main {
-  max-width: 600px;
+.profileCard {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  max-width: 760px;
   margin: 0 auto;
-  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .heading {
-  margin-bottom: 1.5rem;
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  color: #16312d;
+  text-align: center;
 }
 
 .form {
   display: grid;
-  gap: 0.5rem;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form label {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #6f8f89;
+}
+
+.form input {
+  border-radius: 12px;
+  border: 1px solid #cfe6e1;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  background: #f8fcfb;
+  color: #1d3834;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form input:focus {
+  outline: none;
+  border-color: #0b7c6d;
+  box-shadow: 0 0 0 3px rgba(11, 124, 109, 0.2);
 }
 
 .button {
-  margin-top: 1rem;
-  padding: 0.75rem 1rem;
-  background-color: #0070f3;
-  color: white;
+  grid-column: 1 / -1;
+  justify-self: center;
+  background: #0b7c6d;
+  color: #ffffff;
   border: none;
+  border-radius: 999px;
+  padding: 0.85rem 2.6rem;
+  font-weight: 600;
   cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
 }
 
 .status {
-  margin-top: 1rem;
-  color: green;
+  margin: 0;
+  text-align: center;
+  font-weight: 600;
+  color: #0b7c6d;
+}
+
+@media (max-width: 560px) {
+  .button {
+    width: 100%;
+  }
 }

--- a/styles/SavedSearches.module.css
+++ b/styles/SavedSearches.module.css
@@ -1,0 +1,165 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.searchCard {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cardHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.cardHeader h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+  color: #16312d;
+}
+
+.savedOn {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #6f8f89;
+}
+
+.paramList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.paramBadge {
+  background: #f1faf8;
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  border: 1px solid #cde4e0;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: baseline;
+  font-size: 0.9rem;
+}
+
+.paramKey {
+  font-weight: 600;
+  color: #16312d;
+}
+
+.paramValue {
+  color: #486561;
+}
+
+.emptyParams {
+  margin: 0;
+  color: #486561;
+  font-style: italic;
+}
+
+.cardActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.viewButton {
+  background: #0b7c6d;
+  color: #ffffff;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.viewButton:hover,
+.viewButton:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
+}
+
+.deleteButton {
+  background: none;
+  border: none;
+  color: #c2453d;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 0.25rem;
+}
+
+.deleteButton:hover,
+.deleteButton:focus-visible {
+  color: #a2322a;
+}
+
+.stateCard {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #cde4e0;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.stateCard h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  color: #16312d;
+}
+
+.stateCard p {
+  margin: 0;
+  color: #486561;
+  max-width: 520px;
+  line-height: 1.6;
+}
+
+.stateButton {
+  background: #0b7c6d;
+  color: #ffffff;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.stateButton:hover,
+.stateButton:focus-visible {
+  background: #095f52;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 560px) {
+  .cardActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viewButton,
+  .stateButton {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable account layout with Foxtons-inspired header, hero, and tab navigation
- restyle the account overview with richer cards, actions, and supporting content
- bring the profile and saved searches pages into the new layout with updated styling and helper formatting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d215a0d8f8832e95412d4c3e69fb60