### PR TITLE
Fetch Scraye listing details for full media coverage

### DIFF
--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -64,6 +64,128 @@ function formatFeature(value) {
     .join(' ');
 }
 
+function normalizeScrayeImageEntry(entry) {
+  if (!entry) return null;
+
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim();
+    return trimmed
+      ? {
+          id: null,
+          url: trimmed,
+          altText: null,
+        }
+      : null;
+  }
+
+  if (typeof entry === 'object') {
+    const potentialUrlFields = [
+      entry.url,
+      entry.imageUrl,
+      entry.mediaUrl,
+      entry.filename,
+    ];
+
+    let url = null;
+    for (const value of potentialUrlFields) {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed && (trimmed.startsWith('http://') || trimmed.startsWith('https://'))) {
+          url = trimmed;
+          break;
+        }
+      }
+    }
+
+    if (!url) {
+      return null;
+    }
+
+    const altCandidates = [entry.altText, entry.caption, entry.tag];
+    let altText = null;
+    for (const candidate of altCandidates) {
+      if (typeof candidate === 'string') {
+        const trimmed = candidate.trim();
+        if (trimmed) {
+          altText = trimmed;
+          break;
+        }
+      }
+    }
+
+    const id =
+      entry.id ??
+      (typeof entry.publicId === 'string' ? entry.publicId : null) ??
+      null;
+
+    return {
+      id,
+      url,
+      altText,
+    };
+  }
+
+  return null;
+}
+
+function mergeScrayeImages(...groups) {
+  const seen = new Set();
+  const images = [];
+
+  for (const group of groups) {
+    if (!Array.isArray(group)) continue;
+    for (const entry of group) {
+      const normalized = normalizeScrayeImageEntry(entry);
+      if (!normalized || !normalized.url) continue;
+      if (seen.has(normalized.url)) continue;
+      seen.add(normalized.url);
+      images.push(normalized);
+    }
+  }
+
+  return images;
+}
+
+function extractScrayeImagesFromNode(node) {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+
+  const fileImages = Array.isArray(node.files)
+    ? node.files.filter((file) => {
+        if (!file) return false;
+        if (typeof file.filename !== 'string') return false;
+
+        const filename = file.filename.toLowerCase();
+        const tag = typeof file.tag === 'string' ? file.tag.toLowerCase() : '';
+
+        const isNonImageTag =
+          tag.includes('floorplan') ||
+          tag.includes('epc') ||
+          tag.includes('brochure') ||
+          tag.includes('virtual') ||
+          tag.includes('tour');
+        if (isNonImageTag) return false;
+
+        const isNonImageFilename =
+          filename.includes('floorplan') ||
+          filename.includes('epc') ||
+          filename.includes('brochure');
+        if (isNonImageFilename) return false;
+
+        if (!tag) return true;
+
+        return (
+          tag.includes('image') ||
+          tag.includes('photo') ||
+          tag.includes('picture')
+        );
+      })
+    : [];
+
+  return mergeScrayeImages(node.images, node.illustrativeImages, fileImages);
+}
+
 async function scrayeFetch(operations, { pathname, searchTerm } = {}) {
   const headers = {
     'content-type': 'application/json',
@@ -123,6 +245,32 @@ function buildFilter(type) {
     instantViewingsEnabled: null,
     agencyId: null,
   };
+}
+
+async function enrichScrayeListingsWithDetails(listings) {
+  if (!Array.isArray(listings) || listings.length === 0) {
+    return Array.isArray(listings) ? listings : [];
+  }
+
+  const enriched = [];
+  for (const listing of listings) {
+    if (!listing?.id) {
+      enriched.push(listing);
+      continue;
+    }
+
+    try {
+      const detailed = await fetchScrayeListingById(listing.id, {
+        cachedListings: listings,
+      });
+      enriched.push(detailed ?? listing);
+    } catch (error) {
+      console.warn(`Failed to load Scraye listing ${listing.id}`, error);
+      enriched.push(listing);
+    }
+  }
+
+  return enriched;
 }
 
 const RESULTS_QUERY = `
@@ -346,19 +494,7 @@ function normalizeListingNode(node, context) {
       ? formatPriceGBP(priceValue, { isSale })
       : null;
 
-  const images = Array.isArray(node.images)
-    ? node.images
-        .map((img) =>
-          img && img.url
-            ? {
-                id: img.id ?? null,
-                url: img.url,
-                altText: img.altText ?? null,
-              }
-            : null
-        )
-        .filter(Boolean)
-    : [];
+  const images = extractScrayeImagesFromNode(node);
 
   const features = Array.isArray(node.features)
     ? node.features.map((feature) => formatFeature(feature)).filter(Boolean)
@@ -551,7 +687,8 @@ export async function fetchScrayeListings({
     } while (after && (typeof maxPages !== 'number' || page < maxPages));
   }
 
-  return Array.from(results.values());
+  const baseListings = Array.from(results.values());
+  return enrichScrayeListingsWithDetails(baseListings);
 }
 
 export async function fetchScrayeListingById(id, { cachedListings = [] } = {}) {


### PR DESCRIPTION
## Summary
- normalize Scraye image payloads and merge illustrative and file-based images while filtering non-media attachments
- add a detail-enrichment pass so each listing pulls full Scraye descriptions and image galleries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d217f5a880832e94b34f439c7407c8