### PR TITLE
Prioritize available rentals on to-rent page

### DIFF
--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -506,9 +506,25 @@ export async function getStaticProps() {
     statuses: ['available', 'under_offer', 'let_agreed', 'let', 'let_stc', 'let_by'],
   });
 
-  const properties = raw.slice(0, 50).map((property) => ({
+  const available = [];
+  const archived = [];
+
+  raw.forEach((property) => {
+    if (property && typeof property === 'object') {
+      const status = normalizeStatus(property.status);
+      if (status.includes('let')) {
+        archived.push(property);
+      } else {
+        available.push(property);
+      }
+    }
+  });
+
+  const prioritized = available.concat(archived.slice(0, 40));
+
+  const properties = prioritized.map((property) => ({
     ...property,
-    images: (property.images || []).slice(0, 3),
+    images: Array.isArray(property.images) ? property.images.slice(0, 3) : [],
     description: property.description ? property.description.slice(0, 200) : '',
   }));
 


### PR DESCRIPTION
## Summary
- prioritise available rental listings before recently-let entries when building static props
- cap archived rentals while keeping the full set of available homes and normalise image arrays defensively

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21bb7fa60832e8c1e1d39d0d812a6