### PR TITLE
Hide global header on account pages

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,19 +4,23 @@ import 'slick-carousel/slick/slick-theme.css';
 import '../styles/carousel.css';
 import '../styles/leaflet.css';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import ChatWidget from '../components/ChatWidget';
 import { SessionProvider } from '../components/SessionProvider';
 
 export default function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+  const showHeader = !router.pathname.startsWith('/account');
+
   return (
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <SessionProvider>
-        <Header />
+        {showHeader ? <Header /> : null}
         <Component {...pageProps} />
         <Footer />
         <ChatWidget />


### PR DESCRIPTION
## Summary
- hide the main site header whenever viewing routes under /account

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32cf51918832eac081bb89d76a7a3