### PR TITLE
Add AI-driven live support chat assistant

### DIFF
--- a/components/ChatWidget.js
+++ b/components/ChatWidget.js
@@ -1,26 +1,834 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  FaCalendarAlt,
+  FaCheckCircle,
+  FaComments,
+  FaPaperPlane,
+  FaRobot,
+  FaTimes,
+} from 'react-icons/fa';
+
+import agents from '../data/agents.json';
+import supportData from '../data/ai-support.json';
+import styles from '../styles/ChatWidget.module.css';
+
+const STOP_WORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'from',
+  'that',
+  'this',
+  'what',
+  'have',
+  'need',
+  'show',
+  'listings',
+  'listing',
+  'properties',
+  'property',
+  'please',
+  'about',
+  'tell',
+  'help',
+  'find',
+  'any',
+  'are',
+  'there',
+  'do',
+  'you',
+  'me',
+  'my',
+  'of',
+  'on',
+  'up',
+  'to',
+  'in',
+  'a',
+  'an',
+  'is',
+]);
+
+const createSearchText = (listing) =>
+  [
+    listing.id,
+    listing.title,
+    listing.address,
+    listing.area,
+    listing.summary,
+    listing.price,
+    listing.transactionType,
+    listing.status,
+    listing.tags?.join(' '),
+    listing.bedrooms ? `${listing.bedrooms} bed` : null,
+    listing.bathrooms ? `${listing.bathrooms} bath` : null,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+const createKnowledgeBase = () => {
+  const agentMap = new Map(agents.map((agent) => [String(agent.id), agent]));
+
+  const team = (supportData.teamNotes || []).map((note) => {
+    const linkedAgent = agentMap.get(String(note.id));
+    return {
+      id: note.id,
+      name: linkedAgent?.name || note.name || 'Aktonz advisor',
+      phone: linkedAgent?.phone,
+      bio: linkedAgent?.bio,
+      role: note.role,
+      focus: note.focus || [],
+      email: note.email || linkedAgent?.email,
+    };
+  });
+
+  const listings = (supportData.listings || []).map((listing) => ({
+    ...listing,
+    transactionType: listing.transactionType || 'rent',
+    searchText: createSearchText(listing),
+  }));
+  const listingMap = new Map(listings.map((listing) => [listing.id, listing]));
+
+  const contacts = (supportData.contacts || []).map((contact) => {
+    const preferredAgent = agentMap.get(String(contact.preferredAgentId));
+    const timeline = (contact.conversations || [])
+      .map((event) => ({
+        ...event,
+        agent: agentMap.get(String(event.agentId)) || preferredAgent || null,
+      }))
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+    return {
+      ...contact,
+      agent: preferredAgent || null,
+      timeline,
+      lastInteraction: timeline[0] || null,
+      relatedListings: (contact.relatedListings || [])
+        .map((id) => listingMap.get(id))
+        .filter(Boolean),
+    };
+  });
+
+  const contactMap = new Map(contacts.map((contact) => [contact.id, contact]));
+
+  const appointments = (supportData.appointments || [])
+    .map((appointment) => ({
+      ...appointment,
+      contact: contactMap.get(appointment.contactId) || null,
+      agent: agentMap.get(String(appointment.agentId)) || null,
+      property: appointment.propertyId ? listingMap.get(appointment.propertyId) || null : null,
+    }))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  const viewings = (supportData.viewings || [])
+    .map((viewing) => ({
+      ...viewing,
+      contact: contactMap.get(viewing.contactId) || null,
+      agent: agentMap.get(String(viewing.agentId)) || null,
+      property: listingMap.get(viewing.propertyId) || null,
+    }))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  const offers = (supportData.offers || [])
+    .map((offer) => {
+      const contact = contactMap.get(offer.contactId) || null;
+      return {
+        ...offer,
+        contact,
+        property: listingMap.get(offer.propertyId) || null,
+        agent: contact?.agent || null,
+      };
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  return {
+    company: supportData.company,
+    team,
+    agents: Array.from(agentMap.values()),
+    listings,
+    contacts,
+    appointments,
+    viewings,
+    offers,
+  };
+};
+
+const searchListings = (input, knowledge) => {
+  const lower = input.toLowerCase();
+  const tokens = lower.split(/[^a-z0-9]+/).filter(Boolean);
+  const rentFocus = /(rent|letting|tenant)/.test(lower);
+  const saleFocus = /(buy|sale|selling|purchase|vendor)/.test(lower);
+  const bedroomMatch = lower.match(/(\d+)\s*(?:bed|bedroom)/);
+  const desiredBedrooms = bedroomMatch ? Number(bedroomMatch[1]) : null;
+
+  const focusedTokens = tokens.filter((token) => token.length > 2 && !STOP_WORDS.has(token));
+  const tokenGroups = focusedTokens.length ? [focusedTokens, tokens] : [tokens];
+  let matches = [];
+
+  for (const group of tokenGroups) {
+    if (!group.length) continue;
+    matches = knowledge.listings.filter((listing) => {
+      if (rentFocus && listing.transactionType !== 'rent') return false;
+      if (saleFocus && listing.transactionType !== 'sale') return false;
+      if (desiredBedrooms && listing.bedrooms && listing.bedrooms < desiredBedrooms) return false;
+      return group.some((token) => listing.searchText.includes(token));
+    });
+    if (matches.length) break;
+  }
+
+  if (!matches.length) {
+    matches = knowledge.listings.filter((listing) => {
+      if (rentFocus && listing.transactionType !== 'rent') return false;
+      if (saleFocus && listing.transactionType !== 'sale') return false;
+      if (desiredBedrooms && listing.bedrooms && listing.bedrooms < desiredBedrooms) return false;
+      return true;
+    });
+  }
+
+  return matches.slice(0, 3);
+};
+
+const createBotReplies = (input, knowledge, formatters) => {
+  const lower = input.toLowerCase();
+  const now = new Date();
+  const replies = [];
+
+  const matchedContact = knowledge.contacts.find((contact) => {
+    const name = contact.name.toLowerCase();
+    const firstName = name.split(' ')[0];
+    return lower.includes(name) || lower.includes(firstName);
+  });
+
+  if (matchedContact) {
+    const lastTouch = matchedContact.lastInteraction
+      ? formatters.describeRecency(new Date(matchedContact.lastInteraction.date))
+      : null;
+
+    replies.push({
+      from: 'bot',
+      type: 'text',
+      text: `Here's the latest on ${matchedContact.name}: ${matchedContact.stage}. ${matchedContact.summary} ${
+        lastTouch ? `We last spoke ${lastTouch} via ${matchedContact.lastInteraction.channel.toLowerCase()}.` : ''
+      }`,
+    });
+
+    replies.push({
+      from: 'bot',
+      type: 'timeline',
+      contact: matchedContact,
+      events: matchedContact.timeline.slice(0, 5),
+    });
+
+    if (matchedContact.relatedListings.length) {
+      replies.push({
+        from: 'bot',
+        type: 'listings',
+        title: `${matchedContact.name}'s active shortlist`,
+        listings: matchedContact.relatedListings,
+      });
+    }
+
+    return replies;
+  }
+
+  if (lower.includes('conversation') || lower.includes('interaction') || lower.includes('history')) {
+    replies.push({
+      from: 'bot',
+      type: 'text',
+      text: 'Here are the latest touchpoints across your active clients.',
+    });
+    replies.push({
+      from: 'bot',
+      type: 'contacts',
+      contacts: knowledge.contacts,
+    });
+    return replies;
+  }
+
+  if (/(appointment|meeting|consult|call)/.test(lower)) {
+    const upcoming = knowledge.appointments.filter((appt) => new Date(appt.date) >= now);
+    if (upcoming.length) {
+      replies.push({
+        from: 'bot',
+        type: 'events',
+        title: 'Upcoming appointments',
+        items: upcoming.map((appt) => ({
+          id: appt.id,
+          title: `${appt.type} with ${appt.contact?.name || 'client'}`,
+          time: formatters.formatDateTime(appt.date),
+          description: appt.notes,
+          meta: appt.location,
+        })),
+      });
+    } else {
+      replies.push({
+        from: 'bot',
+        type: 'text',
+        text: "You don't have any future appointments in the diary.",
+      });
+    }
+    return replies;
+  }
+
+  if (/(viewing|tour|inspection)/.test(lower)) {
+    const upcoming = knowledge.viewings.filter((viewing) => new Date(viewing.date) >= now);
+    if (upcoming.length) {
+      replies.push({
+        from: 'bot',
+        type: 'events',
+        title: 'Scheduled viewings',
+        items: upcoming.map((viewing) => ({
+          id: viewing.id,
+          title: `${viewing.property?.title || 'Viewing'} with ${viewing.contact?.name || 'client'}`,
+          time: formatters.formatDateTime(viewing.date),
+          description: viewing.notes,
+          meta: viewing.status,
+        })),
+      });
+    } else {
+      replies.push({
+        from: 'bot',
+        type: 'text',
+        text: 'No live viewings are booked right now. Let me know if you would like to arrange one.',
+      });
+    }
+    return replies;
+  }
+
+  if (/(offer|negotiation|deal|accepted|rejected)/.test(lower)) {
+    if (knowledge.offers.length) {
+      replies.push({
+        from: 'bot',
+        type: 'events',
+        title: 'Offer pipeline',
+        items: knowledge.offers.map((offer) => ({
+          id: offer.id,
+          title: `${offer.contact?.name || 'Client'} — ${offer.amount}`,
+          time: formatters.formatDateTime(offer.date),
+          description: `${offer.property?.title || 'Property'} • ${offer.status}`,
+          meta: offer.notes,
+        })),
+      });
+    } else {
+      replies.push({
+        from: 'bot',
+        type: 'text',
+        text: 'There are no open offers recorded today.',
+      });
+    }
+    return replies;
+  }
+
+  if (/(contact|client|landlord|tenant|buyer|seller)/.test(lower)) {
+    replies.push({
+      from: 'bot',
+      type: 'contacts',
+      contacts: knowledge.contacts,
+    });
+    return replies;
+  }
+
+  if (/(team|agent|advisor|negotiator|who can i speak)/.test(lower)) {
+    replies.push({
+      from: 'bot',
+      type: 'text',
+      text: 'Your dedicated Aktonz advisors are on hand for lettings, sales and portfolio strategy.',
+    });
+    replies.push({
+      from: 'bot',
+      type: 'team',
+      members: knowledge.team,
+    });
+    return replies;
+  }
+
+  if (
+    /(company|aktonz|service|landlord service|sell my home|manage|management|what do you do)/.test(
+      lower,
+    )
+  ) {
+    const company = knowledge.company;
+    const services = (company?.services || []).map((service) => `• ${service}`).join('\n');
+    replies.push({
+      from: 'bot',
+      type: 'text',
+      text: `${company.name} — ${company.tagline}.\n${company.mission}\n\n${services}\n\nWe're based at ${company.office.address}. Call ${company.office.phone} or email ${company.office.email}.`,
+    });
+    return replies;
+  }
+
+  if (/(account|login|profile|preferences|saved search|dashboard)/.test(lower)) {
+    replies.push({
+      from: 'bot',
+      type: 'text',
+      text: 'Jump into your account dashboard to adjust search preferences, manage saved searches and review recent activity. The profile area keeps your details and move-in timeline accurate for the team.',
+    });
+    return replies;
+  }
+
+  if (/(listing|property|home|flat|apartment|house|rent|sale|buy|selling)/.test(lower)) {
+    const results = searchListings(input, knowledge);
+    if (results.length) {
+      const contextLabel = /(sale|buy|selling)/.test(lower)
+        ? 'sales'
+        : /(rent|letting|tenant)/.test(lower)
+          ? 'rental'
+          : 'standout';
+      replies.push({
+        from: 'bot',
+        type: 'text',
+        text: `Here are ${results.length} ${contextLabel} options that fit what you described.`,
+      });
+      replies.push({
+        from: 'bot',
+        type: 'listings',
+        listings: results,
+      });
+    } else {
+      replies.push({
+        from: 'bot',
+        type: 'text',
+        text: "I couldn't find an exact match yet, but share a little more detail and I'll curate a shortlist.",
+      });
+    }
+    return replies;
+  }
+
+  replies.push({
+    from: 'bot',
+    type: 'text',
+    text: "I'm the Aktonz digital assistant. Ask me about your clients, appointments, offers or any listings and I'll bring the right details into the chat.",
+  });
+
+  return replies;
+};
 
 export default function ChatWidget() {
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const knowledge = useMemo(() => createKnowledgeBase(), []);
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState(() => [
+    {
+      id: 'welcome-1',
+      from: 'bot',
+      type: 'text',
+      text: "Hi, I'm the Aktonz Intelligent Digital Assistant. How can I help today?",
+    },
+    {
+      id: 'welcome-2',
+      from: 'bot',
+      type: 'text',
+      text: 'Ask about your clients, upcoming viewings, offers or our latest listings.',
+    },
+  ]);
+  const [inputValue, setInputValue] = useState('');
+  const [isTyping, setIsTyping] = useState(false);
+  const scrollRef = useRef(null);
+  const typingTimeoutRef = useRef();
 
-    const propertyId = process.env.NEXT_PUBLIC_TAWKTO_PROPERTY_ID;
-    if (!propertyId) return;
+  const dateTimeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-GB', {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
+    [],
+  );
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-GB', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      }),
+    [],
+  );
 
-    window.Tawk_API = window.Tawk_API || {};
-    window.Tawk_LoadStart = new Date();
+  const formatDateTime = useCallback((value) => dateTimeFormatter.format(new Date(value)), [dateTimeFormatter]);
+  const formatDate = useCallback((value) => dateFormatter.format(new Date(value)), [dateFormatter]);
 
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = `https://embed.tawk.to/${propertyId}/default`;
-    script.charset = 'UTF-8';
-    script.setAttribute('crossorigin', '*');
-    document.body.appendChild(script);
+  const describeRecency = useCallback((date) => {
+    const now = Date.now();
+    const diff = now - date.getTime();
 
-    return () => {
-      document.body.removeChild(script);
-    };
+    if (diff < 0) {
+      const future = Math.abs(diff);
+      const hours = Math.round(future / (1000 * 60 * 60));
+      if (hours < 24) {
+        return `in ${hours <= 1 ? 'about an hour' : `${hours} hours`}`;
+      }
+      const days = Math.round(future / (1000 * 60 * 60 * 24));
+      return `in ${days === 1 ? 'a day' : `${days} days`}`;
+    }
+
+    const minutes = Math.round(diff / (1000 * 60));
+    if (minutes <= 1) return 'just now';
+    if (minutes < 60) return `${minutes} minutes ago`;
+
+    const hours = Math.round(diff / (1000 * 60 * 60));
+    if (hours < 24) return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
+
+    const days = Math.round(diff / (1000 * 60 * 60 * 24));
+    if (days < 7) return `${days} ${days === 1 ? 'day' : 'days'} ago`;
+
+    const weeks = Math.round(days / 7);
+    if (weeks < 4) return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
+
+    const months = Math.round(days / 30);
+    return `${months} ${months === 1 ? 'month' : 'months'} ago`;
   }, []);
 
-  return null;
+  const buildReplies = useCallback(
+    (input) => createBotReplies(input, knowledge, { formatDateTime, formatDate, describeRecency }),
+    [knowledge, formatDateTime, formatDate, describeRecency],
+  );
+
+  const sendMessage = useCallback(
+    (providedText) => {
+      const text = (typeof providedText === 'string' ? providedText : inputValue).trim();
+      if (!text) return;
+
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+
+      const userMessage = {
+        id: `user-${Date.now()}`,
+        from: 'user',
+        type: 'text',
+        text,
+      };
+
+      setMessages((prev) => [...prev, userMessage]);
+      setInputValue('');
+      setIsTyping(true);
+
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current);
+      }
+
+      typingTimeoutRef.current = setTimeout(() => {
+        const replies = buildReplies(text).map((reply, index) => ({
+          ...reply,
+          from: 'bot',
+          id: `${reply.type}-${Date.now()}-${index}`,
+        }));
+        setMessages((prev) => [...prev, ...replies]);
+        setIsTyping(false);
+      }, 450);
+    },
+    [inputValue, buildReplies, isOpen],
+  );
+
+  useEffect(() => () => typingTimeoutRef.current && clearTimeout(typingTimeoutRef.current), []);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, isTyping]);
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  const suggestions = useMemo(
+    () => [
+      'Show me my upcoming appointments',
+      'What viewings are booked?',
+      "Give me Sophie Turner's conversation history",
+      'Which offers are still pending?',
+      'Find me a two bedroom rental in Shoreditch',
+    ],
+    [],
+  );
+
+  const renderMessageContent = useCallback(
+    (message) => {
+      if (message.type === 'text') {
+        return message.text.split('\n').map((line, index) => (
+          <p key={index} className={styles.textLine}>
+            {line}
+          </p>
+        ));
+      }
+
+      if (message.type === 'listings') {
+        return (
+          <div className={styles.sectionContent}>
+            {message.title ? <p className={styles.sectionTitle}>{message.title}</p> : null}
+            <ul className={styles.listingList}>
+              {message.listings.map((listing) => {
+                const metaParts = [];
+                if (listing.bedrooms) metaParts.push(`${listing.bedrooms} bed`);
+                if (listing.transactionType === 'rent') metaParts.push('To let');
+                if (listing.transactionType === 'sale') metaParts.push('For sale');
+                if (listing.status) metaParts.push(listing.status);
+                return (
+                  <li key={listing.id} className={styles.listingItem}>
+                    <div className={styles.listingHeader}>
+                      <strong>{listing.title}</strong>
+                      <span className={styles.listingPrice}>{listing.price}</span>
+                    </div>
+                    <div className={styles.listingAddress}>{listing.address}</div>
+                    {metaParts.length ? (
+                      <div className={styles.listingMeta}>{metaParts.join(' • ')}</div>
+                    ) : null}
+                    {listing.summary ? <p className={styles.listingSummary}>{listing.summary}</p> : null}
+                    {listing.link ? (
+                      <a
+                        className={styles.listingLink}
+                        href={listing.link}
+                        target={listing.link.startsWith('http') ? '_blank' : '_self'}
+                        rel={listing.link.startsWith('http') ? 'noopener noreferrer' : undefined}
+                      >
+                        View details
+                      </a>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      }
+
+      if (message.type === 'events') {
+        return (
+          <div className={styles.sectionContent}>
+            {message.title ? <p className={styles.sectionTitle}>{message.title}</p> : null}
+            <ul className={styles.eventList}>
+              {message.items.map((item) => (
+                <li key={item.id} className={styles.eventItem}>
+                  <div className={styles.eventTime}>
+                    <FaCalendarAlt aria-hidden="true" /> {item.time}
+                  </div>
+                  <div className={styles.eventTitle}>{item.title}</div>
+                  {item.meta ? <div className={styles.eventMeta}>{item.meta}</div> : null}
+                  {item.description ? <p className={styles.eventDescription}>{item.description}</p> : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      if (message.type === 'contacts') {
+        return (
+          <div className={styles.sectionContent}>
+            <p className={styles.sectionTitle}>Active contacts</p>
+            <ul className={styles.contactList}>
+              {message.contacts.map((contact) => (
+                <li key={contact.id} className={styles.contactItem}>
+                  <div className={styles.contactHeader}>
+                    <strong>{contact.name}</strong>
+                    <span className={styles.contactStage}>{contact.stage}</span>
+                  </div>
+                  <div className={styles.contactFocus}>{contact.searchFocus}</div>
+                  {contact.lastInteraction ? (
+                    <div className={styles.contactMeta}>
+                      Last spoke {describeRecency(new Date(contact.lastInteraction.date))} via {contact.lastInteraction.channel}
+                    </div>
+                  ) : null}
+                  {contact.agent ? (
+                    <div className={styles.contactMeta}>Handled by {contact.agent.name}</div>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      if (message.type === 'timeline') {
+        return (
+          <div className={styles.sectionContent}>
+            <div className={styles.timelineHeader}>
+              <div>
+                <strong>{message.contact.name}</strong>
+                <div className={styles.timelineStage}>{message.contact.stage}</div>
+              </div>
+              {message.contact.agent ? (
+                <div className={styles.timelineAgent}>Advisor: {message.contact.agent.name}</div>
+              ) : null}
+            </div>
+            <div className={styles.timelineSummary}>{message.contact.summary}</div>
+            <ul className={styles.timelineList}>
+              {message.events.map((event, index) => (
+                <li key={`${event.date}-${index}`} className={styles.timelineItem}>
+                  <div className={styles.timelineTime}>{formatDateTime(event.date)}</div>
+                  <div className={styles.timelineBody}>
+                    <div className={styles.timelineMeta}>
+                      {event.channel}
+                      {event.agent ? ` • ${event.agent.name}` : ''}
+                    </div>
+                    <p>{event.summary}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            {message.contact.activeRequirements?.length ? (
+              <div className={styles.requirements}>
+                <p>Key requirements:</p>
+                <ul>
+                  {message.contact.activeRequirements.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        );
+      }
+
+      if (message.type === 'team') {
+        return (
+          <div className={styles.sectionContent}>
+            <p className={styles.sectionTitle}>Your Aktonz team</p>
+            <ul className={styles.teamList}>
+              {message.members.map((member) => (
+                <li key={member.id} className={styles.teamItem}>
+                  <div className={styles.teamHeader}>
+                    <strong>{member.name}</strong>
+                    <span className={styles.teamRole}>{member.role}</span>
+                  </div>
+                  {member.focus?.length ? (
+                    <div className={styles.teamFocus}>{member.focus.join(' • ')}</div>
+                  ) : null}
+                  {member.email ? <div className={styles.teamMeta}>Email: {member.email}</div> : null}
+                  {member.phone ? <div className={styles.teamMeta}>Phone: {member.phone}</div> : null}
+                  {member.bio ? <p className={styles.teamBio}>{member.bio}</p> : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      return null;
+    },
+    [describeRecency, formatDateTime],
+  );
+
+  const renderMessage = useCallback(
+    (message) => {
+      const richContent = ['listings', 'events', 'contacts', 'timeline', 'team'].includes(message.type);
+      return (
+        <div
+          className={`${styles.messageBubble} ${
+            message.from === 'user' ? styles.messageUser : styles.messageBot
+          } ${richContent ? styles.richContent : ''}`}
+        >
+          {renderMessageContent(message)}
+        </div>
+      );
+    },
+    [renderMessageContent],
+  );
+
+  return (
+    <div className={styles.container} aria-live="polite">
+      <div
+        className={`${styles.panel} ${isOpen ? styles.panelOpen : ''}`}
+        role="dialog"
+        aria-modal="false"
+        aria-label="Aktonz live support"
+        aria-hidden={!isOpen}
+      >
+        <div className={styles.header}>
+          <div className={styles.headerContent}>
+            <div className={styles.headerTitle}>
+              <FaRobot aria-hidden="true" />
+              <span>Aktonz AI Support</span>
+            </div>
+            <div className={styles.headerStatus}>
+              <span className={styles.statusDot} />
+              Online now
+            </div>
+          </div>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={() => setIsOpen(false)}
+            aria-label="Close chat"
+          >
+            <FaTimes />
+          </button>
+        </div>
+
+        <div className={styles.messages} ref={scrollRef}>
+          {messages.map((message) => (
+            <div key={message.id} className={styles.messageRow}>
+              {renderMessage(message)}
+            </div>
+          ))}
+          {isTyping ? (
+            <div className={styles.messageRow}>
+              <div className={`${styles.messageBubble} ${styles.messageBot}`}>
+                <span className={styles.typingDot} />
+                <span className={styles.typingDot} />
+                <span className={styles.typingDot} />
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className={styles.suggestions}>
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className={styles.suggestion}
+              onClick={() => sendMessage(suggestion)}
+            >
+              <FaCheckCircle aria-hidden="true" />
+              {suggestion}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.inputArea}>
+          <textarea
+            className={styles.input}
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Ask about clients, viewings, offers or listings..."
+            onKeyDown={handleKeyDown}
+            rows={2}
+            aria-label="Message Aktonz support"
+          />
+          <button
+            type="button"
+            className={styles.sendButton}
+            onClick={() => sendMessage()}
+            aria-label="Send message"
+            disabled={!inputValue.trim()}
+          >
+            <FaPaperPlane />
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className={`${styles.launcher} ${isOpen ? styles.launcherActive : ''}`}
+        onClick={() => setIsOpen((open) => !open)}
+        aria-label={isOpen ? 'Minimise Aktonz support chat' : 'Open Aktonz support chat'}
+      >
+        <FaComments aria-hidden="true" />
+        <span className={styles.launcherLabel}>{isOpen ? 'Close chat' : 'Need help?'}</span>
+      </button>
+    </div>
+  );
 }

--- a/data/ai-support.json
+++ b/data/ai-support.json
@@ -1,0 +1,256 @@
+{
+  "company": {
+    "name": "Aktonz Estate Agents",
+    "tagline": "London lettings, sales and asset management",
+    "mission": "We combine deep local expertise with smart data insights to match every client with the right property faster.",
+    "services": [
+      "Tailored search for renters, buyers and corporate relocations",
+      "End-to-end landlord services including compliance, marketing and portfolio strategy",
+      "Sales progression with proactive weekly updates",
+      "Instant viewing scheduling and digital offer negotiation"
+    ],
+    "coverage": ["Central London", "East London", "North London"],
+    "office": {
+      "address": "14 Abersham Road, London E8 2LN",
+      "phone": "020 3389 8009",
+      "email": "info@aktonz.com"
+    },
+    "hours": {
+      "weekdays": "08:30-19:00",
+      "saturday": "10:00-16:00",
+      "sunday": "By appointment"
+    }
+  },
+  "teamNotes": [
+    {
+      "id": "1723",
+      "role": "Head of Lettings",
+      "focus": ["North & East London lettings", "Corporate relocation"],
+      "email": "lettings@aktonz.com"
+    },
+    {
+      "id": "1724",
+      "role": "Senior Sales Advisor",
+      "focus": ["Prime Central London sales", "Portfolio reviews"],
+      "email": "sales@aktonz.com"
+    }
+  ],
+  "listings": [
+    {
+      "id": "ALX-3756638",
+      "title": "Room 4, 41 Ilkeston Court",
+      "address": "Overbury Street, Hackney, London E5",
+      "area": "Hackney",
+      "transactionType": "rent",
+      "price": "£950 pcm",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "status": "Let agreed",
+      "summary": "Furnished double room in a four-bedroom maisonette with an open-plan kitchen, secure fob access and wood flooring throughout.",
+      "tags": ["House share", "Furnished", "Hackney", "Zone 2"],
+      "link": "/property/854421"
+    },
+    {
+      "id": "SCRAYE-950001",
+      "title": "Boutique Four Bedroom Maisonette",
+      "address": "Fitzrovia, London W1T",
+      "area": "Fitzrovia",
+      "transactionType": "rent",
+      "price": "£2,275 pcm",
+      "bedrooms": 4,
+      "bathrooms": 3,
+      "status": "Available",
+      "summary": "Pet-friendly duplex with a roof terrace, private balcony and instant viewing slots.",
+      "tags": ["Maisonette", "Roof terrace", "Pet friendly"],
+      "link": "https://www.scraye.com/listings/950001"
+    },
+    {
+      "id": "SCRAYE-950002",
+      "title": "Stylish Four Bedroom Apartment",
+      "address": "Shoreditch, London E2",
+      "area": "Shoreditch",
+      "transactionType": "rent",
+      "price": "£1,750 pcm",
+      "bedrooms": 4,
+      "bathrooms": 4,
+      "status": "Available",
+      "summary": "Smart-home enabled apartment with residents' gym access and skyline views.",
+      "tags": ["Apartment", "Residents' gym", "Smart home"],
+      "link": "https://www.scraye.com/listings/950002"
+    },
+    {
+      "id": "ALX-49780680",
+      "title": "Earls Court Road Apartment",
+      "address": "Earls Court Road, South Kensington, London SW5",
+      "area": "South Kensington",
+      "transactionType": "sale",
+      "price": "£495,000",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "status": "For sale",
+      "summary": "First-floor one bedroom flat with high ceilings, big windows and private balcony moments from Earl's Court station.",
+      "tags": ["Flat", "Balcony", "Prime Central"],
+      "link": "/property/49780680"
+    }
+  ],
+  "appointments": [
+    {
+      "id": "apt-20250318",
+      "type": "Rental strategy session",
+      "date": "2025-03-18T10:30:00Z",
+      "location": "Aktonz HQ, 14 Abersham Road, London E8 2LN",
+      "contactId": "contact-sophie-turner",
+      "agentId": "1723",
+      "notes": "Review Shoreditch shortlist and prepare referencing documents."
+    },
+    {
+      "id": "apt-20250319",
+      "type": "Landlord portfolio review",
+      "date": "2025-03-19T15:00:00Z",
+      "location": "Virtual Teams meeting",
+      "contactId": "contact-priya-patel",
+      "agentId": "1724",
+      "notes": "Discuss renewal strategy and pricing for Hackney portfolio."
+    }
+  ],
+  "viewings": [
+    {
+      "id": "view-20250320",
+      "date": "2025-03-20T12:00:00Z",
+      "propertyId": "SCRAYE-950001",
+      "contactId": "contact-sophie-turner",
+      "agentId": "1724",
+      "status": "Confirmed",
+      "notes": "Keys to be collected from concierge at 11:45. Prospect bringing partner."
+    },
+    {
+      "id": "view-20250321",
+      "date": "2025-03-21T18:00:00Z",
+      "propertyId": "SCRAYE-950002",
+      "contactId": "contact-daniel-reed",
+      "agentId": "1723",
+      "status": "Awaiting confirmation",
+      "notes": "Corporate relocation team requested a later slot; awaiting landlord approval."
+    }
+  ],
+  "offers": [
+    {
+      "id": "offer-49780680",
+      "date": "2025-03-12T16:45:00Z",
+      "type": "sale",
+      "propertyId": "ALX-49780680",
+      "contactId": "contact-daniel-reed",
+      "amount": "£482,500",
+      "status": "Awaiting vendor decision",
+      "notes": "Buyer is mortgage-in-principle approved with completion flexibility of 6-8 weeks."
+    },
+    {
+      "id": "offer-3756638",
+      "date": "2025-03-11T11:15:00Z",
+      "type": "rent",
+      "propertyId": "ALX-3756638",
+      "contactId": "contact-sophie-turner",
+      "amount": "£950 pcm",
+      "status": "Referencing in progress",
+      "notes": "Tenant referencing expected back by 18 March; landlord happy to include professional cleaning."
+    }
+  ],
+  "contacts": [
+    {
+      "id": "contact-sophie-turner",
+      "name": "Sophie Turner",
+      "email": "sophie.turner@example.com",
+      "phone": "+44 7700 900123",
+      "stage": "Hot tenant",
+      "preferredAgentId": "1723",
+      "searchFocus": "2-bedroom, pet-friendly rentals in Shoreditch and Islington up to £2,300 pcm",
+      "activeRequirements": [
+        "Two equally sized double bedrooms",
+        "Pet friendly with nearby green space",
+        "Move-in window between April and May"
+      ],
+      "relatedListings": ["SCRAYE-950001", "SCRAYE-950002"],
+      "summary": "Tech product manager relocating from Manchester with partner and a small dog.",
+      "conversations": [
+        {
+          "date": "2025-03-12T09:30:00Z",
+          "channel": "Phone",
+          "agentId": "1723",
+          "summary": "Confirmed interest in Shoreditch E2 options and scheduled the Fitzrovia viewing for 20 March."
+        },
+        {
+          "date": "2025-03-10T14:05:00Z",
+          "channel": "Email",
+          "agentId": "1724",
+          "summary": "Shared curated shortlist with virtual tours and referencing checklist."
+        },
+        {
+          "date": "2025-03-07T16:20:00Z",
+          "channel": "WhatsApp",
+          "agentId": "1723",
+          "summary": "Discussed pet policy confirmation and landlord flexibility on furnished items."
+        }
+      ]
+    },
+    {
+      "id": "contact-daniel-reed",
+      "name": "Daniel Reed",
+      "email": "daniel.reed@urbanaxis.co.uk",
+      "phone": "+44 7700 900456",
+      "stage": "Warm buyer",
+      "preferredAgentId": "1724",
+      "searchFocus": "Prime Zone 1 one-bedroom apartments up to £520,000",
+      "activeRequirements": [
+        "Must allow short-let flexibility six weeks a year",
+        "Close to a Zone 1 Underground station",
+        "Strong rental yield for investment portfolio"
+      ],
+      "relatedListings": ["ALX-49780680"],
+      "summary": "Portfolio investor expanding London holdings after recent sale in Canary Wharf.",
+      "conversations": [
+        {
+          "date": "2025-03-13T11:10:00Z",
+          "channel": "Teams",
+          "agentId": "1724",
+          "summary": "Vendor feedback pending; discussed comparable sales on Earls Court Road."
+        },
+        {
+          "date": "2025-03-08T08:45:00Z",
+          "channel": "Email",
+          "agentId": "1724",
+          "summary": "Issued offer paperwork and proof of funds for £482,500."
+        }
+      ]
+    },
+    {
+      "id": "contact-priya-patel",
+      "name": "Priya Patel",
+      "email": "priya.patel@solsticecapital.com",
+      "phone": "+44 7700 900789",
+      "stage": "Landlord",
+      "preferredAgentId": "1723",
+      "searchFocus": "Portfolio management across Hackney and Shoreditch",
+      "activeRequirements": [
+        "Annual rental yield analysis",
+        "Hands-on tenant management",
+        "Quarterly compliance checks"
+      ],
+      "relatedListings": ["ALX-3756638"],
+      "summary": "Owns three Hackney house shares managed by Aktonz since 2019.",
+      "conversations": [
+        {
+          "date": "2025-03-11T09:00:00Z",
+          "channel": "Video call",
+          "agentId": "1724",
+          "summary": "Reviewed renewal pricing for Ilkeston Court room; agreed to hold at £950 pcm."
+        },
+        {
+          "date": "2025-03-05T17:40:00Z",
+          "channel": "Email",
+          "agentId": "1723",
+          "summary": "Shared compliance pack update and scheduled portfolio review."
+        }
+      ]
+    }
+  ]
+}

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -9,6 +9,7 @@ import {
   loadScrayeListingsByType,
   fetchScrayeListingById,
   normalizeScrayeListings,
+  loadScrayeCache,
 } from './scraye.mjs';
 
 const API_URL = 'https://api.apex27.co.uk/listings';
@@ -310,6 +311,49 @@ export function normalizeImageUrl(img) {
 
 export function normalizeImages(images = []) {
   return images.map((img) => normalizeImageUrl(img)).filter(Boolean);
+}
+
+function mapScrayeListingToProperty(item, transactionType) {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  return {
+    id: item.id,
+    sourceId: item.sourceId ?? null,
+    transactionType,
+    price: item.priceValue ?? null,
+    priceCurrency: item.priceCurrency ?? 'GBP',
+    rentFrequency: item.rentFrequency ?? null,
+    pricePrefix: extractPricePrefix(item) ?? null,
+    displayAddress: item.title ?? '',
+    description: item.description ?? '',
+    summary: item.description ?? '',
+    bedrooms: item.bedrooms ?? null,
+    bathrooms: item.bathrooms ?? null,
+    propertyType: item.propertyType ?? null,
+    propertyTypeLabel: resolvePropertyTypeLabel(item) ?? null,
+    status: item.status ?? null,
+    featured: Boolean(item.featured),
+    latitude: item.latitude ?? item.lat ?? null,
+    longitude: item.longitude ?? item.lng ?? null,
+    city: item.city ?? null,
+    county: item.county ?? null,
+    outcode: item.outcode ?? null,
+    matchingSearchRegions: Array.isArray(item.matchingRegions)
+      ? item.matchingRegions
+      : [],
+    images: Array.isArray(item.images) ? item.images : [],
+    media: Array.isArray(item.media) ? item.media : [],
+    externalUrl: item.externalUrl ?? item.url ?? null,
+    source: item.source ?? 'scraye',
+    furnishedState: item.furnishedState ?? null,
+    createdAt: item.createdAt ?? null,
+    updatedAt: item.updatedAt ?? null,
+    depositType: item.depositType ?? null,
+    size: item.size ?? null,
+    _scraye: item._scraye ?? {},
+  };
 }
 
 export async function fetchProperties(params = {}) {
@@ -665,71 +709,88 @@ export async function fetchPropertiesByType(type, options = {}) {
     propertyType,
     limit,
     maxImages,
+    useCacheOnly = false,
   } = options;
 
   const baseParams = { transactionType };
   if (propertyType) baseParams.propertyType = propertyType;
 
-  let properties;
-  if (Array.isArray(statuses) && statuses.length > 0) {
+  const normalizeStatusValue = (value) =>
+    typeof value === 'string' ? value.toLowerCase().replace(/\s+/g, '_') : '';
 
-    const results = [];
-    for (const status of statuses) {
-      const props = await fetchProperties({ transactionType, status });
-      results.push(Array.isArray(props) ? props : []);
-      await sleep(200);
+  const requestedStatuses = Array.isArray(statuses)
+    ? statuses
+        .map((status) => normalizeStatusValue(status))
+        .filter(Boolean)
+    : null;
+
+  const filterByStatuses = (collection) => {
+    if (!requestedStatuses) {
+      return collection;
     }
+    return collection.filter((item) =>
+      requestedStatuses.includes(normalizeStatusValue(item?.status)),
+    );
+  };
 
-    properties = results.flat();
-  } else {
-    const props = await fetchProperties(baseParams);
-    properties = Array.isArray(props) ? props : [];
+  let properties = [];
+  if (useCacheOnly) {
+    try {
+      const cached = await getCachedProperties();
+      if (Array.isArray(cached)) {
+        properties = filterByStatuses(cached);
+      }
+    } catch (error) {
+      console.warn('Unable to load cached Apex27 listings', error);
+      properties = [];
+    }
   }
 
-  try {
-    const scrayeCache = await loadScrayeListingsByType(transactionType);
-    if (Array.isArray(scrayeCache) && scrayeCache.length > 0) {
-      const scrayeListings = normalizeScrayeListings(scrayeCache).map((item) => ({
-        id: item.id,
-        sourceId: item.sourceId ?? null,
-        transactionType,
-        price: item.priceValue ?? null,
-        priceCurrency: item.priceCurrency ?? 'GBP',
-        rentFrequency: item.rentFrequency ?? null,
-        pricePrefix: extractPricePrefix(item) ?? null,
-
-        displayAddress: item.title ?? '',
-        description: item.description ?? '',
-        summary: item.description ?? '',
-        bedrooms: item.bedrooms ?? null,
-        bathrooms: item.bathrooms ?? null,
-        propertyType: item.propertyType ?? null,
-        propertyTypeLabel: resolvePropertyTypeLabel(item) ?? null,
-        status: item.status ?? null,
-        featured: Boolean(item.featured),
-        latitude: item.latitude ?? item.lat ?? null,
-        longitude: item.longitude ?? item.lng ?? null,
-        city: item.city ?? null,
-        county: item.county ?? null,
-        outcode: item.outcode ?? null,
-        matchingSearchRegions: Array.isArray(item.matchingRegions)
-          ? item.matchingRegions
-          : [],
-        images: Array.isArray(item.images) ? item.images : [],
-        media: Array.isArray(item.media) ? item.media : [],
-        externalUrl: item.externalUrl ?? item.url ?? null,
-        source: item.source ?? 'scraye',
-        furnishedState: item.furnishedState ?? null,
-        createdAt: item.createdAt ?? null,
-        updatedAt: item.updatedAt ?? null,
-        depositType: item.depositType ?? null,
-        size: item.size ?? null,
-        _scraye: item._scraye ?? {},
-      }));
-      properties = properties.concat(scrayeListings);
+  if (!useCacheOnly) {
+    if (requestedStatuses && requestedStatuses.length > 0) {
+      const results = [];
+      for (const status of requestedStatuses) {
+        const props = await fetchProperties({ transactionType, status });
+        results.push(Array.isArray(props) ? props : []);
+        await sleep(200);
+      }
+      properties = results.flat();
+    } else {
+      const props = await fetchProperties(baseParams);
+      properties = Array.isArray(props) ? props : [];
     }
-  } catch (error) {
-    console.warn('Failed to load Scraye listings from cache', error);
+  }
+
+  if (useCacheOnly) {
+    try {
+      const cache = await loadScrayeCache();
+      const bucket =
+        transactionType === 'sale' ? cache?.sale ?? [] : cache?.rent ?? [];
+      if (Array.isArray(bucket) && bucket.length > 0) {
+        const mapped = normalizeScrayeListings(bucket)
+          .map((item) => mapScrayeListingToProperty(item, transactionType))
+          .filter(Boolean);
+        properties = properties.concat(mapped);
+      }
+    } catch (error) {
+      console.warn('Unable to load cached Scraye listings', error);
+    }
+  } else {
+    try {
+      const scrayeCache = await loadScrayeListingsByType(transactionType);
+      if (Array.isArray(scrayeCache) && scrayeCache.length > 0) {
+        const scrayeListings = normalizeScrayeListings(scrayeCache)
+          .map((item) => mapScrayeListingToProperty(item, transactionType))
+          .filter(Boolean);
+        properties = properties.concat(scrayeListings);
+      }
+    } catch (error) {
+      console.warn('Failed to load Scraye listings from cache', error);
+    }
+  }
+
+  if (!useCacheOnly && requestedStatuses) {
+    properties = filterByStatuses(properties);
   }
 
   const seenIds = new Set();
@@ -859,6 +920,20 @@ export async function fetchPropertiesByType(type, options = {}) {
   }
 
   return limited;
+}
+
+export async function fetchPropertiesByTypeCachedFirst(type, options = {}) {
+  const cachedResults = await fetchPropertiesByType(type, {
+    ...options,
+    useCacheOnly: true,
+  });
+
+  if (Array.isArray(cachedResults) && cachedResults.length > 0) {
+    return cachedResults;
+  }
+
+  const { useCacheOnly: _ignored, ...rest } = options;
+  return fetchPropertiesByType(type, rest);
 }
 
 export async function fetchSearchRegions() {

--- a/pages/favourites.js
+++ b/pages/favourites.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import PropertyList from '../components/PropertyList';
-import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
 export default function Favourites({ properties }) {
@@ -30,11 +30,10 @@ export default function Favourites({ properties }) {
 }
 
 export async function getStaticProps() {
-  const sale = await fetchPropertiesByType('sale', {
+  const sale = await fetchPropertiesByTypeCachedFirst('sale', {
     statuses: ['available', 'under_offer', 'sold'],
   });
-  await new Promise((res) => setTimeout(res, 200));
-  const rent = await fetchPropertiesByType('rent', {
+  const rent = await fetchPropertiesByTypeCachedFirst('rent', {
     statuses: ['available', 'under_offer', 'let_agreed', 'let'],
   });
   const properties = [...sale.slice(0, 20), ...rent.slice(0, 20)];

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -7,7 +7,7 @@ import PropertyMap from '../components/PropertyMap';
 import AgentCard from '../components/AgentCard';
 import ListingFilters from '../components/ListingFilters';
 import ListingInsights from '../components/ListingInsights';
-import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import agentsData from '../data/agents.json';
 import homeStyles from '../styles/Home.module.css';
 import saleStyles from '../styles/ForSale.module.css';
@@ -453,7 +453,7 @@ export default function ForSale({ properties, agents }) {
 }
 
 export async function getStaticProps() {
-  const raw = await fetchPropertiesByType('sale', {
+  const raw = await fetchPropertiesByTypeCachedFirst('sale', {
     statuses: ['available', 'under_offer', 'sold'],
   });
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import PropertyList from '../components/PropertyList';
 import Hero from '../components/Hero';
 import Features from '../components/Features';
 import Stats from '../components/Stats';
-import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
 export default function Home({ sales, lettings, archiveSales }) {
@@ -37,10 +37,10 @@ export default function Home({ sales, lettings, archiveSales }) {
 
 export async function getStaticProps() {
   const [allSale, allRent] = await Promise.all([
-    fetchPropertiesByType('sale', {
+    fetchPropertiesByTypeCachedFirst('sale', {
       statuses: ['available', 'under_offer', 'sold'],
     }),
-    fetchPropertiesByType('rent', {
+    fetchPropertiesByTypeCachedFirst('rent', {
       statuses: ['available'],
     }),
   ]);

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -12,13 +12,11 @@ import PropertyMap from '../../components/PropertyMap';
 import Head from 'next/head';
 import {
   fetchPropertyById,
-  fetchProperties,
-  fetchPropertiesByType,
+  fetchPropertiesByTypeCachedFirst,
   extractMedia,
   normalizeImages,
   extractPricePrefix,
 } from '../../lib/apex27.mjs';
-import { loadScrayeListingsByType, normalizeScrayeListings } from '../../lib/scraye.mjs';
 import {
   resolvePropertyIdentifier,
   propertyMatchesIdentifier,
@@ -52,6 +50,58 @@ function rentToMonthly(price, freq) {
       return amount / 12;
     default:
       return amount;
+  }
+}
+
+async function loadPrebuildPropertyIds(limit = 24) {
+  if (!limit || limit <= 0) {
+    return [];
+  }
+
+  try {
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const filePath = pathMod.join(process.cwd(), 'data', 'listings.json');
+    const raw = await fs.readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+
+    const ids = [];
+    const seen = new Set();
+
+    if (Array.isArray(data)) {
+      for (const entry of data) {
+        const identifier = resolvePropertyIdentifier(entry);
+        if (!identifier) {
+          continue;
+        }
+
+        const normalized = String(identifier).trim();
+        if (!normalized) {
+          continue;
+        }
+
+        if (normalized.toLowerCase().startsWith('scraye-')) {
+          continue;
+        }
+
+        const dedupeKey = normalized.toLowerCase();
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+
+        seen.add(dedupeKey);
+        ids.push(normalized);
+
+        if (ids.length >= limit) {
+          break;
+        }
+      }
+    }
+
+    return ids;
+  } catch (error) {
+    console.warn('Unable to derive prebuild property ids from cache', error);
+    return [];
   }
 }
 
@@ -233,29 +283,8 @@ export default function Property({ property, recommendations }) {
 }
 
 export async function getStaticPaths() {
-  const [sale, rent, scrayeRent, scrayeSale] = await Promise.all([
-    fetchProperties({ transactionType: 'sale' }),
-    fetchProperties({ transactionType: 'rent' }),
-    loadScrayeListingsByType('rent'),
-    loadScrayeListingsByType('sale'),
-  ]);
-
-  const scrayeListings = [
-    ...normalizeScrayeListings(scrayeRent),
-    ...normalizeScrayeListings(scrayeSale),
-  ];
-
-  const properties = [...sale, ...rent, ...scrayeListings];
-  const seen = new Set();
-  const paths = [];
-  properties.forEach((property) => {
-    const identifier = resolvePropertyIdentifier(property);
-    if (!identifier) return;
-    const normalized = String(identifier).trim().toLowerCase();
-    if (!normalized || seen.has(normalized)) return;
-    seen.add(normalized);
-    paths.push({ params: { id: String(identifier) } });
-  });
+  const ids = await loadPrebuildPropertyIds(24);
+  const paths = ids.map((id) => ({ params: { id: String(id) } }));
   return {
     paths,
     fallback: 'blocking',
@@ -350,7 +379,7 @@ export async function getStaticProps({ params }) {
     };
   }
 
-  const allRent = await fetchPropertiesByType('rent');
+  const allRent = await fetchPropertiesByTypeCachedFirst('rent');
   const recommendations = allRent
     .filter((p) => !propertyMatchesIdentifier(p, params.id))
     .slice(0, 4);

--- a/pages/property/index.js
+++ b/pages/property/index.js
@@ -1,5 +1,5 @@
 import PropertyList from '../../components/PropertyList';
-import { fetchPropertiesByType } from '../../lib/apex27.mjs';
+import { fetchPropertiesByTypeCachedFirst } from '../../lib/apex27.mjs';
 import styles from '../../styles/Home.module.css';
 
 export default function PropertyArchive({ properties }) {
@@ -13,10 +13,10 @@ export default function PropertyArchive({ properties }) {
 
 export async function getStaticProps() {
   const [sale, rent] = await Promise.all([
-    fetchPropertiesByType('sale', {
+    fetchPropertiesByTypeCachedFirst('sale', {
       statuses: ['available', 'under_offer', 'sold'],
     }),
-    fetchPropertiesByType('rent'),
+    fetchPropertiesByTypeCachedFirst('rent'),
   ]);
 
   const allowedSale = ['available', 'under_offer', 'sold'];

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -7,7 +7,7 @@ import PropertyMap from '../components/PropertyMap';
 import ListingFilters from '../components/ListingFilters';
 import ListingInsights from '../components/ListingInsights';
 import AgentCard from '../components/AgentCard';
-import { fetchPropertiesByType } from '../lib/apex27.mjs';
+import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import agentsData from '../data/agents.json';
 import homeStyles from '../styles/Home.module.css';
 import rentStyles from '../styles/ToRent.module.css';
@@ -502,7 +502,7 @@ export default function ToRent({ properties, agents }) {
 }
 
 export async function getStaticProps() {
-  const raw = await fetchPropertiesByType('rent', {
+  const raw = await fetchPropertiesByTypeCachedFirst('rent', {
     statuses: ['available', 'under_offer', 'let_agreed', 'let', 'let_stc', 'let_by'],
   });
 

--- a/styles/ChatWidget.module.css
+++ b/styles/ChatWidget.module.css
@@ -1,0 +1,508 @@
+.container {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+  z-index: 60;
+}
+
+.panel {
+  width: 22rem;
+  max-width: calc(100vw - 2rem);
+  max-height: 32rem;
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+  transform: translateY(12px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.panelOpen {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.header {
+  padding: 1rem 1.25rem;
+  background: linear-gradient(135deg, #1d4ed8, #0f172a);
+  color: #f8fafc;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.headerTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.headerTitle svg {
+  font-size: 1.1rem;
+}
+
+.headerStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.statusDot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 9999px;
+  background: #34d399;
+  position: relative;
+}
+
+.statusDot::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 9999px;
+  border: 1px solid rgba(52, 211, 153, 0.45);
+  animation: pulse 2s ease infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.5;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 0.4;
+    transform: scale(0.9);
+  }
+}
+
+.closeButton {
+  background: rgba(15, 23, 42, 0.2);
+  border: none;
+  color: #f8fafc;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.closeButton:hover {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.messages {
+  flex: 1;
+  background: #f8fafc;
+  padding: 1rem 1rem 0.75rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.messageRow {
+  display: flex;
+  width: 100%;
+}
+
+.messageBubble {
+  font-size: 0.9rem;
+  line-height: 1.45;
+  padding: 0.75rem 0.9rem;
+  border-radius: 1rem;
+  max-width: 100%;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.07);
+}
+
+.messageBot {
+  background: #ffffff;
+  color: #0f172a;
+  border-bottom-left-radius: 0.35rem;
+}
+
+.messageUser {
+  background: #1d4ed8;
+  color: #f8fafc;
+  margin-left: auto;
+  border-bottom-right-radius: 0.35rem;
+}
+
+.richContent {
+  width: 100%;
+}
+
+.textLine + .textLine {
+  margin-top: 0.35rem;
+}
+
+.sectionContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sectionTitle {
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+}
+
+.listingList,
+.eventList,
+.contactList,
+.timelineList,
+.teamList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listingItem,
+.eventItem,
+.contactItem,
+.timelineItem,
+.teamItem {
+  background: #f1f5f9;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.listingHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.listingPrice {
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.listingAddress {
+  color: #475569;
+}
+
+.listingMeta {
+  color: #1f2937;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.listingSummary {
+  margin: 0;
+  color: #334155;
+}
+
+.listingLink {
+  align-self: flex-start;
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.listingLink:hover {
+  text-decoration: underline;
+}
+
+.eventTime {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.eventTitle {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eventMeta {
+  font-size: 0.8rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.eventDescription {
+  margin: 0;
+  color: #334155;
+}
+
+.contactHeader,
+.teamHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.contactStage,
+.teamRole {
+  font-size: 0.75rem;
+  background: rgba(29, 78, 216, 0.12);
+  color: #1d4ed8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 9999px;
+  align-self: flex-start;
+}
+
+.contactFocus,
+.teamFocus,
+.teamBio,
+.contactMeta,
+.teamMeta {
+  color: #334155;
+  font-size: 0.85rem;
+}
+
+.timelineHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.timelineStage {
+  font-size: 0.8rem;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.timelineAgent {
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.timelineSummary {
+  color: #334155;
+  font-size: 0.85rem;
+}
+
+.timelineTime {
+  font-size: 0.8rem;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.timelineMeta {
+  font-size: 0.8rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.timelineBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.timelineBody p {
+  margin: 0.25rem 0 0;
+  color: #334155;
+}
+
+.requirements {
+  background: rgba(30, 64, 175, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.requirements p {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.requirements ul {
+  list-style: disc;
+  margin: 0.35rem 0 0 1.25rem;
+  color: #334155;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0 1rem 0.75rem;
+}
+
+.suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #e0e7ff;
+  color: #1e3a8a;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.suggestion:hover {
+  background: #c7d2fe;
+}
+
+.inputArea {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  padding: 0 1rem 1rem;
+}
+
+.input {
+  flex: 1;
+  border-radius: 0.75rem;
+  border: 1px solid #dbe2ef;
+  padding: 0.6rem 0.75rem;
+  font-family: inherit;
+  resize: none;
+  font-size: 0.9rem;
+  color: #0f172a;
+  background: #ffffff;
+}
+
+.input:focus {
+  outline: 2px solid #93c5fd;
+}
+
+.sendButton {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: #1d4ed8;
+  color: #f8fafc;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.sendButton:disabled {
+  background: #cbd5f5;
+  cursor: not-allowed;
+}
+
+.sendButton:not(:disabled):hover {
+  background: #1e40af;
+}
+
+.launcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: #1d4ed8;
+  color: #f8fafc;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.launcher svg {
+  font-size: 1.1rem;
+}
+
+.launcher:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 26px rgba(15, 23, 42, 0.28);
+}
+
+.launcherActive {
+  background: #0f172a;
+}
+
+.launcherLabel {
+  white-space: nowrap;
+}
+
+.typingDot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.25rem;
+  border-radius: 9999px;
+  background: rgba(30, 64, 175, 0.6);
+  animation: typing 1.2s ease-in-out infinite;
+}
+
+.typingDot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typingDot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typing {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
+@media (max-width: 640px) {
+  .container {
+    right: 0.75rem;
+    left: 0.75rem;
+    bottom: 1rem;
+    align-items: stretch;
+  }
+
+  .panel {
+    width: 100%;
+    max-height: calc(100vh - 6rem);
+  }
+
+  .launcher {
+    align-self: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the legacy embed with an AI chat assistant that understands Aktonz contacts, appointments, viewings, offers and listings
- add a curated support knowledge base covering company details, clients and property stock for the assistant to use
- style a responsive floating chat panel with quick suggestions and accessible controls on every page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33acf485c832e96ac038732fb01bd