### PR TITLE
Sort Scraye listings before saving cache

### DIFF
--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -1072,3 +1072,32 @@ export function normalizeScrayeListings(listings) {
     return true;
   });
 }
+
+function compareScrayeIds(a, b) {
+  const normalizeId = (value) => {
+    if (!value) return { str: '', num: NaN };
+    const raw = String(value).trim();
+    if (!raw) return { str: '', num: NaN };
+    const digits = raw.replace(/[^0-9]/g, '');
+    const num = digits ? Number(digits) : NaN;
+    return { str: raw, num };
+  };
+
+  const left = normalizeId(a);
+  const right = normalizeId(b);
+
+  if (Number.isFinite(left.num) && Number.isFinite(right.num)) {
+    return left.num - right.num;
+  }
+
+  return left.str.localeCompare(right.str);
+}
+
+export function sortScrayeListings(listings) {
+  if (!Array.isArray(listings)) return [];
+  const entries = listings.slice();
+  entries.sort((entryA, entryB) =>
+    compareScrayeIds(entryA?.sourceId ?? entryA?.id, entryB?.sourceId ?? entryB?.id)
+  );
+  return entries;
+}

--- a/scripts/syncScraye.mjs
+++ b/scripts/syncScraye.mjs
@@ -3,6 +3,7 @@ import path from 'path';
 import {
   fetchScrayeListings,
   normalizeScrayeListings,
+  sortScrayeListings,
   loadScrayeCache,
 } from '../lib/scraye.mjs';
 
@@ -45,8 +46,8 @@ async function main() {
     fetchScrayeListings({ transactionType: 'sale', placeIds: placeIds.length ? placeIds : undefined }),
   ]);
 
-  const rent = normalizeScrayeListings(rentListings);
-  const sale = normalizeScrayeListings(saleListings);
+  const rent = sortScrayeListings(normalizeScrayeListings(rentListings));
+  const sale = sortScrayeListings(normalizeScrayeListings(saleListings));
 
   const cache = {
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add a helper to deterministically sort Scraye listings by their numeric identifier
- ensure the Scraye sync script writes sorted rent and sale arrays to stabilise cache output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33ec547b4832e913715a18e576ea1