### PR TITLE
Fall back to cached Scraye listings when detail fetch fails

### DIFF
--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -866,6 +866,10 @@ export async function fetchScrayeListingById(id, { cachedListings = [] } = {}) {
     (item) => item?.sourceId === cleanId || item?.id === `scraye-${cleanId}`
   );
 
+  if (baseEntry && !needsScrayeDetailEnrichment(baseEntry)) {
+    return baseEntry;
+  }
+
   const operations = [
     {
       operationName: 'Listing',
@@ -874,9 +878,21 @@ export async function fetchScrayeListingById(id, { cachedListings = [] } = {}) {
     },
   ];
 
-  const json = await scrayeFetch(operations, {
-    pathname: `/listings/${cleanId}`,
-  });
+  let json;
+  try {
+    json = await scrayeFetch(operations, {
+      pathname: `/listings/${cleanId}`,
+    });
+  } catch (error) {
+    if (baseEntry) {
+      console.warn(
+        `Falling back to cached Scraye listing ${cleanId} after fetch failure`,
+        error
+      );
+      return baseEntry;
+    }
+    throw error;
+  }
 
   const payload = json.find((item) => item?.data?.listing?.id === cleanId);
   if (!payload) {
@@ -1071,4 +1087,33 @@ export function normalizeScrayeListings(listings) {
     seen.add(listing.sourceId);
     return true;
   });
+}
+
+function compareScrayeIds(a, b) {
+  const normalizeId = (value) => {
+    if (!value) return { str: '', num: NaN };
+    const raw = String(value).trim();
+    if (!raw) return { str: '', num: NaN };
+    const digits = raw.replace(/[^0-9]/g, '');
+    const num = digits ? Number(digits) : NaN;
+    return { str: raw, num };
+  };
+
+  const left = normalizeId(a);
+  const right = normalizeId(b);
+
+  if (Number.isFinite(left.num) && Number.isFinite(right.num)) {
+    return left.num - right.num;
+  }
+
+  return left.str.localeCompare(right.str);
+}
+
+export function sortScrayeListings(listings) {
+  if (!Array.isArray(listings)) return [];
+  const entries = listings.slice();
+  entries.sort((entryA, entryB) =>
+    compareScrayeIds(entryA?.sourceId ?? entryA?.id, entryB?.sourceId ?? entryB?.id)
+  );
+  return entries;
 }

--- a/scripts/syncScraye.mjs
+++ b/scripts/syncScraye.mjs
@@ -3,6 +3,7 @@ import path from 'path';
 import {
   fetchScrayeListings,
   normalizeScrayeListings,
+  sortScrayeListings,
   loadScrayeCache,
 } from '../lib/scraye.mjs';
 
@@ -45,8 +46,8 @@ async function main() {
     fetchScrayeListings({ transactionType: 'sale', placeIds: placeIds.length ? placeIds : undefined }),
   ]);
 
-  const rent = normalizeScrayeListings(rentListings);
-  const sale = normalizeScrayeListings(saleListings);
+  const rent = sortScrayeListings(normalizeScrayeListings(rentListings));
+  const sale = sortScrayeListings(normalizeScrayeListings(saleListings));
 
   const cache = {
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- stop refetching Scraye listings if the cached entry is already enriched
- reuse cached Scraye data when the detail request fails so static builds keep working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33ec547b4832e913715a18e576ea1