### PR TITLE
Broaden Scraye sale listing coverage

### DIFF
--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -20,6 +20,10 @@ function getProxyAgent() {
   return cachedProxyAgent;
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function toTitleCase(value) {
   if (!value) return null;
   return String(value)
@@ -235,6 +239,7 @@ function needsScrayeDetailEnrichment(listing) {
 
 
 async function scrayeFetch(operations, { pathname, searchTerm } = {}) {
+  const maxAttempts = 4;
   const headers = {
     'content-type': 'application/json',
     accept: 'application/json',
@@ -250,21 +255,45 @@ async function scrayeFetch(operations, { pathname, searchTerm } = {}) {
     headers['x-search'] = searchTerm;
   }
 
-  const response = await fetch(SCRAYE_API_URL, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(operations),
-    dispatcher: getProxyAgent(),
-  });
+  const retriableStatusCodes = new Set([408, 425, 429, 500, 502, 503, 504]);
+  const payload = JSON.stringify(operations);
+  let lastError = null;
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    throw new Error(
-      `Scraye API request failed with status ${response.status}: ${text.slice(0, 200)}`
-    );
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(SCRAYE_API_URL, {
+        method: 'POST',
+        headers,
+        body: payload,
+        dispatcher: getProxyAgent(),
+      });
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (response?.ok) {
+      return response.json();
+    }
+
+    if (response) {
+      const text = await response.text().catch(() => '');
+      const error = new Error(
+        `Scraye API request failed with status ${response.status}: ${text.slice(0, 200)}`
+      );
+      lastError = error;
+      if (!retriableStatusCodes.has(response.status) || attempt === maxAttempts - 1) {
+        throw error;
+      }
+    } else if (attempt === maxAttempts - 1) {
+      throw lastError ?? new Error('Scraye API request failed');
+    }
+
+    const backoff = 500 * 2 ** attempt;
+    await sleep(backoff);
   }
 
-  return response.json();
+  throw lastError ?? new Error('Scraye API request failed');
 }
 
 function buildFilter(type) {
@@ -703,16 +732,55 @@ export async function fetchScrayeListings({
   placeIds,
   pageSize = 48,
   maxPages,
+  maxListings,
 } = {}) {
   const configs = await fetchPlaceConfigs();
   const desiredType = transactionType === 'sale' ? 'sale' : 'rent';
   const filtered = configs.filter((config) => config.transactionType === desiredType);
 
-  const selected = Array.isArray(placeIds) && placeIds.length > 0
-    ? filtered.filter((config) => placeIds.includes(config.placeId))
-    : filtered;
+  const maxPlaces = transactionType === 'sale' ? 12 : 18;
+  const seenPlaces = new Set();
+  const prioritized = [];
+
+  const addConfig = (config) => {
+    if (!config) return;
+    const key = `${config.placeId}:${config.slug}`;
+    if (seenPlaces.has(key)) return;
+    seenPlaces.add(key);
+    prioritized.push(config);
+  };
+
+  if (Array.isArray(placeIds) && placeIds.length > 0) {
+    const normalizedTargets = placeIds
+      .map((id) => (id != null ? String(id).trim() : ''))
+      .filter(Boolean);
+
+    for (const target of normalizedTargets) {
+      for (const config of filtered) {
+        if (config.placeId !== target) continue;
+        addConfig(config);
+        if (prioritized.length >= maxPlaces) break;
+      }
+      if (prioritized.length >= maxPlaces) {
+        break;
+      }
+    }
+  }
+
+  for (const config of filtered) {
+    if (prioritized.length >= maxPlaces) {
+      break;
+    }
+    addConfig(config);
+  }
+
+  const selected = prioritized.length > 0 ? prioritized : filtered.slice(0, maxPlaces);
 
   const results = new Map();
+  const limit =
+    typeof maxListings === 'number' && Number.isFinite(maxListings) && maxListings > 0
+      ? maxListings
+      : Infinity;
 
   for (const config of selected) {
     let after = null;
@@ -741,10 +809,19 @@ export async function fetchScrayeListings({
         },
       ];
 
-      const json = await scrayeFetch(operations, {
-        pathname: config.pathname,
-        searchTerm: '',
-      });
+      let json;
+      try {
+        json = await scrayeFetch(operations, {
+          pathname: config.pathname,
+          searchTerm: '',
+        });
+      } catch (error) {
+        console.warn(
+          `Failed to fetch Scraye listings for place ${config.placeId} (${config.slug})`,
+          error
+        );
+        break;
+      }
 
       const payload = json.find((item) => item?.data?.place?.id === config.placeId);
       if (!payload) break;
@@ -762,17 +839,39 @@ export async function fetchScrayeListings({
         const normalized = normalizeListingNode(edge.node, context);
         if (!normalized) continue;
         results.set(edge.node.id, normalized);
+        if (results.size >= limit) {
+          break;
+        }
       }
 
       after = listings?.pageInfo?.hasNextPage ? listings.pageInfo.endCursor : null;
       page += 1;
-    } while (after && (typeof maxPages !== 'number' || page < maxPages));
+    } while (
+      results.size < limit &&
+      after &&
+      (typeof maxPages !== 'number' || page < maxPages)
+    );
+
+    if (results.size >= limit) {
+      break;
+    }
+
+    await sleep(250);
   }
 
   const baseListings = Array.from(results.values());
+  if (baseListings.length === 0) {
+    return [];
+  }
+
+  const concurrency = Math.min(
+    baseListings.length,
+    Math.min(3, Math.max(1, Math.floor(baseListings.length / 20) || 2))
+  );
+
   return enrichScrayeListingsWithDetails(baseListings, {
-    force: true,
-    concurrency: 8,
+    force: false,
+    concurrency,
   });
 
 }
@@ -887,41 +986,97 @@ export async function loadScrayeCache() {
   }
 }
 
+function derivePreferredScrayePlaceIds(listings, { limit = 6 } = {}) {
+  if (!Array.isArray(listings) || listings.length === 0) {
+    return [];
+  }
+
+  const counts = new Map();
+  for (const listing of listings) {
+    const placeId =
+      (listing?._scraye && listing._scraye.placeId) ||
+      listing?.placeId ||
+      listing?.placeID ||
+      null;
+    if (!placeId) continue;
+    const normalized = String(placeId).trim();
+    if (!normalized) continue;
+    counts.set(normalized, (counts.get(normalized) || 0) + 1);
+  }
+
+  if (counts.size === 0) {
+    return [];
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, Math.max(1, limit))
+    .map(([placeId]) => placeId);
+}
+
 export async function loadScrayeListingsByType(type) {
   const cache = await loadScrayeCache();
   const transactionType = type === 'sale' ? 'sale' : 'rent';
 
-  let listings = [];
+  let cachedListings = [];
   if (cache && typeof cache === 'object') {
     const bucket = transactionType === 'sale' ? cache.sale : cache.rent;
     if (Array.isArray(bucket) && bucket.length > 0) {
-      listings = bucket;
+      cachedListings = bucket;
     }
   }
 
-  if (Array.isArray(listings) && listings.length > 0) {
-    listings = await enrichScrayeListingsWithDetails(listings, {
+  let liveListings = [];
+  try {
+    const envPlaceIds = (process.env.SCRAYE_PLACE_IDS || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const derivedPlaceIds = derivePreferredScrayePlaceIds(cachedListings, {
+      limit: transactionType === 'sale' ? 6 : 8,
+    });
+    let placeIdTargets = envPlaceIds.length > 0 ? envPlaceIds : derivedPlaceIds;
+    if (placeIdTargets.length === 0) {
+      placeIdTargets = ['MA'];
+    }
+
+    const liveResults = await fetchScrayeListings({
+      transactionType,
+      placeIds: placeIdTargets,
+      pageSize: transactionType === 'sale' ? 32 : 48,
+      maxPages: transactionType === 'sale' ? 2 : 3,
+      maxListings: transactionType === 'sale' ? 120 : 180,
+    });
+    if (Array.isArray(liveResults) && liveResults.length > 0) {
+      liveListings = liveResults;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch live Scraye listings', error);
+  }
+
+  const combined = [];
+  if (Array.isArray(liveListings) && liveListings.length > 0) {
+    combined.push(...liveListings);
+  }
+  if (Array.isArray(cachedListings) && cachedListings.length > 0) {
+    combined.push(...cachedListings);
+  }
+
+  if (combined.length === 0) {
+    return [];
+  }
+
+  const unique = normalizeScrayeListings(combined);
+
+  try {
+    return await enrichScrayeListingsWithDetails(unique, {
       force: false,
       concurrency: 4,
     });
-
+  } catch (error) {
+    console.warn('Failed to enrich Scraye listings with details', error);
+    return unique;
   }
-
-  if (!Array.isArray(listings) || listings.length === 0) {
-    try {
-      const liveResults = await fetchScrayeListings({
-        transactionType,
-        pageSize: 48,
-      });
-      if (Array.isArray(liveResults) && liveResults.length > 0) {
-        listings = liveResults;
-      }
-    } catch (error) {
-      console.warn('Failed to fetch live Scraye listings', error);
-    }
-  }
-
-  return Array.isArray(listings) ? listings : [];
 }
 
 export function normalizeScrayeListings(listings) {

--- a/pages/for-sale.js
+++ b/pages/for-sale.js
@@ -457,7 +457,34 @@ export async function getStaticProps() {
     statuses: ['available', 'under_offer', 'sold'],
   });
 
-  const properties = raw.slice(0, 50).map((property) => ({
+  const scrayeListings = [];
+  const otherListings = [];
+
+  raw.forEach((property) => {
+    const source = typeof property?.source === 'string' ? property.source.toLowerCase() : '';
+    if (source === 'scraye') {
+      scrayeListings.push(property);
+    } else {
+      otherListings.push(property);
+    }
+  });
+
+  const prioritized = [];
+  const seen = new Set();
+  const pushUnique = (property) => {
+    if (!property) return;
+    const key = property.id ? String(property.id).toLowerCase() : null;
+    if (key && seen.has(key)) return;
+    if (key) {
+      seen.add(key);
+    }
+    prioritized.push(property);
+  };
+
+  scrayeListings.forEach(pushUnique);
+  otherListings.forEach(pushUnique);
+
+  const properties = prioritized.slice(0, 50).map((property) => ({
     ...property,
     images: (property.images || []).slice(0, 3),
     description: property.description ? property.description.slice(0, 200) : '',


### PR DESCRIPTION
## Summary
- expand Scraye sale fetch selection to include fallback regions beyond cached place IDs so newly added listings surface
- deduplicate targeted and fallback place configs while capping total requests to respect Scraye rate limits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3261c8d38832eaad93d402ab6761d