### PR TITLE
Fix filesystem imports for Next.js build

### DIFF
--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -254,7 +254,7 @@ async function getCachedProperties() {
     return null;
   }
   try {
-    const fs = await import('fs/promises');
+    const fs = await import('node:fs/promises');
     const pathMod = await import('path');
     const filePath = pathMod.join(process.cwd(), 'data', 'listings.json');
     const json = await fs.readFile(filePath, 'utf8');

--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -1126,7 +1126,7 @@ export async function loadScrayeCache() {
 
   const loadPromise = (async () => {
     try {
-      const fs = await import('fs/promises');
+      const fs = await import('node:fs/promises');
       const path = await import('path');
       const filePath = path.join(process.cwd(), 'data', 'scraye.json');
       const text = await fs.readFile(filePath, 'utf8');

--- a/pages/api/price-alerts.js
+++ b/pages/api/price-alerts.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import path from 'path';
 
 const FILE_PATH = path.join(process.cwd(), 'data', 'price-alerts.json');

--- a/pages/api/save-search.js
+++ b/pages/api/save-search.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import path from 'path';
 
 const FILE_PATH = path.join(process.cwd(), 'data', 'saved-searches.json');

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -59,7 +59,7 @@ async function loadPrebuildPropertyIds(limit = 24) {
   }
 
   try {
-    const fs = await import('fs/promises');
+    const fs = await import('node:fs/promises');
     const pathMod = await import('path');
     const filePath = pathMod.join(process.cwd(), 'data', 'listings.json');
     const raw = await fs.readFile(filePath, 'utf8');

--- a/scripts/enrichScrayeAddresses.mjs
+++ b/scripts/enrichScrayeAddresses.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import path from 'path';
 import { promisify } from 'util';
 import { execFile } from 'child_process';

--- a/scripts/generateAreaMapData.mjs
+++ b/scripts/generateAreaMapData.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import https from 'https';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/monitor-prices.js
+++ b/scripts/monitor-prices.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import path from 'path';
 
 const LISTINGS_PATH = path.join(process.cwd(), 'data', 'listings.json');

--- a/scripts/syncScraye.mjs
+++ b/scripts/syncScraye.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import path from 'path';
 import {
   fetchScrayeListings,


### PR DESCRIPTION
## Summary
- switch all uses of `fs/promises` to `node:fs/promises` to align with Next.js bundling on Node 18+
- ensure property page prebuild helper and caching utilities work during static generation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34ffe7498832ea19587dea60428da