### PR TITLE
Disable live Apex27 fetches during CI builds

### DIFF
--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -18,6 +18,67 @@ const REGIONS_URL = 'https://api.apex27.co.uk/search-regions';
 const API_KEY = process.env.APEX27_API_KEY;
 const HAS_API_KEY = Boolean(API_KEY && API_KEY !== 'X-Api-Key');
 
+function readEnvValue(name) {
+  if (typeof process === 'undefined' || !process.env) {
+    return null;
+  }
+  return process.env[name] ?? null;
+}
+
+function parseEnvBoolean(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return null;
+}
+
+function determineShouldFetchLiveApex() {
+  const explicit = parseEnvBoolean(readEnvValue('APEX27_LIVE_FETCH'));
+  if (explicit !== null) {
+    return explicit;
+  }
+
+  const disable = parseEnvBoolean(readEnvValue('APEX27_DISABLE_LIVE_FETCH'));
+  if (disable !== null) {
+    return !disable;
+  }
+
+  if (parseEnvBoolean(readEnvValue('CI')) === true) {
+    return false;
+  }
+
+  if (parseEnvBoolean(readEnvValue('VERCEL')) === true) {
+    return false;
+  }
+
+  return HAS_API_KEY;
+}
+
+const LIVE_APEX_FETCH_ENABLED = determineShouldFetchLiveApex();
+
+function isLiveApexFetchEnabled() {
+  return HAS_API_KEY && LIVE_APEX_FETCH_ENABLED;
+}
+
+let liveApexFetchWarningLogged = false;
+
+function logLiveFetchDisabledOnce(message) {
+  if (liveApexFetchWarningLogged) {
+    return;
+  }
+  liveApexFetchWarningLogged = true;
+  console.warn(message);
+}
+
 function coercePricePrefixValue(value, seen = new Set()) {
   if (value == null) {
     return null;
@@ -359,7 +420,16 @@ function mapScrayeListingToProperty(item, transactionType) {
 export async function fetchProperties(params = {}) {
   const cached = await getCachedProperties();
 
-  if (!HAS_API_KEY) {
+  if (!HAS_API_KEY || !isLiveApexFetchEnabled()) {
+    if (cached == null) {
+      logLiveFetchDisabledOnce(
+        'Apex27 live fetch disabled and no cached listings available.'
+      );
+    } else {
+      logLiveFetchDisabledOnce(
+        'Apex27 live fetch disabled; using cached listings only.'
+      );
+    }
     return cached ?? [];
   }
 
@@ -403,6 +473,7 @@ export async function fetchProperties(params = {}) {
 export async function fetchPropertyById(id) {
   const cached = await getCachedProperties();
   const idStr = String(id ?? '').trim();
+  const allowLiveFetch = isLiveApexFetchEnabled();
 
   if (!idStr) {
     return null;
@@ -508,7 +579,7 @@ export async function fetchPropertyById(id) {
   }
 
   const targetedLookup = async () => {
-    if (!HAS_API_KEY || candidateParamSets.length === 0) {
+    if (!HAS_API_KEY || !allowLiveFetch || candidateParamSets.length === 0) {
       return null;
     }
 
@@ -549,7 +620,7 @@ export async function fetchPropertyById(id) {
 
     }
 
-    if (!HAS_API_KEY) {
+    if (!HAS_API_KEY || !allowLiveFetch) {
       return null;
     }
 
@@ -568,7 +639,12 @@ export async function fetchPropertyById(id) {
     }
   };
 
-  if (!HAS_API_KEY) {
+  if (!HAS_API_KEY || !allowLiveFetch) {
+    if (!allowLiveFetch) {
+      logLiveFetchDisabledOnce(
+        'Apex27 live fetch disabled; resolving property from cached listings only.'
+      );
+    }
     return await fallbackLookup();
   }
 
@@ -959,6 +1035,13 @@ export async function fetchPropertiesByTypeCachedFirst(type, options = {}) {
 
 export async function fetchSearchRegions() {
   if (!HAS_API_KEY) {
+    return [];
+  }
+
+  if (!isLiveApexFetchEnabled()) {
+    logLiveFetchDisabledOnce(
+      'Apex27 live fetch disabled; returning empty search regions.'
+    );
     return [];
   }
 


### PR DESCRIPTION
## Summary
- add environment-based guards that disable Apex27 live requests in CI/Vercel environments and rely on cached listings
- ensure property lookups and search region fetches respect the guard while emitting a single warning when falling back

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d350624f8c832e9bc5181102240728