### PR TITLE
Ensure cached property data available in serverless builds

### DIFF
--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -317,9 +317,32 @@ async function getCachedProperties() {
   try {
     const fs = await import('node:fs/promises');
     const pathMod = await import('path');
-    const filePath = pathMod.join(process.cwd(), 'data', 'listings.json');
-    const json = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(json);
+
+    const candidatePaths = [
+      pathMod.join(process.cwd(), 'data', 'listings.json'),
+      // Fallback for serverless environments where the working directory does
+      // not include the data folder but the traced bundle keeps the file
+      // alongside this module.
+      new URL('../data/listings.json', import.meta.url),
+    ];
+
+    for (const candidate of candidatePaths) {
+      try {
+        const json = await fs.readFile(candidate, 'utf8');
+        return JSON.parse(json);
+      } catch (error) {
+        if (error?.code === 'ENOENT') {
+          continue;
+        }
+        // Bubble up syntax errors so we can surface useful logging further
+        // down instead of silently discarding malformed caches.
+        if (error instanceof SyntaxError) {
+          throw error;
+        }
+      }
+    }
+
+    return null;
   } catch {
     return null;
   }

--- a/lib/scraye.mjs
+++ b/lib/scraye.mjs
@@ -1128,15 +1128,36 @@ export async function loadScrayeCache() {
     try {
       const fs = await import('node:fs/promises');
       const path = await import('path');
-      const filePath = path.join(process.cwd(), 'data', 'scraye.json');
-      const text = await fs.readFile(filePath, 'utf8');
-      return JSON.parse(text);
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        console.warn('Scraye cache contains invalid JSON; falling back to live fetch');
-      } else {
-        console.warn('Unable to load Scraye cache', error);
+
+      const candidatePaths = [
+        path.join(process.cwd(), 'data', 'scraye.json'),
+        new URL('../data/scraye.json', import.meta.url),
+      ];
+
+      for (const candidate of candidatePaths) {
+        try {
+          const text = await fs.readFile(candidate, 'utf8');
+          return JSON.parse(text);
+        } catch (error) {
+          if (error?.code === 'ENOENT') {
+            continue;
+          }
+          if (error instanceof SyntaxError) {
+            console.warn(
+              'Scraye cache contains invalid JSON; falling back to live fetch'
+            );
+            return null;
+          }
+          throw error;
+        }
       }
+
+      console.warn(
+        'Scraye cache not found in expected locations; falling back to live fetch'
+      );
+      return null;
+    } catch (error) {
+      console.warn('Unable to load Scraye cache', error);
       return null;
     }
   })();


### PR DESCRIPTION
## Summary
- add fallback filesystem paths so cached Apex27 listings can be read when process.cwd() lacks the data directory
- update Scraye cache loader to search multiple locations and log when the cache file is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d352fec094832e9097b233a4dd2cc3