### PR TITLE
Fix contact API to send enquiries to info address

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -23,16 +23,14 @@ export default async function handler(req, res) {
     });
 
     const from = process.env.EMAIL_FROM || process.env.SMTP_USER;
-    const aktonz = process.env.AKTONZ_EMAIL;
+    const aktonz = process.env.AKTONZ_EMAIL || 'info@aktonz.com';
 
-    if (aktonz) {
-      await transporter.sendMail({
-        to: aktonz,
-        from,
-        subject: `New enquiry from ${name}`,
-        text: `${name} <${email}> says: ${message}`,
-      });
-    }
+    await transporter.sendMail({
+      to: aktonz,
+      from,
+      subject: `New enquiry from ${name}`,
+      text: `${name} <${email}> says: ${message}`,
+    });
 
     await transporter.sendMail({
       to: email,


### PR DESCRIPTION
## Summary
- default the contact form handler to send enquiries to info@aktonz.com
- ensure the enquiry email is always dispatched to the info inbox while still acknowledging the sender

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3566be204832eb435e04136e097c6