### PR TITLE
Ensure property forms notify Aktonz

### DIFF
--- a/pages/api/book-viewing.js
+++ b/pages/api/book-viewing.js
@@ -64,6 +64,7 @@ export default async function handler(req, res) {
     });
 
     const from = process.env.FROM_EMAIL || 'no-reply@aktonz.com';
+    const aktonzEmail = process.env.AKTONZ_EMAIL || 'info@aktonz.com';
 
     await transporter.sendMail({
       from,
@@ -81,9 +82,13 @@ export default async function handler(req, res) {
 
     await transporter.sendMail({
       from,
-      to: 'info@aktonz.com',
+      to: aktonzEmail,
       subject: 'New viewing request',
-      text: `${name || 'Someone'} has requested a viewing for ${propertyTitle} on ${date} at ${time}. Contact: ${email} ${phone || ''}`,
+      text: `${
+        name || 'Someone'
+      } has requested a viewing for ${propertyTitle} on ${date} at ${time}. Contact: ${email} ${
+        phone || ''
+      }`,
     });
 
     res.status(200).json({ ok: true });

--- a/pages/api/offers.js
+++ b/pages/api/offers.js
@@ -53,16 +53,14 @@ export default async function handler(req, res) {
     });
 
     const from = process.env.EMAIL_FROM || process.env.SMTP_USER;
-    const aktonz = process.env.AKTONZ_EMAIL;
+    const aktonz = process.env.AKTONZ_EMAIL || 'info@aktonz.com';
 
-    if (aktonz) {
-      await transporter.sendMail({
-        to: aktonz,
-        from,
-        subject: `New offer for ${propertyTitle}`,
-        text: `${name} <${email}> offered £${price} ${frequency} for property ${propertyId}.`,
-      });
-    }
+    await transporter.sendMail({
+      to: aktonz,
+      from,
+      subject: `New offer for ${propertyTitle}`,
+      text: `${name} <${email}> offered £${price} ${frequency} for property ${propertyId}.`,
+    });
 
     await transporter.sendMail({
       to: email,


### PR DESCRIPTION
## Summary
- default viewing confirmation notifications to the Aktonz team address when no override is configured
- make offer notifications always deliver to the Aktonz inbox while preserving the customer receipt email

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3569def30832e9bc92320a6555eac