### PR TITLE
Handle missing SMTP config in contact API

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -12,17 +12,27 @@ export default async function handler(req, res) {
   }
 
   try {
-    const transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT || 587),
-      secure: process.env.SMTP_SECURE === 'true',
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
-    });
+    const smtpConfigProvided =
+      process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS;
 
-    const from = process.env.EMAIL_FROM || process.env.SMTP_USER;
+    const transporter = smtpConfigProvided
+      ? nodemailer.createTransport({
+          host: process.env.SMTP_HOST,
+          port: Number(process.env.SMTP_PORT || 587),
+          secure: process.env.SMTP_SECURE === 'true',
+          auth: {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASS,
+          },
+        })
+      : nodemailer.createTransport({ jsonTransport: true });
+
+    if (!smtpConfigProvided) {
+      console.warn('SMTP configuration missing. Using JSON transport.');
+    }
+
+    const from =
+      process.env.EMAIL_FROM || process.env.SMTP_USER || 'no-reply@aktonz.com';
     const aktonz = process.env.AKTONZ_EMAIL || 'info@aktonz.com';
 
     await transporter.sendMail({


### PR DESCRIPTION
## Summary
- fallback to a JSON transport when SMTP credentials are not configured so the contact API succeeds locally
- default the from address to a sensible value and log when the fallback is used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d357c86ed8832eb2b7b92e278f98fc