### PR TITLE
Fix gallery dot accessibility semantics

### DIFF
--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -137,16 +137,19 @@ export default function PropertyCard({ property }) {
                 >
                   ›
                 </button>
-                <div className="gallery-dots" role="tablist" aria-label={`${title} gallery`}>
+                <div
+                  className="gallery-dots"
+                  role="group"
+                  aria-label={`${title} gallery navigation`}
+                >
                   {images.map((_, index) => (
                     <button
                       type="button"
                       key={`${sliderKeyPrefix}-dot-${index}`}
                       className={`gallery-dot${index === currentImage ? ' active' : ''}`}
                       onClick={(event) => handleDotClick(event, index)}
-
                       aria-label={`View image ${index + 1}`}
-                      aria-current={index === currentImage ? 'true' : undefined}
+                      aria-pressed={index === currentImage}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- replace the property card gallery dot container tablist role with a simple grouped control
- expose the active slide through aria-pressed on each navigation dot to avoid missing ARIA child warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d359f259e0832e97f4c6e381c3930d