### PR TITLE
Ensure email APIs report missing SMTP configuration

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -1,0 +1,39 @@
+import nodemailer from 'nodemailer';
+
+const REQUIRED_SMTP_VARIABLES = ['SMTP_HOST', 'SMTP_USER', 'SMTP_PASS'];
+
+export function getMissingSmtpConfig() {
+  return REQUIRED_SMTP_VARIABLES.filter((key) => !process.env[key]);
+}
+
+export function createSmtpTransport() {
+  const missing = getMissingSmtpConfig();
+
+  if (missing.length > 0) {
+    const error = new Error(
+      `Missing SMTP configuration values: ${missing.join(', ')}`
+    );
+    error.code = 'SMTP_CONFIG_MISSING';
+    error.missing = missing;
+    throw error;
+  }
+
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT || 587),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+}
+
+export function resolveFromAddress(defaultFallback = 'no-reply@aktonz.com') {
+  return (
+    process.env.EMAIL_FROM ||
+    process.env.FROM_EMAIL ||
+    process.env.SMTP_USER ||
+    defaultFallback
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared Nodemailer helper that validates the SMTP environment
- update contact, offer, and viewing API routes to reuse the helper and surface configuration issues
- return API errors instead of silent success when mail cannot be sent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d35b6948f4832e923aafda1d24e122