### PR TITLE
Add gallery dataset and API endpoint

### DIFF
--- a/data/gallery.json
+++ b/data/gallery.json
@@ -1,0 +1,363 @@
+[
+  {
+    "category": "Pre appointment presentations",
+    "slug": "pre-appointment-presentations",
+    "items": [
+      {
+        "title": "Meet Your Valuer",
+        "slide": "Meet Your Valuer",
+        "agency": "Webbers New",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/webbers-new.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381022/10002143/RCCsyHvPpO4hb1T_UtxmeSXFR6J_K-MLSNhlVPSWSYaoVFenaIu-hVlR4fRTYOEd_ID3_jrc9CerSX05M4mqEA2?em=&slide=Meet_Your_Valuer"
+      },
+      {
+        "title": "Meet your valuer",
+        "slide": "Meet your valuer",
+        "agency": "Parkers",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/parkers.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381026/10002195/lQiDTBI_zljNg1GN5zlR--d4-clQvW4XHrbemkYCTt0wo5qzrw0yk57bjoCtaNY_MYAhAwJTcYPl1CTgyOUgqQ2?em=&slide=Meet_your_valuer"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Hardy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/hardy.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1370170/9856191/zTEZJTdAUaFgUDIVmpZMdJrQCYCDMCEMaxHoxSSxwD28xVQoc2vXjrBeK5MWfomrW_AnlH-_z9LPhMnq2b9tQg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Fine New",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/fine-new.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/mavity-test-estates/811331/2785817/BkjyUFoMWx1ayB9HgkpVK6VZFosoVGy1pXJ5xCV9qfQ2B8q7nijsvbjkNWn7adEuBnYAfzwrxxA-87hrA6QI0A2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 11.52.19",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-11.52.19.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3033404/34243214/aAoYt5Rhwafrn8kVHBoYcQxMeU_9xLokdYp0KBI_-AFt9cUcJS3tvqSLFb7pdT7gvskrEJ9Ec7vbKmU4cPVSiQ2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 11.54.44",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-11.54.44.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3033424/34243470/ml59z7VbFtdEY_qUtcZ7q_bOrCvfSX_29FXH9JULTiAiA7EmQDUiMEpVdiUi_eAi89HQ5Nm7g6B2ZJO4PcsRPA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 11.57.11 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-11.57.11-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3033458/34243956/GD0rb0ZJdU9s4wZ9zoLEyea-GEbthhEWI8nodoyU2nte6p-3xiszmpE69yLJE4sxETG22ihJGTzkIlMz9aQaHQ2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 11.59.38 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-11.59.38-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034034/34252547/Z-XZpweviKkc1ncywKHZXE5S5JWr5hvOJwIoQNNm3yaOOpL7QsmO7FibpIqOhB-i6Bv4IK60VkyMbJsRMwQMOQ2?em=&slide=Home"
+      }
+    ]
+  },
+  {
+    "category": "Sales proposals",
+    "slug": "sales-proposals",
+    "items": [
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.22.35 2",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.22.35-2.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034385/34257974/F5CJAJnbShbPXuGi1TzRs57MFdJn7DV1wg0L8V5cjWePPoaFRDn2mK_p7fcfVrzfRoLWq-ZhoplFHCE0LRc4lw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.24.14",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.24.14.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034369/34257727/EslSDjUR-G7T2TTNRwRdWBF9ycnd7w0V80gcWjYfwavZpBImO-rlcDq0KqDNoH6O_4PYB7IQpgMxExkyfTJf1A2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.25.29",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.25.29.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034328/34257095/X_hNzIO0aBuysUuP2fWqHiEkZ-kRi4gQrohPrH14M-GYbnl4IQIktSllBBTxGoiXRyDSr_0zXYHGkoOHwR5jXg2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.27.20 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.27.20-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034302/34256727/nxcH8VqGF5EFM68i8dVLrUHlZC2SYxk8_bdbuBm68bJ3MW02fUNpGcnt_-R1ykeHwvZFkAQUXkXoha7sb3eDKQ2?em=&slide=Home"
+      },
+      {
+        "title": "Welcome to Ryder",
+        "slide": "Welcome to Ryder",
+        "agency": "P Ryder",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/p-ryder.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1369641/9848920/mBHZy02FUVz0FNl34cE0D-UROwH6dj6twb0XLGLIiy2bLE72GeEzM2uBoRTankU9llbnz8LbzaIgGnSNZQTCtA2?em=&slide=Welcome_to_Ryder_&_Dutton"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.29.54",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.29.54.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034213/34255398/z3PLMwVK43QDD9DZqcS_Ew6Gfro42iKX5cvvbeheGdU8lMRrLrGrB4gDbSIELrphrD8dyILrZ_Y1w92dZJC9eA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.31.25 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.31.25-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034185/34254971/cKDTHus079iwgqwejTVRxU1s_n7ZFlyKte8G2tbBEDKoiKmeU8CRMdNAs4qRUfUMkL50-Ag0KMex4-jVCDmp-Q2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.32.20",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.32.20.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034128/34254061/nPGJFGpTilAqvKUxBKarE-mYUBZArz5BtqjaIdcI9Eo_l4wzEDEAYBMew1XqAgnSmv4NsNNEBVUFosJWC4LO6A2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.33.34",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.33.34.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034041/34252675/PNOUFlDoeRarV4Z9fCr8VZ1d3a3FkkGhk57gTNMcDDwR9TX0aVhDZj86vAh1qySuUxJpeOZCi-TpQzlmdRSOPw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.03.53 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.03.53-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264573/37767355/RKaQMxGE8_6JjtLupEZnDmpgy5bHcMSrPrLwjLGOCZfAjF2czrG2rWkrobzDfW1VpHJGFt6BVk557dQzDanQ9g2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.21.12",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.21.12.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035008/34267547/U-EdV8nBrXd5Y5L-5rnrsGDa-cajX5n98-mVEZz3yajWwxR-rGFV7nD7oaDWyU9L0oCXDd9YlyJD_o3UmyZDHg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.07.06",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.07.06.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264629/37768208/giw_Glzm-7midyCl-7GhG6qB_mg7_gsHC2dPZ3384trPNqV7WbqueFPrneplhiovyphyYLyL8CtStBjaM4h3Fw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.09.36 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.09.36-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264649/37768566/P5Nd3kb2pH8LhxkUzbE8skkqjQDLDJBK0zzCwZnnJKy1eFFMFbc8dFoqToepBgCwiBw0ZCMzGOtVah7KyZf8Iw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "P Ocean",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/p-ocean.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1369757/9850564/Bgc9Whqp9ZUs0PKEkLgUER4SBVRtocn3FPWNsxJbxPYWL76gbtDvNVzGoqmjowvo5UslsENWC9JtxHAoCS6urA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.12.37 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.12.37-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264870/37772002/oxbTdX9RaJn9PHmriI91g9zQPYe6BuN2uAxraFMuNBVZdwvT_UVsO2SszhLRrHyN-_6cNujePXY5ojMZ5GOmGA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.13.45 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.13.45-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264885/37772224/-gVRIwPNGqVbEXEdVZfbNLrMUITAFDOXWqnebNd878j7rCIS05AFDDYKasJN8YVD4fTx8JxccwtT8SSFBN7D_Q2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "P Cubitt",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/p-cubitt.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1369843/9851735/Sv8sj3Wf7moxZFWoQlqZrXZBL1KKy2-6WcymtJTiUoZXDQU3XaisIWdS2uV8mLkuSHGbHKr-3EX7sP55n3dllw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "P Wood",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/p-wood.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1370090/9855050/iGpG1dULl9pKaXz797EydXISeFo-xWiEpNm6Ui6dzqMB0mp4n2Z5SGQCK8BRFqkXcgWbIl9ELZbAr-3yB60EfA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Pygott",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/pygott.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381116/10003383/KLR4MuoMM7wWsK2jti8FTP_LbOf8pDFCFyp4AGFMddp970A3rJMUjos-oII63pmQtitCqjl0_la56X-e9Z4Z5A2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Frost",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/frost.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381529/10009297/jduA5DJU5iuAXnmgGeaUWpTgbzro3o9jBfBbYxbl0vcMp7XEC1NU3JTT3_Ond1sFWG1hrIFg1dsY3JeFqgLxQg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Bradleys",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/bradleys.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381583/10010194/4xBjZT49JLsCwrudseCGDtbMAliSn1tuFX3lbGhYyvR_wsH9S_ugwtjYccvjvZ9tS5cG5CIVlvZhrAfJ8Hbrfw2?em=&slide=Home"
+      },
+      {
+        "title": "Cover",
+        "slide": "Cover",
+        "agency": "Archer",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/archer.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381661/10011305/dBRVCP91EpTYmbz9qEaTqPVVq4AACrAX7dE2LEg-EiBX2agMryGvwbmq1GYuxTHTFMjiuLrIfKlVfYUx2ZT6YQ2?em=&slide=Cover"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Pepe",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/pepe.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381672/10011491/lJVyyxKu31cETeNmauiGyus1maU6la4rzoX8ZqRdDLpUICcoyZBHauf6Gf6Nfhse2yOPFZFtguz9t0GCQ_3UDw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2023 09 05 At 14.01.59",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2023/09/Screenshot-2023-09-05-at-14.01.59.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1833350/16374679/LZVs1_NLlYHeHtiaaFMAIawSDuxMFYVw6CewbsTvRUvEHW4RP-skR9L3l94Qa6e2ce16tLKZlqkRb9Do1blZEw2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Curchods",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/curchods.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381685/10011720/0CEfXVRY1zUXPRnT2EHsSMCHc0YiIFbW2tLlQcCKQs6d2FpC6hlQBN4nbhTg_gnl584wGuN7mI25OmlCA6KYZA2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Haslams",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/haslams.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381709/10012081/RhGAAJ97PR7UJvHQxFkbeMGsrCIO2oihf855XBEtST9sgatKaJxYfXNqWrzDw32yLSWID1O4rA_K9ISSSX6LDA2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Wards",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/wards.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381718/10012215/WZKmCimKWv-7kp0Cz5bu5O-wyGyy5lJPGhiuv8cVF4bnnYep_aLsufDR-eYT1KYQc4uAWeUqK-rqWmsYL56hNQ2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.03.17",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.03.17.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035136/34269412/lN0GDve8_5TYLuK7fGxPg5ji3Ob2nuXASLTtEChjr_sCiySA-rJdXL1O1Ub65KYLeHU9P_WvNVayJxSyQ8pN_g2?em=&slide=Home"
+      },
+      {
+        "title": "Your personal estate agent",
+        "slide": "Your personal estate agent",
+        "agency": "Screenshot 2025 07 04 At 12.13.54",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.13.54.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035066/34268447/Gompzb7iX10TB5DTQoSoi7PGknsuiT-ugZTdx9QfsK588pi0H_rmnVj0ybxdmp5W6Kauipi7uxAmWR6j3OkHKQ2?em=&slide=Your_personal_estate_agent"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.15.54 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.15.54-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035046/34268094/OWYnvu_DbCbqiIp3gwtPKab3uaPWpdSKBqZy5plLkIYuadC3mkwSXhDNGKhR_3EKwPXC6nVsHvhh3jfYLKIFfQ2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.19.13",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.19.13.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035031/34267883/rn-ffPYocjVi4eVpeNZNHkRYQLfTvojZMQ8b1kvzSy5HIGL6iTMmlTe56joLSiwMs0q86tUFteJbaznt37_uXg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 09 18 At 17.11.12 Copy",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/Screenshot-2025-09-18-at-17.11.12-copy.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264832/37771422/cbQ6pCl21UztBasdFb0yRQs7PdQ3Ti539mFfAOuE9mfHHpPByaDgDLo98reetn9JVtEgB0pWNdUNflGDsCKs1A2?em=&slide=Home"
+      }
+    ]
+  },
+  {
+    "category": "Lettings proposals",
+    "slug": "lettings-proposals",
+    "items": [
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "P Cooper Lettings",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/p-cooper-lettings.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1370207/9856637/Wn0-sD4x_t1m8k_-dDzcnI347pSuESDD74N3WMc_EAfs6ktLhU3tm-VVfGGQx9dDzy2pvUOQQrjOapiSGMvLvg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Keatons Lettings",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/keatons-lettings.jpg",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381515/10009110/skXyj7ULE2A7VDasET3Cmc1g9Lko2zsd0J-HkFAHdAarM9-1mj0fyNJ9_xkaY-dWEVMseDcCGHldRnFAgVoBlA2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.34.43",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.34.43.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3034041/34252675/PNOUFlDoeRarV4Z9fCr8VZ1d3a3FkkGhk57gTNMcDDwR9TX0aVhDZj86vAh1qySuUxJpeOZCi-TpQzlmdRSOPw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.35.46",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.35.46.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3033343/34242257/ndc9nzfIfQ6FK_hzXvLLh5R2TTBzM9fUr6HL6JKo3Stmbtrhl2IUjvwZeVISmhiKB_zN_2dChPlFPD47iBJ69A2?em=&slide=Home_"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.36.50",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.36.50.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3033277/34241239/K60rdjbJDextB5zr6NahfHRXyLdry51MbYKvEtpNSDK6OH34n2tdYGURa8zy_K8w7_7rfDDs68fXuTDx0xgdRg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.38.35",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.38.35.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3031102/34208299/G68RVZv0z2KXkGRwzOEG-oBy-fMxCjaDACbDlhi7rmHDpldmUU6B5pr-ormrnRzvqdVJ1i7-cbUuCSDcYfnzbg2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.41.05",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.41.05.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3030942/34205792/lHB1HQgnl9GpiK-sFVUvoHGqSnSrbQMygYLiFcSNO8W703rhpLIk-tQwR6L0wBy22w2muJeHUUTe1LcYIdqK6w2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Screenshot 2025 07 04 At 12.41.57",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/07/Screenshot-2025-07-04-at-12.41.57.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3035159/34269790/jti5HSexw04l6_ZWpYxkIFaY8RU0CyTjk5l9Lm6T1R-IC_iAPLD3HPHToojcZwLpFdrHJnR6VtE-sqsea4kVKw2?em=&slide=Home"
+      },
+      {
+        "title": "Home",
+        "slide": "Home",
+        "agency": "Buckley",
+        "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2025/09/buckley.png",
+        "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/3264602/37767811/Ub_cxXM02Zou4ih45wAwgXNeEyB9p1gAuhhZsO6k1-Z-KgEQipoNIb6WPjieWbhCgiI5l5maocs-YB0dzFDcZQ2?em=&slide=Home"
+      }
+    ]
+  }
+]

--- a/pages/api/gallery.js
+++ b/pages/api/gallery.js
@@ -1,0 +1,95 @@
+import gallery from '../../data/gallery.json';
+
+function normalize(value) {
+  return value ? String(value).trim().toLowerCase() : '';
+}
+
+function withOrder(section) {
+  return {
+    category: section.category,
+    slug: section.slug,
+    itemsCount: Array.isArray(section.items) ? section.items.length : 0,
+    items: Array.isArray(section.items)
+      ? section.items.map((item, index) => ({
+          ...item,
+          order: index + 1,
+        }))
+      : [],
+  };
+}
+
+function flattenItems(sections) {
+  const flat = [];
+  sections.forEach((section) => {
+    section.items.forEach((item) => {
+      flat.push({
+        ...item,
+        category: section.category,
+        categorySlug: section.slug,
+      });
+    });
+  });
+  return flat;
+}
+
+export default function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,HEAD');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS' || req.method === 'HEAD') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET', 'OPTIONS', 'HEAD']);
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const sections = gallery.map(withOrder);
+  const totalSections = sections.length;
+  const totalItems = sections.reduce((sum, section) => sum + section.items.length, 0);
+  const meta = {
+    generatedAt: new Date().toISOString(),
+    totalSections,
+    totalItems,
+  };
+
+  const { slug, category, view } = req.query;
+  const requestedSlug = normalize(slug || category);
+  const responseIsFlat = normalize(view) === 'flat';
+
+  if (requestedSlug) {
+    const section = sections.find(
+      (item) => normalize(item.slug) === requestedSlug || normalize(item.category) === requestedSlug
+    );
+
+    if (!section) {
+      return res.status(404).json({ error: 'Gallery category not found' });
+    }
+
+    if (responseIsFlat) {
+      return res.status(200).json({
+        ...meta,
+        items: flattenItems([section]),
+      });
+    }
+
+    return res.status(200).json({
+      ...meta,
+      section,
+    });
+  }
+
+  if (responseIsFlat) {
+    return res.status(200).json({
+      ...meta,
+      items: flattenItems(sections),
+    });
+  }
+
+  return res.status(200).json({
+    ...meta,
+    sections,
+  });
+}


### PR DESCRIPTION
## Summary
- add a curated gallery dataset generated from Acaboom presentation links
- expose a `/api/gallery` endpoint with category filtering and optional flat responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36cdfd6e4832e82a6206740b5fbcf