### PR TITLE
Fix viewing form endpoint base path

### DIFF
--- a/components/ViewingForm.js
+++ b/components/ViewingForm.js
@@ -5,6 +5,7 @@ import styles from '../styles/ViewingForm.module.css';
 
 export default function ViewingForm({ property }) {
   const router = useRouter();
+  const basePath = (router?.basePath ?? '').replace(/\/$/, '');
 
   const initialForm = {
     name: '',
@@ -48,7 +49,7 @@ export default function ViewingForm({ property }) {
     try {
       const endpoint = process.env.NEXT_PUBLIC_BOOK_VIEWING_API
         ? `${process.env.NEXT_PUBLIC_BOOK_VIEWING_API.replace(/\/$/, '')}/${propertyId}/viewings`
-        : `${router.basePath}/api/book-viewing`;
+        : `${basePath}/api/book-viewing`;
 
       const res = await fetch(endpoint, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- ensure the book viewing form falls back to an empty base path when computing its API endpoint
- keep the API call working whether or not Next.js sets router.basePath

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d3707faac4832eab917f7e8b7ca62a