### PR TITLE
Add dedicated admin dashboard header and navigation

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,7 +12,8 @@ import { SessionProvider } from '../components/SessionProvider';
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter();
-  const showHeader = !router.pathname.startsWith('/account');
+  const showHeader =
+    !router.pathname.startsWith('/account') && !router.pathname.startsWith('/admin');
 
   return (
     <>

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -29,7 +29,6 @@ function formatDate(value) {
       minute: '2-digit',
     }).format(new Date(value));
   } catch (error) {
-
     return value;
   }
 }
@@ -175,273 +174,294 @@ export default function AdminDashboard() {
     [offers],
   );
 
-  if (sessionLoading) {
-    return (
-      <main className={styles.main}>
-        <div className={styles.container}>
-          <p className={styles.loading}>Checking your admin access…</p>
+  const renderLayout = (title, content, showNavigation = false) => (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <header className={styles.adminHeader}>
+        <div className={styles.adminHeaderInner}>
+          <div className={styles.adminBrand}>
+            <span className={styles.adminBrandName}>Aktonz</span>
+            <span className={styles.adminBrandBadge}>Admin</span>
+          </div>
+          {showNavigation ? (
+            <nav className={styles.adminNav} aria-label="Admin sections">
+              <ul className={styles.adminNavList}>
+                <li>
+                  <a className={styles.adminNavLink} href="#valuations">
+                    Valuations
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.adminNavLink} href="#viewings">
+                    Viewings
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.adminNavLink} href="#offers">
+                    Offers
+                  </a>
+                </li>
+              </ul>
+            </nav>
+          ) : null}
         </div>
+      </header>
+      <main className={styles.main}>
+        <div className={styles.container}>{content}</div>
       </main>
+    </>
+  );
+
+  if (sessionLoading) {
+    return renderLayout(
+      'Aktonz Admin — Loading',
+      <p className={styles.loading}>Checking your admin access…</p>,
     );
   }
 
   if (!isAdmin) {
-    return (
-      <main className={styles.main}>
-        <div className={styles.container}>
-          <header className={styles.pageHeader}>
-            <div>
-              <p className={styles.pageEyebrow}>Operations</p>
-              <h1 className={styles.pageTitle}>Admin access required</h1>
-            </div>
-          </header>
-          <section className={styles.panel}>
-            <p className={styles.emptyState}>
-              You need to <Link href="/login">sign in with an admin account</Link> to manage valuation
-              requests and offers.
-            </p>
-          </section>
-        </div>
-      </main>
+    return renderLayout(
+      'Aktonz Admin — Access required',
+      <>
+        <header className={styles.pageHeader}>
+          <div>
+            <p className={styles.pageEyebrow}>Operations</p>
+            <h1 className={styles.pageTitle}>Admin access required</h1>
+          </div>
+        </header>
+        <section className={styles.panel}>
+          <p className={styles.emptyState}>
+            You need to <Link href="/login">sign in with an admin account</Link> to manage valuation requests and
+            offers.
+          </p>
+        </section>
+      </>,
     );
   }
 
-  return (
+  return renderLayout(
+    'Aktonz Admin — Offers & valuations',
     <>
-      <Head>
-        <title>Aktonz Admin — Offers &amp; valuations</title>
-      </Head>
-      <main className={styles.main}>
-        <div className={styles.container}>
-          <header className={styles.pageHeader}>
-            <div>
-              <p className={styles.pageEyebrow}>Operations</p>
-              <h1 className={styles.pageTitle}>Offers &amp; valuation requests</h1>
-            </div>
-            <button
-              type="button"
-              className={styles.refreshButton}
-              onClick={loadData}
-              disabled={loading}
-            >
-              Refresh
-            </button>
-          </header>
-
-          {error ? <div className={styles.error}>{error}</div> : null}
-
-          <section className={styles.panel}>
-            <div className={styles.panelHeader}>
-              <div>
-                <h2>Valuation requests</h2>
-                <p>Acaboom captures these valuation leads from the website and synchronises them here.</p>
-              </div>
-              <dl className={styles.summaryList}>
-                <div>
-                  <dt>Open</dt>
-                  <dd>{openValuations.length}</dd>
-                </div>
-                <div>
-                  <dt>Total</dt>
-                  <dd>{valuations.length}</dd>
-                </div>
-              </dl>
-            </div>
-
-            {loading ? (
-              <p className={styles.loading}>Loading valuation requests…</p>
-            ) : valuations.length ? (
-              <div className={styles.tableScroll}>
-                <table className={styles.table}>
-                  <thead>
-                    <tr>
-                      <th>Received</th>
-                      <th>Client</th>
-                      <th>Property</th>
-                      <th>Status &amp; notes</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {valuations.map((valuation) => (
-                      <tr key={valuation.id}>
-                        <td>
-                          <div className={styles.primaryText}>{formatDate(valuation.createdAt)}</div>
-                          {valuation.updatedAt && (
-                            <div className={styles.meta}>Updated {formatDate(valuation.updatedAt)}</div>
-                          )}
-                        </td>
-                        <td>
-                          <div className={styles.primaryText}>
-                            {valuation.firstName} {valuation.lastName}
-                          </div>
-                          <div className={styles.meta}>
-                            <a href={`mailto:${valuation.email}`}>{valuation.email}</a>
-                          </div>
-                          <div className={styles.meta}>
-                            <a href={`tel:${valuation.phone}`}>{valuation.phone}</a>
-                          </div>
-                        </td>
-                        <td>
-                          <div className={styles.primaryText}>{valuation.address}</div>
-                          {valuation.source ? (
-                            <div className={styles.meta}>{valuation.source}</div>
-                          ) : null}
-                          {valuation.appointmentAt ? (
-                            <div className={styles.meta}>Appointment {formatDate(valuation.appointmentAt)}</div>
-                          ) : null}
-                        </td>
-                        <td>
-                          <select
-                            className={styles.statusSelect}
-                            value={valuation.status || statusOptions[0]?.value || 'new'}
-                            onChange={(event) =>
-                              handleStatusChange(valuation, event.target.value)
-                            }
-                            disabled={updatingId === valuation.id}
-                          >
-                            {statusOptions.map((option) => (
-                              <option key={option.value} value={option.value}>
-                                {option.label}
-                              </option>
-                            ))}
-                          </select>
-                          <div className={styles.badge}>
-                            {formatStatusLabel(valuation.status, statusOptions)}
-                          </div>
-                          {valuation.presentation ? (
-                            <div className={styles.meta}>
-                              Style:{' '}
-                              {valuation.presentation.presentationUrl ? (
-                                <a
-                                  href={valuation.presentation.presentationUrl}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                >
-                                  {valuation.presentation.title || 'View presentation'}
-                                </a>
-                              ) : (
-                                valuation.presentation.title || valuation.presentation.id
-                              )}
-                            </div>
-                          ) : null}
-                          {valuation.presentation?.sentAt ? (
-                            <div className={styles.meta}>
-                              Sent {formatDate(valuation.presentation.sentAt)}
-                            </div>
-                          ) : null}
-                          {valuation.presentation?.message ? (
-                            <p className={styles.note}>
-                              <strong>Message:</strong> {valuation.presentation.message}
-                            </p>
-                          ) : null}
-                          {valuation.notes ? (
-                            <p className={styles.note}>{valuation.notes}</p>
-                          ) : null}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <p className={styles.emptyState}>No valuation requests just yet.</p>
-            )}
-          </section>
-
-          <section className={styles.panel}>
-            <div className={styles.panelHeader}>
-              <div>
-                <h2>Offers pipeline</h2>
-                <p>Review live sale and tenancy offers captured across the Aktonz platform.</p>
-              </div>
-              <dl className={styles.summaryList}>
-                <div>
-                  <dt>Sale</dt>
-                  <dd>{salesOffers.length}</dd>
-                </div>
-                <div>
-                  <dt>Rent</dt>
-                  <dd>{rentalOffers.length}</dd>
-                </div>
-              </dl>
-            </div>
-
-            {loading ? (
-              <p className={styles.loading}>Loading offers…</p>
-            ) : offers.length ? (
-              <div className={styles.tableScroll}>
-                <table className={styles.table}>
-                  <thead>
-                    <tr>
-                      <th>Received</th>
-                      <th>Property</th>
-                      <th>Client</th>
-                      <th>Offer</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {offers.map((offer) => (
-                      <tr key={offer.id}>
-                        <td>
-                          <div className={styles.primaryText}>{formatDate(offer.date)}</div>
-                          {offer.agent?.name ? (
-                            <div className={styles.meta}>Handled by {offer.agent.name}</div>
-                          ) : null}
-                        </td>
-                        <td>
-                          <div className={styles.primaryText}>{offer.property?.title || 'Unlinked property'}</div>
-                          {offer.property?.address ? (
-                            <div className={styles.meta}>{offer.property.address}</div>
-                          ) : null}
-                          {offer.property?.link ? (
-                            <div className={styles.meta}>
-                              <a href={offer.property.link} target="_blank" rel="noreferrer">
-                                View listing
-                              </a>
-                            </div>
-                          ) : null}
-                        </td>
-                        <td>
-                          <div className={styles.primaryText}>
-                            {offer.contact?.name || 'Unknown contact'}
-                          </div>
-                          {offer.contact?.email ? (
-                            <div className={styles.meta}>
-                              <a href={`mailto:${offer.contact.email}`}>{offer.contact.email}</a>
-                            </div>
-                          ) : null}
-                          {offer.contact?.phone ? (
-                            <div className={styles.meta}>
-                              <a href={`tel:${offer.contact.phone}`}>{offer.contact.phone}</a>
-                            </div>
-                          ) : null}
-                        </td>
-                        <td>
-                          <div className={styles.primaryText}>{offer.amount}</div>
-                          <div
-                            className={`${styles.offerType} ${
-                              offer.type === 'sale' ? styles.offerTypeSale : styles.offerTypeRent
-                            }`}
-                          >
-                            {offer.type === 'sale' ? 'Sale offer' : 'Tenancy offer'}
-                          </div>
-                          {offer.status ? (
-                            <div className={styles.meta}>{offer.status}</div>
-                          ) : null}
-                          {offer.notes ? <p className={styles.note}>{offer.notes}</p> : null}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <p className={styles.emptyState}>No live offers at the moment.</p>
-            )}
-          </section>
+      <header className={styles.pageHeader}>
+        <div>
+          <p className={styles.pageEyebrow}>Operations</p>
+          <h1 className={styles.pageTitle}>Offers & valuation requests</h1>
         </div>
-      </main>
-    </>
+        <button type="button" className={styles.refreshButton} onClick={loadData} disabled={loading}>
+          Refresh
+        </button>
+      </header>
 
+      {error ? <div className={styles.error}>{error}</div> : null}
+
+      <section id="valuations" className={`${styles.panel} ${styles.anchorSection}`}>
+        <div className={styles.panelHeader}>
+          <div>
+            <h2>Valuation requests</h2>
+            <p>Acaboom captures these valuation leads from the website and synchronises them here.</p>
+          </div>
+          <dl className={styles.summaryList}>
+            <div>
+              <dt>Open</dt>
+              <dd>{openValuations.length}</dd>
+            </div>
+            <div>
+              <dt>Total</dt>
+              <dd>{valuations.length}</dd>
+            </div>
+          </dl>
+        </div>
+
+        {loading ? (
+          <p className={styles.loading}>Loading valuation requests…</p>
+        ) : valuations.length ? (
+          <div className={styles.tableScroll}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Received</th>
+                  <th>Client</th>
+                  <th>Property</th>
+                  <th>Status &amp; notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {valuations.map((valuation) => (
+                  <tr key={valuation.id}>
+                    <td>
+                      <div className={styles.primaryText}>{formatDate(valuation.createdAt)}</div>
+                      {valuation.updatedAt && (
+                        <div className={styles.meta}>Updated {formatDate(valuation.updatedAt)}</div>
+                      )}
+                    </td>
+                    <td>
+                      <div className={styles.primaryText}>
+                        {valuation.firstName} {valuation.lastName}
+                      </div>
+                      <div className={styles.meta}>
+                        <a href={`mailto:${valuation.email}`}>{valuation.email}</a>
+                      </div>
+                      <div className={styles.meta}>
+                        <a href={`tel:${valuation.phone}`}>{valuation.phone}</a>
+                      </div>
+                    </td>
+                    <td>
+                      <div className={styles.primaryText}>{valuation.address}</div>
+                      {valuation.source ? <div className={styles.meta}>{valuation.source}</div> : null}
+                      {valuation.appointmentAt ? (
+                        <div className={styles.meta}>Appointment {formatDate(valuation.appointmentAt)}</div>
+                      ) : null}
+                    </td>
+                    <td>
+                      <select
+                        className={styles.statusSelect}
+                        value={valuation.status || statusOptions[0]?.value || 'new'}
+                        onChange={(event) => handleStatusChange(valuation, event.target.value)}
+                        disabled={updatingId === valuation.id}
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                      <div className={styles.badge}>{formatStatusLabel(valuation.status, statusOptions)}</div>
+                      {valuation.presentation ? (
+                        <div className={styles.meta}>
+                          Style{' '}
+                          {valuation.presentation.presentationUrl ? (
+                            <a
+                              href={valuation.presentation.presentationUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {valuation.presentation.title || 'View presentation'}
+                            </a>
+                          ) : (
+                            valuation.presentation.title || valuation.presentation.id
+                          )}
+                        </div>
+                      ) : null}
+                      {valuation.presentation?.sentAt ? (
+                        <div className={styles.meta}>Sent {formatDate(valuation.presentation.sentAt)}</div>
+                      ) : null}
+                      {valuation.presentation?.message ? (
+                        <p className={styles.note}>
+                          <strong>Message:</strong> {valuation.presentation.message}
+                        </p>
+                      ) : null}
+                      {valuation.notes ? <p className={styles.note}>{valuation.notes}</p> : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className={styles.emptyState}>No valuation requests just yet.</p>
+        )}
+      </section>
+
+      <section id="viewings" className={`${styles.panel} ${styles.anchorSection}`}>
+        <div className={styles.panelHeader}>
+          <div>
+            <h2>Viewings schedule</h2>
+            <p>Coordinate upcoming viewings and keep the team aligned.</p>
+          </div>
+        </div>
+        <p className={styles.emptyState}>Viewing management tools are coming soon.</p>
+      </section>
+
+      <section id="offers" className={`${styles.panel} ${styles.anchorSection}`}>
+        <div className={styles.panelHeader}>
+          <div>
+            <h2>Offers pipeline</h2>
+            <p>Review live sale and tenancy offers captured across the Aktonz platform.</p>
+          </div>
+          <dl className={styles.summaryList}>
+            <div>
+              <dt>Sale</dt>
+              <dd>{salesOffers.length}</dd>
+            </div>
+            <div>
+              <dt>Rent</dt>
+              <dd>{rentalOffers.length}</dd>
+            </div>
+          </dl>
+        </div>
+
+        {loading ? (
+          <p className={styles.loading}>Loading offers…</p>
+        ) : offers.length ? (
+          <div className={styles.tableScroll}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Received</th>
+                  <th>Property</th>
+                  <th>Client</th>
+                  <th>Offer</th>
+                </tr>
+              </thead>
+              <tbody>
+                {offers.map((offer) => (
+                  <tr key={offer.id}>
+                    <td>
+                      <div className={styles.primaryText}>{formatDate(offer.date)}</div>
+                      {offer.agent?.name ? (
+                        <div className={styles.meta}>Handled by {offer.agent.name}</div>
+                      ) : null}
+                    </td>
+                    <td>
+                      <div className={styles.primaryText}>{offer.property?.title || 'Unlinked property'}</div>
+                      {offer.property?.address ? <div className={styles.meta}>{offer.property.address}</div> : null}
+                      {offer.property?.link ? (
+                        <div className={styles.meta}>
+                          <a href={offer.property.link} target="_blank" rel="noreferrer">
+                            View listing
+                          </a>
+                        </div>
+                      ) : null}
+                    </td>
+                    <td>
+                      <div className={styles.primaryText}>
+                        {offer.contact?.name || 'Unknown contact'}
+                      </div>
+                      {offer.contact?.email ? (
+                        <div className={styles.meta}>
+                          <a href={`mailto:${offer.contact.email}`}>{offer.contact.email}</a>
+                        </div>
+                      ) : null}
+                      {offer.contact?.phone ? (
+                        <div className={styles.meta}>
+                          <a href={`tel:${offer.contact.phone}`}>{offer.contact.phone}</a>
+                        </div>
+                      ) : null}
+                    </td>
+                    <td>
+                      <div className={styles.primaryText}>{offer.amount}</div>
+                      <div
+                        className={`${styles.offerType} ${
+                          offer.type === 'sale' ? styles.offerTypeSale : styles.offerTypeRent
+                        }`}
+                      >
+                        {offer.type === 'sale' ? 'Sale offer' : 'Tenancy offer'}
+                      </div>
+                      {offer.status ? <div className={styles.meta}>{offer.status}</div> : null}
+                      {offer.notes ? <p className={styles.note}>{offer.notes}</p> : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className={styles.emptyState}>No live offers at the moment.</p>
+        )}
+      </section>
+    </>,
+    true,
   );
 }

--- a/styles/Admin.module.css
+++ b/styles/Admin.module.css
@@ -12,6 +12,89 @@
   gap: var(--spacing-xl);
 }
 
+.adminHeader {
+  background: var(--color-background);
+  border-bottom: 1px solid var(--color-border-light);
+  padding: var(--spacing-md) var(--spacing-md);
+}
+
+.adminHeaderInner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.adminBrand {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-xs);
+}
+
+.adminBrandName {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.adminBrandBadge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted-text);
+  background: var(--color-surface-alt);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.adminNav {
+  margin-left: auto;
+}
+
+.adminNavList {
+  list-style: none;
+  display: flex;
+  gap: var(--spacing-sm);
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.adminNavList li {
+  display: flex;
+}
+
+.adminNavLink {
+  display: inline-flex;
+  align-items: center;
+  padding: calc(var(--spacing-xs) * 1.5) var(--spacing-sm);
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--color-text);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.adminNavLink:hover,
+.adminNavLink:focus-visible {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.adminNavLink:focus-visible {
+  outline: 2px solid var(--color-border);
+  outline-offset: 2px;
+}
+
+.anchorSection {
+  scroll-margin-top: calc(var(--spacing-xl) + var(--spacing-md));
+}
+
 .pageHeader {
   display: flex;
   justify-content: space-between;
@@ -210,6 +293,18 @@
 }
 
 @media (max-width: 768px) {
+  .adminHeaderInner {
+    justify-content: center;
+  }
+
+  .adminNav {
+    width: 100%;
+  }
+
+  .adminNavList {
+    justify-content: center;
+  }
+
   .panel {
     padding: var(--spacing-lg);
   }


### PR DESCRIPTION
## Summary
- hide the marketing header on admin routes so the dashboard can render its own chrome
- add an admin dashboard header with quick navigation links and a placeholder viewings panel
- style the new admin navigation and anchor sections for better scrolling behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d376f7a454832e9706e1e7a2afdf32