### PR TITLE
Add dedicated admin views for valuations and offers

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -235,6 +235,11 @@ export default function AdminDashboard() {
               <div>
                 <h2>Valuation requests</h2>
                 <p>Acaboom captures these valuation leads from the website and synchronises them here.</p>
+                <div className={styles.panelLinks}>
+                  <Link href="/admin/valuations" className={styles.panelLink}>
+                    Manage valuation pipeline
+                  </Link>
+                </div>
               </div>
               <dl className={styles.summaryList}>
                 <div>
@@ -308,6 +313,12 @@ export default function AdminDashboard() {
                           <div className={styles.badge}>
                             {formatStatusLabel(valuation.status, statusOptions)}
                           </div>
+                          <Link
+                            href={`/admin/valuations/${encodeURIComponent(valuation.id)}`}
+                            className={styles.rowLink}
+                          >
+                            Manage this valuation
+                          </Link>
                           {valuation.presentation ? (
                             <div className={styles.meta}>
                               Style:{' '}
@@ -353,6 +364,11 @@ export default function AdminDashboard() {
               <div>
                 <h2>Offers pipeline</h2>
                 <p>Review live sale and tenancy offers captured across the Aktonz platform.</p>
+                <div className={styles.panelLinks}>
+                  <Link href="/admin/offers" className={styles.panelLink}>
+                    Manage offers workspace
+                  </Link>
+                </div>
               </div>
               <dl className={styles.summaryList}>
                 <div>
@@ -428,6 +444,12 @@ export default function AdminDashboard() {
                           {offer.status ? (
                             <div className={styles.meta}>{offer.status}</div>
                           ) : null}
+                          <Link
+                            href={`/admin/offers?id=${encodeURIComponent(offer.id)}`}
+                            className={styles.rowLink}
+                          >
+                            Review this offer
+                          </Link>
                           {offer.notes ? <p className={styles.note}>{offer.notes}</p> : null}
                         </td>
                       </tr>

--- a/pages/admin/offers/index.js
+++ b/pages/admin/offers/index.js
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { useSession } from '../../../components/SessionProvider';
+import styles from '../../../styles/AdminOffers.module.css';
+
+function formatDate(value) {
+  if (!value) {
+    return '—';
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function normalizeRouteId(value) {
+  if (Array.isArray(value)) {
+    return value[0] || null;
+  }
+
+  return typeof value === 'string' ? value : null;
+}
+
+export default function AdminOffersPage() {
+  const router = useRouter();
+  const { user, loading: sessionLoading } = useSession();
+  const isAdmin = user?.role === 'admin';
+
+  const [offers, setOffers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+
+  const loadOffers = useCallback(async () => {
+    if (!isAdmin) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/offers');
+      if (!response.ok) {
+        throw new Error('Failed to fetch offers');
+      }
+
+      const payload = await response.json();
+      const entries = Array.isArray(payload.offers) ? payload.offers.slice() : [];
+      entries.sort((a, b) => new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime());
+      setOffers(entries);
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load the offers pipeline. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setOffers([]);
+      setLoading(false);
+      return;
+    }
+
+    loadOffers();
+  }, [isAdmin, loadOffers]);
+
+  const sortedOffers = useMemo(() => offers.slice(), [offers]);
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    const routeId = normalizeRouteId(router.query.id);
+    if (routeId) {
+      setSelectedId(routeId);
+    }
+  }, [router.isReady, router.query.id]);
+
+  useEffect(() => {
+    if (!sortedOffers.length) {
+      return;
+    }
+
+    const routeId = router.isReady ? normalizeRouteId(router.query.id) : null;
+    if (routeId && sortedOffers.some((offer) => offer.id === routeId)) {
+      return;
+    }
+
+    const activeId = selectedId && sortedOffers.some((offer) => offer.id === selectedId)
+      ? selectedId
+      : sortedOffers[0]?.id;
+
+    if (activeId && activeId !== routeId) {
+      setSelectedId(activeId);
+      if (router.isReady) {
+        router.replace(
+          { pathname: '/admin/offers', query: { id: activeId } },
+          `/admin/offers?id=${activeId}`,
+          { shallow: true },
+        );
+      }
+    }
+  }, [sortedOffers, router, selectedId]);
+
+  const selectedOffer = useMemo(
+    () => sortedOffers.find((offer) => offer.id === selectedId) || null,
+    [sortedOffers, selectedId],
+  );
+
+  const handleSelectOffer = useCallback(
+    (offerId) => {
+      if (!offerId || offerId === selectedId) {
+        return;
+      }
+
+      setSelectedId(offerId);
+      if (router.isReady) {
+        router.replace(
+          { pathname: '/admin/offers', query: { id: offerId } },
+          `/admin/offers?id=${offerId}`,
+          { shallow: true },
+        );
+      }
+    },
+    [router, selectedId],
+  );
+
+  if (sessionLoading) {
+    return (
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <p className={styles.loading}>Checking your admin access…</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <section className={styles.tableSection}>
+            <p className={styles.emptyState}>
+              You need to <Link href="/login">sign in with an admin account</Link> to review and manage offers.
+            </p>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Aktonz Admin — Offers workspace</title>
+      </Head>
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <p className={styles.breadcrumb}>
+              <Link href="/admin">← Back to dashboard</Link>
+            </p>
+            <div className={styles.headerTop}>
+              <div>
+                <h1>Manage offers pipeline</h1>
+                <p>Track negotiations, review contact details and keep the sales and lettings pipeline aligned.</p>
+              </div>
+              <button
+                type="button"
+                className={styles.refreshButton}
+                onClick={loadOffers}
+                disabled={loading}
+              >
+                Refresh
+              </button>
+            </div>
+            {error ? <div className={styles.errorMessage}>{error}</div> : null}
+          </header>
+
+          <div className={styles.content}>
+            <section className={styles.tableSection}>
+              {loading && !sortedOffers.length ? (
+                <p className={styles.loading}>Loading offers…</p>
+              ) : sortedOffers.length ? (
+                <div className={styles.tableWrapper}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>Received</th>
+                        <th>Property</th>
+                        <th>Client</th>
+                        <th>Offer</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedOffers.map((offer) => (
+                        <tr
+                          key={offer.id}
+                          data-active={offer.id === selectedId}
+                          onClick={() => handleSelectOffer(offer.id)}
+                        >
+                          <td>
+                            <div className={styles.primaryCell}>
+                              <strong>{formatDate(offer.date)}</strong>
+                              {offer.agent?.name ? (
+                                <span className={styles.muted}>Handled by {offer.agent.name}</span>
+                              ) : null}
+                            </div>
+                          </td>
+                          <td>
+                            <div className={styles.primaryCell}>
+                              <strong>{offer.property?.title || 'Unlinked property'}</strong>
+                              {offer.property?.address ? (
+                                <span className={styles.muted}>{offer.property.address}</span>
+                              ) : null}
+                              {offer.property?.link ? (
+                                <a
+                                  href={offer.property.link}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className={styles.tableLink}
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  View listing
+                                </a>
+                              ) : null}
+                            </div>
+                          </td>
+                          <td>
+                            <div className={styles.primaryCell}>
+                              <strong>{offer.contact?.name || 'Unknown contact'}</strong>
+                              {offer.contact?.email ? (
+                                <a
+                                  href={`mailto:${offer.contact.email}`}
+                                  className={styles.tableLink}
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  {offer.contact.email}
+                                </a>
+                              ) : null}
+                              {offer.contact?.phone ? (
+                                <a
+                                  href={`tel:${offer.contact.phone}`}
+                                  className={styles.tableLink}
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  {offer.contact.phone}
+                                </a>
+                              ) : null}
+                            </div>
+                          </td>
+                          <td>
+                            <div className={styles.primaryCell}>
+                              <strong>{offer.amount || '—'}</strong>
+                              <span
+                                className={`${styles.offerTag} ${
+                                  offer.type === 'sale' ? styles.offerTagSale : styles.offerTagRent
+                                }`}
+                              >
+                                {offer.type === 'sale' ? 'Sale offer' : 'Tenancy offer'}
+                              </span>
+                              {offer.status ? (
+                                <span className={styles.muted}>{offer.status}</span>
+                              ) : null}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className={styles.emptyState}>No live offers captured yet.</p>
+              )}
+            </section>
+
+            <section className={styles.detailPanel}>
+              {!sortedOffers.length && !loading ? (
+                <p className={styles.emptyState}>
+                  <strong>No offers in flight.</strong> Once offers are submitted across the platform they will appear here.
+                </p>
+              ) : !selectedOffer ? (
+                <p className={styles.emptyState}>Select an offer from the table to see the full context.</p>
+              ) : (
+                <>
+                  <div className={styles.detailHeader}>
+                    <h2>
+                      {selectedOffer.contact?.name || 'Prospect'}
+                    </h2>
+                    <div
+                      className={`${styles.offerTag} ${
+                        selectedOffer.type === 'sale' ? styles.offerTagSale : styles.offerTagRent
+                      }`}
+                    >
+                      {selectedOffer.type === 'sale' ? 'Sale offer' : 'Tenancy offer'}
+                    </div>
+                  </div>
+
+                  <div className={styles.detailSummary}>
+                    {selectedOffer.contact?.email ? (
+                      <a href={`mailto:${selectedOffer.contact.email}`}>{selectedOffer.contact.email}</a>
+                    ) : null}
+                    {selectedOffer.contact?.phone ? (
+                      <a href={`tel:${selectedOffer.contact.phone}`}>{selectedOffer.contact.phone}</a>
+                    ) : null}
+                    {selectedOffer.agent?.name ? (
+                      <span className={styles.muted}>Assigned agent: {selectedOffer.agent.name}</span>
+                    ) : null}
+                  </div>
+
+                  <dl className={styles.metaGrid}>
+                    <div>
+                      <dt>Received</dt>
+                      <dd>{formatDate(selectedOffer.date)}</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{selectedOffer.status || 'Pending review'}</dd>
+                    </div>
+                    <div>
+                      <dt>Offer amount</dt>
+                      <dd className={styles.highlight}>{selectedOffer.amount || '—'}</dd>
+                    </div>
+                    {selectedOffer.property?.address ? (
+                      <div>
+                        <dt>Property</dt>
+                        <dd>{selectedOffer.property.address}</dd>
+                      </div>
+                    ) : null}
+                  </dl>
+
+                  {selectedOffer.notes ? (
+                    <p className={styles.notes}>{selectedOffer.notes}</p>
+                  ) : (
+                    <p className={styles.muted}>No additional notes recorded yet.</p>
+                  )}
+
+                  {selectedOffer.property?.link ? (
+                    <a
+                      href={selectedOffer.property.link}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={styles.tableLink}
+                    >
+                      View property listing
+                    </a>
+                  ) : null}
+                </>
+              )}
+            </section>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/pages/admin/valuations/[id].js
+++ b/pages/admin/valuations/[id].js
@@ -1,0 +1,1 @@
+export { default } from './index';

--- a/pages/admin/valuations/index.js
+++ b/pages/admin/valuations/index.js
@@ -1,0 +1,561 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import { useSession } from '../../../components/SessionProvider';
+import styles from '../../../styles/AdminValuations.module.css';
+
+const DEFAULT_STATUS_OPTIONS = [
+  { value: 'new', label: 'New' },
+  { value: 'contacted', label: 'Contacted' },
+  { value: 'valuation_sent', label: 'Valuation Sent' },
+  { value: 'lost', label: 'Lost' },
+  { value: 'archived', label: 'Archived' },
+];
+
+function formatDate(value) {
+  if (!value) {
+    return '—';
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function formatStatusLabel(status, options) {
+  const option = options.find((entry) => entry.value === status);
+  if (option) {
+    return option.label;
+  }
+
+  return options.length ? options[0].label : status;
+}
+
+function resolveStatusOptions(payload) {
+  if (Array.isArray(payload)) {
+    return payload
+      .filter((entry) => entry && typeof entry === 'object' && entry.value)
+      .map((entry) => ({
+        value: entry.value,
+        label:
+          entry.label ||
+          String(entry.value)
+            .split('_')
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' '),
+      }));
+  }
+
+  if (Array.isArray(payload?.statuses)) {
+    return payload.statuses.map((value) => ({
+      value,
+      label: String(value)
+        .split('_')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' '),
+    }));
+  }
+
+  if (Array.isArray(payload?.statusOptions)) {
+    return resolveStatusOptions(payload.statusOptions);
+  }
+
+  return DEFAULT_STATUS_OPTIONS;
+}
+
+function normalizeRouteId(value) {
+  if (Array.isArray(value)) {
+    return value[0] || null;
+  }
+
+  return typeof value === 'string' ? value : null;
+}
+
+function toDateTimeLocalInputValue(value) {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const iso = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16);
+  return iso;
+}
+
+export default function AdminValuationsPage() {
+  const router = useRouter();
+  const { user, loading: sessionLoading } = useSession();
+  const isAdmin = user?.role === 'admin';
+
+  const [valuations, setValuations] = useState([]);
+  const [statusOptions, setStatusOptions] = useState(DEFAULT_STATUS_OPTIONS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [formState, setFormState] = useState({
+    status: DEFAULT_STATUS_OPTIONS[0].value,
+    appointmentAt: '',
+    notes: '',
+  });
+
+  const loadValuations = useCallback(async () => {
+    if (!isAdmin) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/admin/valuations');
+      if (!response.ok) {
+        throw new Error('Failed to fetch valuations');
+      }
+
+      const payload = await response.json();
+      const entries = Array.isArray(payload.valuations) ? payload.valuations.slice() : [];
+      entries.sort(
+        (a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime(),
+      );
+      setValuations(entries);
+
+      const nextStatusOptions = resolveStatusOptions(payload);
+      if (nextStatusOptions.length) {
+        setStatusOptions(nextStatusOptions);
+      } else {
+        setStatusOptions(DEFAULT_STATUS_OPTIONS);
+      }
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load valuation requests. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setValuations([]);
+      setLoading(false);
+      return;
+    }
+
+    loadValuations();
+  }, [isAdmin, loadValuations]);
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    const routeId = normalizeRouteId(router.query.id);
+    if (routeId) {
+      setSelectedId(routeId);
+    }
+  }, [router.isReady, router.query.id]);
+
+  useEffect(() => {
+    if (!valuations.length) {
+      return;
+    }
+
+    const routeId = router.isReady ? normalizeRouteId(router.query.id) : null;
+    if (routeId && valuations.some((entry) => entry.id === routeId)) {
+      return;
+    }
+
+    const activeId = selectedId && valuations.some((entry) => entry.id === selectedId)
+      ? selectedId
+      : valuations[0]?.id;
+
+    if (activeId && activeId !== routeId) {
+      setSelectedId(activeId);
+      if (router.isReady) {
+        router.replace(
+          { pathname: '/admin/valuations/[id]', query: { id: activeId } },
+          `/admin/valuations/${activeId}`,
+          { shallow: true },
+        );
+      }
+    }
+  }, [valuations, router, selectedId]);
+
+  const selectedValuation = useMemo(
+    () => valuations.find((entry) => entry.id === selectedId) || null,
+    [valuations, selectedId],
+  );
+
+  useEffect(() => {
+    if (!selectedValuation) {
+      return;
+    }
+
+    setFormState({
+      status: selectedValuation.status || statusOptions[0]?.value || 'new',
+      appointmentAt: toDateTimeLocalInputValue(selectedValuation.appointmentAt),
+      notes: selectedValuation.notes || '',
+    });
+    setFormError(null);
+    setSuccessMessage('');
+  }, [selectedValuation, statusOptions]);
+
+  const handleSelectValuation = useCallback(
+    (id) => {
+      if (!id || id === selectedId) {
+        return;
+      }
+
+      setSelectedId(id);
+      setFormError(null);
+      setSuccessMessage('');
+      if (router.isReady) {
+        router.replace(
+          { pathname: '/admin/valuations/[id]', query: { id } },
+          `/admin/valuations/${id}`,
+          { shallow: true },
+        );
+      }
+    },
+    [router, selectedId],
+  );
+
+  const handleResetForm = useCallback(() => {
+    if (!selectedValuation) {
+      return;
+    }
+
+    setFormState({
+      status: selectedValuation.status || statusOptions[0]?.value || 'new',
+      appointmentAt: toDateTimeLocalInputValue(selectedValuation.appointmentAt),
+      notes: selectedValuation.notes || '',
+    });
+    setFormError(null);
+    setSuccessMessage('');
+  }, [selectedValuation, statusOptions]);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!selectedValuation) {
+        return;
+      }
+
+      const payload = { id: selectedValuation.id };
+      let hasChanges = false;
+
+      const nextStatus = formState.status || statusOptions[0]?.value || 'new';
+      if (nextStatus !== (selectedValuation.status || statusOptions[0]?.value || 'new')) {
+        payload.status = nextStatus;
+        hasChanges = true;
+      }
+
+      const currentAppointmentValue = toDateTimeLocalInputValue(selectedValuation.appointmentAt);
+      const nextAppointmentValue = formState.appointmentAt;
+      if (nextAppointmentValue !== currentAppointmentValue) {
+        if (nextAppointmentValue) {
+          const parsed = new Date(nextAppointmentValue);
+          if (Number.isNaN(parsed.getTime())) {
+            setFormError('Enter a valid appointment date and time.');
+            return;
+          }
+          payload.appointmentAt = parsed.toISOString();
+        } else {
+          payload.appointmentAt = null;
+        }
+        hasChanges = true;
+      }
+
+      const nextNotes = formState.notes ?? '';
+      const currentNotes = selectedValuation.notes ?? '';
+      if (nextNotes !== currentNotes) {
+        payload.notes = nextNotes;
+        hasChanges = true;
+      }
+
+      if (!hasChanges) {
+        setFormError(null);
+        setSuccessMessage('No changes to save — this valuation is already up to date.');
+        return;
+      }
+
+      setSaving(true);
+      setFormError(null);
+      setSuccessMessage('');
+
+      try {
+        const response = await fetch('/api/admin/valuations', {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to update valuation');
+        }
+
+        const { valuation: updated } = await response.json();
+        setValuations((current) =>
+          current.map((entry) => (entry.id === updated.id ? { ...entry, ...updated } : entry)),
+        );
+        setSuccessMessage('Valuation updated successfully.');
+      } catch (err) {
+        console.error(err);
+        setFormError('Unable to save the valuation changes. Please try again.');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [formState, selectedValuation, statusOptions],
+  );
+
+  if (sessionLoading) {
+    return (
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <p className={styles.loading}>Checking your admin access…</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <section className={styles.detailPanel}>
+            <p className={styles.emptyState}>
+              You need to <Link href="/login">sign in with an admin account</Link> to manage valuation requests.
+            </p>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Aktonz Admin — Valuation requests</title>
+      </Head>
+      <main className={styles.page}>
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <p className={styles.breadcrumb}>
+              <Link href="/admin">← Back to dashboard</Link>
+            </p>
+            <div className={styles.headerTop}>
+              <div>
+                <h1>Manage valuation requests</h1>
+                <p>Review enquiry details, log appointment notes and keep statuses in sync with your team.</p>
+              </div>
+              <button
+                type="button"
+                className={styles.refreshButton}
+                onClick={loadValuations}
+                disabled={loading}
+              >
+                Refresh
+              </button>
+            </div>
+            {error ? <div className={styles.error}>{error}</div> : null}
+          </header>
+
+          <div className={styles.content}>
+            <aside className={styles.listPanel}>
+              <div className={styles.listHeader}>
+                <h2>Valuation requests</h2>
+                <p>Select a request to view the full record.</p>
+              </div>
+              {loading && !valuations.length ? (
+                <p className={styles.loading}>Loading valuation requests…</p>
+              ) : valuations.length ? (
+                <ul className={styles.list}>
+                  {valuations.map((valuation) => (
+                    <li key={valuation.id}>
+                      <button
+                        type="button"
+                        data-active={valuation.id === selectedId}
+                        onClick={() => handleSelectValuation(valuation.id)}
+                      >
+                        <span className={styles.listPrimary}>
+                          {valuation.firstName} {valuation.lastName}
+                        </span>
+                        <span className={styles.listMeta}>{formatDate(valuation.createdAt)}</span>
+                        <span className={styles.listMeta}>
+                          {formatStatusLabel(valuation.status, statusOptions)}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={styles.emptyState}>No valuation requests to review just yet.</p>
+              )}
+            </aside>
+
+            <section className={styles.detailPanel}>
+              {!valuations.length && !loading ? (
+                <p className={styles.emptyState}>
+                  <strong>No valuation requests yet.</strong> Leads captured on the website will appear here ready for review.
+                </p>
+              ) : !selectedValuation ? (
+                <p className={styles.emptyState}>Select a valuation from the list to see the full details.</p>
+              ) : (
+                <>
+                  <div className={styles.detailHeader}>
+                    <h2>
+                      {selectedValuation.firstName} {selectedValuation.lastName}
+                    </h2>
+                    <span className={styles.statusBadge}>
+                      {formatStatusLabel(selectedValuation.status, statusOptions)}
+                    </span>
+                    <p className={styles.subtitle}>{selectedValuation.address}</p>
+                  </div>
+
+                  <div className={styles.contactLinks}>
+                    {selectedValuation.email ? (
+                      <a href={`mailto:${selectedValuation.email}`}>{selectedValuation.email}</a>
+                    ) : null}
+                    {selectedValuation.phone ? (
+                      <a href={`tel:${selectedValuation.phone}`}>{selectedValuation.phone}</a>
+                    ) : null}
+                  </div>
+
+                  <dl className={styles.metaGrid}>
+                    <div>
+                      <dt>Received</dt>
+                      <dd>{formatDate(selectedValuation.createdAt)}</dd>
+                    </div>
+                    <div>
+                      <dt>Updated</dt>
+                      <dd>{formatDate(selectedValuation.updatedAt)}</dd>
+                    </div>
+                    {selectedValuation.source ? (
+                      <div>
+                        <dt>Source</dt>
+                        <dd>{selectedValuation.source}</dd>
+                      </div>
+                    ) : null}
+                    {selectedValuation.appointmentAt ? (
+                      <div>
+                        <dt>Appointment</dt>
+                        <dd>{formatDate(selectedValuation.appointmentAt)}</dd>
+                      </div>
+                    ) : null}
+                  </dl>
+
+                  {selectedValuation.presentation ? (
+                    <div className={styles.presentationCard}>
+                      <h3>Valuation style</h3>
+                      <p className={styles.presentationMessage}>
+                        {selectedValuation.presentation.title || selectedValuation.presentation.id}
+                      </p>
+                      {selectedValuation.presentation.presentationUrl ? (
+                        <a
+                          href={selectedValuation.presentation.presentationUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className={styles.presentationLink}
+                        >
+                          Open presentation
+                        </a>
+                      ) : null}
+                      {selectedValuation.presentation.sentAt ? (
+                        <p className={styles.presentationMeta}>
+                          Sent {formatDate(selectedValuation.presentation.sentAt)}
+                        </p>
+                      ) : null}
+                      {selectedValuation.presentation.message ? (
+                        <p className={styles.presentationMessage}>
+                          {selectedValuation.presentation.message}
+                        </p>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {successMessage ? <div className={styles.success}>{successMessage}</div> : null}
+                  {formError ? <div className={styles.error}>{formError}</div> : null}
+
+                  <form className={styles.form} onSubmit={handleSubmit}>
+                    <div className={styles.formGroup}>
+                      <label htmlFor="valuation-status">Status</label>
+                      <select
+                        id="valuation-status"
+                        value={formState.status}
+                        onChange={(event) =>
+                          setFormState((current) => ({ ...current, status: event.target.value }))
+                        }
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className={styles.formGroup}>
+                      <label htmlFor="valuation-appointment">Appointment</label>
+                      <input
+                        id="valuation-appointment"
+                        type="datetime-local"
+                        value={formState.appointmentAt}
+                        onChange={(event) =>
+                          setFormState((current) => ({ ...current, appointmentAt: event.target.value }))
+                        }
+                      />
+                      <p className={styles.helperText}>Leave blank if no appointment is scheduled.</p>
+                    </div>
+
+                    <div className={styles.formGroup}>
+                      <label htmlFor="valuation-notes">Notes</label>
+                      <textarea
+                        id="valuation-notes"
+                        value={formState.notes}
+                        onChange={(event) =>
+                          setFormState((current) => ({ ...current, notes: event.target.value }))
+                        }
+                      />
+                    </div>
+
+                    <div className={styles.formActions}>
+                      <button type="submit" className={styles.primaryButton} disabled={saving}>
+                        {saving ? 'Saving…' : 'Save changes'}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.secondaryButton}
+                        onClick={handleResetForm}
+                        disabled={saving}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </form>
+                </>
+              )}
+            </section>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/styles/Admin.module.css
+++ b/styles/Admin.module.css
@@ -76,6 +76,26 @@
   color: var(--color-muted-text);
 }
 
+.panelLinks {
+  margin-top: var(--spacing-xs);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.panelLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-weight: 600;
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.panelLink:hover {
+  text-decoration: underline;
+}
+
 .summaryList {
   display: flex;
   gap: var(--spacing-lg);
@@ -162,6 +182,26 @@
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: 999px;
   background: var(--color-surface-alt);
+}
+
+.rowLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.rowLink::after {
+  content: '→';
+  font-family: inherit;
+}
+
+.rowLink:hover {
+  text-decoration: underline;
 }
 
 .offerType {

--- a/styles/AdminOffers.module.css
+++ b/styles/AdminOffers.module.css
@@ -1,143 +1,254 @@
 .page {
   min-height: 100vh;
-  background: var(--color-background, #ffffff);
-  color: var(--color-text, #0f172a);
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: var(--spacing-xl) var(--spacing-md);
 }
 
 .container {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 2.5rem 1.5rem 4rem;
   display: grid;
-  gap: 2rem;
+  gap: var(--spacing-xl);
 }
 
-.header h1 {
+.header {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.breadcrumb {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-text);
+}
+
+.breadcrumb a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.headerTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.headerTop h1 {
   margin: 0;
   font-size: 2rem;
 }
 
-.header p {
-  margin: 0.5rem 0 0;
-  color: var(--color-muted-text, #475569);
+.headerTop p {
+  margin: var(--spacing-xs) 0 0;
+  color: var(--color-muted-text);
 }
 
-.panel {
-  padding: 1.75rem;
-  border-radius: 18px;
-  border: 1px solid var(--color-border-light, #e2e8f0);
-  background: rgba(148, 163, 184, 0.12);
-}
-
-.tokenForm {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.tokenForm label {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  color: var(--color-muted-text, #475569);
-}
-
-.tokenRow {
-  display: grid;
-  gap: 1rem;
-}
-
-@media (min-width: 600px) {
-  .tokenRow {
-    grid-template-columns: 1fr auto;
-  }
-}
-
-.tokenRow input {
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid var(--color-border-light, #cbd5f5);
-  font-size: 1rem;
-}
-
-.tokenRow button {
-  padding: 0.85rem 1.8rem;
-  border-radius: 999px;
+.refreshButton {
+  background: var(--color-text);
+  color: var(--color-background);
   border: none;
-  background: var(--color-secondary, #1e293b);
-  color: var(--color-background, #ffffff);
+  border-radius: 999px;
+  padding: calc(var(--spacing-sm) * 1.5) calc(var(--spacing-md) * 1.5);
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   cursor: pointer;
+  transition: opacity 0.2s ease;
 }
 
-.error {
-  margin-top: 0.75rem;
-  color: var(--color-error, #dc2626);
+.refreshButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
-.tableSection {
+.content {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.tableSection,
+.detailPanel {
+  background: var(--color-background);
+  border-radius: 18px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.06);
+  padding: var(--spacing-xl);
+}
+
+.tableWrapper {
   overflow-x: auto;
 }
 
-.tableSection table {
+.table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--color-surface, #ffffff);
-  border-radius: 18px;
-  overflow: hidden;
+  min-width: 760px;
 }
 
-.tableSection thead {
-  background: rgba(15, 23, 42, 0.04);
-}
-
-.tableSection th,
-.tableSection td {
-  padding: 1rem 1.25rem;
+.table thead th {
   text-align: left;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted-text);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.table td {
+  padding: var(--spacing-md) var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border-light);
   vertical-align: top;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.table tbody tr:hover {
+  background: var(--color-surface-alt);
+}
+
+.table tbody tr[data-active='true'] {
+  background: var(--color-surface-alt);
 }
 
 .primaryCell {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--spacing-xs);
 }
 
 .primaryCell strong {
   font-size: 1rem;
 }
 
-.primaryCell span {
-  color: var(--color-muted-text, #475569);
-  font-size: 0.9rem;
+.primaryCell span,
+.muted {
+  font-size: 0.85rem;
+  color: var(--color-muted-text);
 }
 
-.tableSection select,
-.tableSection textarea {
-  width: 100%;
-  border-radius: 10px;
-  border: 1px solid var(--color-border-light, #cbd5f5);
-  font-size: 0.95rem;
-  padding: 0.65rem 0.75rem;
+.offerTag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 999px;
+  margin-top: var(--spacing-xs);
 }
 
-.tableSection textarea {
-  min-height: 120px;
-  resize: vertical;
+.offerTagSale {
+  background: rgba(0, 128, 96, 0.12);
+  color: var(--color-success);
 }
 
-.paymentMeta {
-  margin-top: 0.5rem;
+.offerTagRent {
+  background: rgba(0, 112, 243, 0.12);
+  color: var(--color-secondary);
+}
+
+.tableLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.tableLink::after {
+  content: '→';
+}
+
+.tableLink:hover {
+  text-decoration: underline;
+}
+
+.detailHeader {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.detailHeader h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.detailSummary {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.85rem;
+  gap: calc(var(--spacing-xs) * 1.5);
+  font-size: 0.95rem;
 }
 
-.paymentMeta a {
-  color: var(--color-secondary, #1e293b);
+.detailSummary a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.detailSummary a:hover {
   text-decoration: underline;
+}
+
+.metaGrid {
+  display: grid;
+  gap: var(--spacing-sm);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metaGrid div {
+  display: grid;
+  gap: calc(var(--spacing-xs) / 2);
+}
+
+.metaGrid dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted-text);
+}
+
+.metaGrid dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.notes {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.loading,
+.emptyState {
+  margin: 0;
+  color: var(--color-muted-text);
+}
+
+.errorMessage {
+  color: var(--color-error);
+  background: rgba(255, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-weight: 600;
+}
+
+.highlight {
+  font-weight: 600;
 }

--- a/styles/AdminValuations.module.css
+++ b/styles/AdminValuations.module.css
@@ -1,0 +1,341 @@
+.page {
+  background: var(--color-surface);
+  min-height: 100vh;
+  padding: var(--spacing-xl) var(--spacing-md);
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.header {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.breadcrumb {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-text);
+}
+
+.breadcrumb a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.headerTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.headerTop h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.headerTop p {
+  margin: var(--spacing-xs) 0 0;
+  color: var(--color-muted-text);
+}
+
+.refreshButton {
+  background: var(--color-text);
+  color: var(--color-background);
+  border: none;
+  border-radius: 999px;
+  padding: calc(var(--spacing-sm) * 1.5) calc(var(--spacing-md) * 1.5);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.refreshButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.content {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+@media (min-width: 960px) {
+  .content {
+    grid-template-columns: 320px 1fr;
+    align-items: flex-start;
+  }
+}
+
+.listPanel,
+.detailPanel {
+  background: var(--color-background);
+  border-radius: 18px;
+  padding: var(--spacing-xl);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.listHeader h2 {
+  margin: 0;
+}
+
+.listHeader p {
+  margin: 0;
+  color: var(--color-muted-text);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.list button {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+  display: grid;
+  gap: calc(var(--spacing-xs) / 2);
+}
+
+.list button:hover {
+  border-color: var(--color-border-light);
+  background: var(--color-surface-alt);
+}
+
+.list button[data-active='true'] {
+  border-color: var(--color-border);
+  background: var(--color-surface-alt);
+}
+
+.listPrimary {
+  font-weight: 600;
+}
+
+.listMeta {
+  font-size: 0.85rem;
+  color: var(--color-muted-text);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 999px;
+  background: var(--color-surface-alt);
+}
+
+.detailHeader {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.detailHeader h2 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--color-muted-text);
+}
+
+.contactLinks {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-xs) * 1.5);
+  font-size: 0.95rem;
+}
+
+.contactLinks a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
+.contactLinks a:hover {
+  text-decoration: underline;
+}
+
+.metaGrid {
+  display: grid;
+  gap: var(--spacing-sm);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metaGrid div {
+  display: grid;
+  gap: calc(var(--spacing-xs) / 2);
+}
+
+.metaGrid dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted-text);
+}
+
+.metaGrid dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.presentationCard {
+  border-radius: 14px;
+  border: 1px solid var(--color-border-light);
+  padding: var(--spacing-md);
+  background: var(--color-surface-alt);
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.presentationCard h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.presentationLink {
+  color: var(--color-secondary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.presentationLink:hover {
+  text-decoration: underline;
+}
+
+.presentationMeta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-text);
+}
+
+.presentationMessage {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.form {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.formGroup {
+  display: grid;
+  gap: calc(var(--spacing-xs) / 2);
+}
+
+.formGroup label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted-text);
+}
+
+.formGroup select,
+.formGroup textarea,
+.formGroup input {
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.formGroup textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.helperText {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-muted-text);
+}
+
+.formActions {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.primaryButton {
+  background: var(--color-text);
+  color: var(--color-background);
+  border: none;
+  border-radius: 999px;
+  padding: var(--spacing-sm) calc(var(--spacing-md) * 1.5);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondaryButton {
+  border: none;
+  background: transparent;
+  color: var(--color-muted-text);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.error,
+.success {
+  border-radius: 12px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-weight: 600;
+}
+
+.error {
+  color: var(--color-error);
+  background: rgba(255, 0, 0, 0.08);
+}
+
+.success {
+  color: var(--color-success);
+  background: rgba(0, 128, 96, 0.08);
+}
+
+.loading,
+.emptyState {
+  margin: 0;
+  color: var(--color-muted-text);
+}
+
+.emptyState strong {
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- create a valuations management view with list selection, detail editing, and status updates
- add an offers workspace with sortable table, detail summary, and admin links from the dashboard
- refresh admin styles with contextual links and shared panel helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d37630db34832e879a181524bbae6b