### PR TITLE
Customize valuation presentations per client

### DIFF
--- a/data/valuations.json
+++ b/data/valuations.json
@@ -36,7 +36,7 @@
         "thumbnailUrl": "https://acaboom.com/wp-content/uploads/2022/11/webbers-new.jpg",
         "presentationUrl": "https://cloud.clients.property/pr/acaboom-template-gallery/1381022/10002143/RCCsyHvPpO4hb1T_UtxmeSXFR6J_K-MLSNhlVPSWSYaoVFenaIu-hVlR4fRTYOEd_ID3_jrc9CerSX05M4mqEA2?em=&slide=Meet_Your_Valuer",
         "order": 1,
-        "message": "Here is the valuation presentation we discussed. Please review before Friday's appointment.",
+        "message": "Hi Luca, here is the tailored valuation presentation for 27 Murray Grove with the latest loft conversion comparables. Let me know if you'd like any other insights before Friday's appointment.",
         "selectedAt": "2025-03-18T15:45:00Z",
         "sentAt": "2025-03-18T16:00:00Z"
       }

--- a/styles/AdminValuations.module.css
+++ b/styles/AdminValuations.module.css
@@ -255,6 +255,13 @@
   gap: calc(var(--spacing-xs) / 2);
 }
 
+.formGroupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
 .formGroup label {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -275,6 +282,31 @@
 .formGroup textarea {
   min-height: 140px;
   resize: vertical;
+}
+
+.formGroup textarea:disabled {
+  background: var(--color-surface-alt);
+  color: var(--color-muted-text);
+}
+
+.linkButton {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  color: var(--color-secondary);
+  cursor: pointer;
+}
+
+.linkButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.linkButton:not(:disabled):hover,
+.linkButton:not(:disabled):focus {
+  text-decoration: underline;
 }
 
 .helperText {


### PR DESCRIPTION
## Summary
- add admin controls to select valuation presentations and craft bespoke client messages
- store personalised templates and helper text to encourage property-specific outreach
- refresh sample valuation data to demonstrate tailored messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d718beb8a8832ebfac0539d3046fde