### PR TITLE
Add Microsoft 365 connection flow to admin dashboard

### DIFF
--- a/pages/api/admin/email/microsoft/connect.js
+++ b/pages/api/admin/email/microsoft/connect.js
@@ -1,0 +1,128 @@
+import crypto from 'crypto';
+
+import { getAdminFromSession } from '../../../../../lib/admin-users.mjs';
+import { readSession } from '../../../../../lib/session.js';
+
+const STATE_COOKIE_NAME = 'aktonz_ms_state';
+const STATE_MAX_AGE = 60 * 10; // 10 minutes
+
+function requireAdmin(req, res) {
+  const session = readSession(req);
+  const admin = getAdminFromSession(session);
+
+  if (!admin) {
+    res.status(401).json({ error: 'Admin authentication required' });
+    return null;
+  }
+
+  return admin;
+}
+
+function setStateCookie(res, value) {
+  const parts = [
+    `${STATE_COOKIE_NAME}=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${STATE_MAX_AGE}`,
+  ];
+
+  if (process.env.NODE_ENV === 'production') {
+    parts.push('Secure');
+  }
+
+  res.setHeader('Set-Cookie', parts.join('; '));
+}
+
+function getOAuthConfiguration() {
+  const clientId = process.env.MICROSOFT_CLIENT_ID;
+  const redirectUri = process.env.MICROSOFT_REDIRECT_URI;
+  const tenant = process.env.MICROSOFT_TENANT_ID || 'common';
+  const scopes =
+    process.env.MICROSOFT_SCOPES || 'offline_access https://graph.microsoft.com/.default';
+
+  const missing = [];
+  if (!clientId) {
+    missing.push('MICROSOFT_CLIENT_ID');
+  }
+  if (!redirectUri) {
+    missing.push('MICROSOFT_REDIRECT_URI');
+  }
+
+  return {
+    clientId,
+    redirectUri,
+    tenant,
+    scopes,
+    missing,
+  };
+}
+
+function buildAuthorizationUrl({ clientId, redirectUri, tenant, scopes }, state) {
+  const baseUrl = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    response_mode: 'query',
+    scope: scopes,
+    state,
+  });
+
+  if (process.env.MICROSOFT_OAUTH_PROMPT) {
+    params.set('prompt', process.env.MICROSOFT_OAUTH_PROMPT);
+  } else {
+    params.set('prompt', 'consent');
+  }
+
+  if (process.env.MICROSOFT_LOGIN_HINT) {
+    params.set('login_hint', process.env.MICROSOFT_LOGIN_HINT);
+  }
+
+  return `${baseUrl}?${params.toString()}`;
+}
+
+export default function handler(req, res) {
+  if (!requireAdmin(req, res)) {
+    return;
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+
+  if (req.method === 'HEAD') {
+    return res.status(200).end();
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST', 'HEAD']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const config = getOAuthConfiguration();
+
+  if (config.missing.length) {
+    return res.status(500).json({
+      error: `Missing Microsoft integration configuration: ${config.missing.join(', ')}`,
+      missing: config.missing,
+    });
+  }
+
+  const state = crypto.randomBytes(16).toString('hex');
+
+  try {
+    setStateCookie(res, state);
+  } catch (err) {
+    console.error('Unable to set Microsoft OAuth state cookie', err);
+    return res.status(500).json({
+      error: 'Unable to initiate Microsoft connection. Try again later.',
+    });
+  }
+
+  const authorizationUrl = buildAuthorizationUrl(config, state);
+
+  return res.status(200).json({
+    authorizationUrl,
+    state,
+    message: 'Redirecting you to Microsoft to finish email configuration…',
+  });
+}

--- a/styles/Admin.module.css
+++ b/styles/Admin.module.css
@@ -159,6 +159,77 @@
   color: var(--color-muted-text);
 }
 
+.integrationActions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.integrationButton {
+  background: var(--color-secondary);
+  color: var(--color-background);
+  border: none;
+  border-radius: 999px;
+  padding: calc(var(--spacing-sm) * 1.5) calc(var(--spacing-lg));
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.integrationButton:hover,
+.integrationButton:focus-visible {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.integrationButton:focus-visible {
+  outline: 2px solid var(--color-background);
+  outline-offset: 2px;
+}
+
+.integrationButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.integrationDetails {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.integrationError {
+  margin: 0;
+  color: var(--color-error);
+  font-weight: 600;
+}
+
+.integrationStatus {
+  margin: 0;
+  color: var(--color-muted-text);
+}
+
+.integrationStatus a {
+  color: var(--color-secondary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.integrationStatus a:hover,
+.integrationStatus a:focus-visible {
+  text-decoration: underline;
+}
+
+.integrationList {
+  margin: 0;
+  padding-left: var(--spacing-lg);
+  color: var(--color-muted-text);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
 .panelLinks {
   margin-top: var(--spacing-xs);
   display: flex;


### PR DESCRIPTION
## Summary
- add a Microsoft 365 connection panel to the admin dashboard with a CTA that launches the OAuth flow
- implement an admin-only API endpoint that prepares the Microsoft authorization URL and persists the OAuth state cookie
- style the new integration section for clarity, guidance, and accessibility

## Testing
- npm test -- admin-users

------
https://chatgpt.com/codex/tasks/task_e_68d7195b2864832e92eee159f932110a