### PR TITLE
Fix admin dashboard hook order to avoid React error

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -223,33 +223,6 @@ export default function AdminDashboard() {
     </>
   );
 
-  if (sessionLoading) {
-    return renderLayout(
-      'Aktonz Admin — Loading',
-      <p className={styles.loading}>Checking your admin access…</p>,
-    );
-  }
-
-  if (!isAdmin) {
-    return renderLayout(
-      'Aktonz Admin — Access required',
-      <>
-        <header className={styles.pageHeader}>
-          <div>
-            <p className={styles.pageEyebrow}>Operations</p>
-            <h1 className={styles.pageTitle}>Admin access required</h1>
-          </div>
-        </header>
-        <section className={styles.panel}>
-          <p className={styles.emptyState}>
-            You need to <Link href="/login">sign in with an admin account</Link> to manage valuation
-            requests and offers.
-          </p>
-        </section>
-      </>,
-    );
-  }
-
   const handleConnectMicrosoft = useCallback(async () => {
     let popup = null;
     let authorizationUrl = null;
@@ -324,6 +297,33 @@ export default function AdminDashboard() {
 
     }
   }, []);
+
+  if (sessionLoading) {
+    return renderLayout(
+      'Aktonz Admin — Loading',
+      <p className={styles.loading}>Checking your admin access…</p>,
+    );
+  }
+
+  if (!isAdmin) {
+    return renderLayout(
+      'Aktonz Admin — Access required',
+      <>
+        <header className={styles.pageHeader}>
+          <div>
+            <p className={styles.pageEyebrow}>Operations</p>
+            <h1 className={styles.pageTitle}>Admin access required</h1>
+          </div>
+        </header>
+        <section className={styles.panel}>
+          <p className={styles.emptyState}>
+            You need to <Link href="/login">sign in with an admin account</Link> to manage valuation
+            requests and offers.
+          </p>
+        </section>
+      </>,
+    );
+  }
 
   return renderLayout(
     'Aktonz Admin — Offers & valuations',


### PR DESCRIPTION
## Summary
- ensure the Microsoft connection callback hook is defined before conditional early returns in the admin dashboard
- keep React hook invocation order consistent when session state changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d720772c70832e9a946e81ea83b679