### PR TITLE
Handle missing Microsoft email configuration gracefully

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -260,6 +260,19 @@ export default function AdminDashboard() {
         throw new Error(message);
       }
 
+      if (payload?.requiresConfiguration) {
+        const missing = Array.isArray(payload?.missing)
+          ? payload.missing.join(', ')
+          : null;
+        setConnectError(
+          payload?.message ||
+            (missing
+              ? `Configure these Microsoft settings before connecting: ${missing}.`
+              : 'Configure the Microsoft integration settings before connecting.'),
+        );
+        return;
+      }
+
       if (payload?.authorizationUrl) {
         authorizationUrl = payload.authorizationUrl;
         setConnectAuthorizationUrl(payload.authorizationUrl);


### PR DESCRIPTION
## Summary
- derive a redirect URI for the Microsoft OAuth flow from the incoming request when environment variables are missing
- respond with a helpful configuration message instead of a 500 error when the Microsoft integration is not yet configured
- surface the configuration guidance in the admin UI so the Microsoft connect button no longer fails silently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7220e3aa8832e9a19cbbc6d0cefc4