### PR TITLE
Adjust valuation hero spacing to avoid chat widget overlap

### DIFF
--- a/styles/Valuation.module.css
+++ b/styles/Valuation.module.css
@@ -7,7 +7,7 @@
     no-repeat center/cover;
   color: var(--color-background);
   position: relative;
-  padding: var(--spacing-xl) var(--spacing-md);
+  padding: var(--spacing-xl) var(--spacing-md) calc(var(--spacing-xl) + 9rem);
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-lg);
@@ -142,7 +142,7 @@
 
 @media (max-width: 768px) {
   .hero {
-    padding: var(--spacing-lg) var(--spacing-sm);
+    padding: var(--spacing-lg) var(--spacing-sm) calc(var(--spacing-xl) + 11rem);
   }
 
   .form {


### PR DESCRIPTION
## Summary
- increase bottom padding on the valuation hero section so the fixed chat widget no longer covers the booking form
- expand the mobile padding to maintain clear access to the submit button on smaller screens

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d7229ae0f4832eac0a67e74d5b5945