### PR TITLE
Fix contact API headers for compatibility checks

### DIFF
--- a/lib/api/contact-handler.mjs
+++ b/lib/api/contact-handler.mjs
@@ -5,15 +5,29 @@ import {
   sendMailOrThrow,
 } from '../mailer.mjs';
 
+function setCommonHeaders(res) {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Cache-Control', 'no-cache, max-age=0, s-maxage=0');
+}
+
+function respondJson(res, statusCode, payload) {
+  setCommonHeaders(res);
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  return res.status(statusCode).json(payload);
+}
+
 export default async function handleContact(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
-    return res.status(405).end('Method Not Allowed');
+    setCommonHeaders(res);
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.status(405).end('Method Not Allowed');
+    return;
   }
 
   const { name, email, message } = req.body || {};
   if (!name || !email || !message) {
-    return res.status(400).json({ error: 'Missing required fields' });
+    return respondJson(res, 400, { error: 'Missing required fields' });
   }
 
   try {
@@ -46,19 +60,19 @@ export default async function handleContact(req, res) {
   } catch (err) {
     if (err?.code === 'SMTP_CONFIG_MISSING') {
       console.error('SMTP configuration missing for contact form', err.missing);
-      return res
-        .status(500)
-        .json({ error: 'Email service is not configured.' });
+      return respondJson(res, 500, {
+        error: 'Email service is not configured.',
+      });
     }
 
     if (err?.code === 'SMTP_DELIVERY_FAILED') {
       console.error('SMTP rejected contact form message', err.missing, err.info);
-      return res.status(502).json({ error: 'Email delivery failed.' });
+      return respondJson(res, 502, { error: 'Email delivery failed.' });
     }
 
     console.error('Failed to send enquiry emails', err);
-    return res.status(500).json({ error: 'Failed to send message' });
+    return respondJson(res, 500, { error: 'Failed to send message' });
   }
 
-  return res.status(200).json({ ok: true });
+  return respondJson(res, 200, { ok: true });
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,15 @@ function withNoSniff(headers) {
 
 const staticHeaders = [
   {
+    source: '/((?!_next/static).*)',
+    headers: withNoSniff([
+      {
+        key: 'Cache-Control',
+        value: 'no-cache, max-age=0, s-maxage=0',
+      },
+    ]),
+  },
+  {
     source: '/_next/static/:buildId/_buildManifest.js',
     headers: withNoSniff([
       {
@@ -78,7 +87,7 @@ const staticHeaders = [
     headers: withNoSniff([
       {
         key: 'Cache-Control',
-        value: 'no-store',
+        value: 'no-cache, max-age=0, s-maxage=0',
       },
     ]),
 
@@ -88,7 +97,7 @@ const staticHeaders = [
     headers: withNoSniff([
       {
         key: 'Cache-Control',
-        value: 'no-store',
+        value: 'no-cache, max-age=0, s-maxage=0',
       },
     ]),
 


### PR DESCRIPTION
## Summary
- ensure the contact form API always returns JSON with utf-8 charset and shared cache-control + nosniff headers
- configure site-wide dynamic route headers to drop must-revalidate/no-store directives while keeping security header coverage

## Testing
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d749b26f58832ea41bbb1484f075de