### PR TITLE
Add Microsoft Graph status APIs and smoke test script

### DIFF
--- a/README-aktonz-email.md
+++ b/README-aktonz-email.md
@@ -1,0 +1,26 @@
+# Microsoft Graph Email Setup for aktonz.com
+
+## Azure AD configuration
+- App Registration → **API permissions (Delegated)**: add `Mail.Send`, `offline_access`, and `User.Read`, then click **Grant admin consent** for the tenant.
+- App Registration → **Authentication**: confirm `https://aktonz.com/api/microsoft/callback` exists and add the dev URI `http://localhost:3000/api/admin/email/microsoft/callback`.
+- App Registration → **Certificates & secrets**: create a new client secret named `aktonz-prod`, copy the **Value**, update the Vercel env var, and delete any old secrets.
+- App Registration → **Supported account types**: keep the app single-tenant.
+- Authentication → **Implicit/hybrid flows**: ensure all toggles remain **Off**.
+
+## Required Vercel environment variables
+Set the following in the Production and Preview environments:
+- `MS_CLIENT_SECRET` – latest value from the Azure app registration.
+- `TOKEN_ENCRYPTION_KEY` – 32-byte random value encoded with `openssl rand -base64 32`.
+- `KV_REST_API_URL` (or `KV_URL`) and `KV_REST_API_TOKEN` – provided when linking the Vercel KV database.
+
+## Redirect URIs
+- Production: `https://aktonz.com/api/microsoft/callback`
+- Local development: `http://localhost:3000/api/admin/email/microsoft/callback`
+
+## Test plan (6 steps)
+1. Navigate to `/admin` and click **Connect to Microsoft**; sign in with `info@aktonz.com` and grant consent.
+2. In Vercel KV, verify the `aktonz:ms:tokens` hash contains `access`, `refresh`, and `expiresAt` fields.
+3. Submit `/api/contact` with sample data and confirm an email arrives in the `info@aktonz.com` mailbox.
+4. Submit `/api/book-viewing`, `/api/offers`, and `/api/valuations` to ensure each sends mail to the correct recipient list.
+5. Wait for the access token to age, then trigger another form submission to confirm automatic refresh works.
+6. Revoke the client secret in Azure, set a new `MS_CLIENT_SECRET` in Vercel, and repeat step 1 to ensure rotation succeeds.

--- a/lib/crypto-util.ts
+++ b/lib/crypto-util.ts
@@ -1,0 +1,68 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH_BYTES = 12;
+
+export interface EncryptedPayload {
+  iv: string;
+  authTag: string;
+  ciphertext: string;
+}
+
+function getKey(): Buffer {
+  const keyBase64 = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!keyBase64) {
+    throw new Error('TOKEN_ENCRYPTION_KEY environment variable is required');
+  }
+
+  const key = Buffer.from(keyBase64, 'base64');
+  if (key.length !== 32) {
+    throw new Error('TOKEN_ENCRYPTION_KEY must be a base64-encoded 32-byte value for AES-256-GCM');
+  }
+
+  return key;
+}
+
+export function encryptText(plaintext: string): EncryptedPayload {
+  const iv = randomBytes(IV_LENGTH_BYTES);
+  const cipher = createCipheriv(ALGORITHM, getKey(), iv);
+
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    iv: iv.toString('base64'),
+    authTag: authTag.toString('base64'),
+    ciphertext: ciphertext.toString('base64'),
+  };
+}
+
+export function decryptText(payload: EncryptedPayload): string {
+  const iv = Buffer.from(payload.iv, 'base64');
+  const authTag = Buffer.from(payload.authTag, 'base64');
+  const ciphertext = Buffer.from(payload.ciphertext, 'base64');
+
+  const decipher = createDecipheriv(ALGORITHM, getKey(), iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+export function serializeEncryptedPayload(payload: EncryptedPayload): string {
+  return JSON.stringify(payload);
+}
+
+export function deserializeEncryptedPayload(serialized: string): EncryptedPayload {
+  const parsed = JSON.parse(serialized);
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid encrypted payload');
+  }
+
+  return {
+    iv: parsed.iv,
+    authTag: parsed.authTag,
+    ciphertext: parsed.ciphertext,
+  };
+}

--- a/lib/ms-graph.ts
+++ b/lib/ms-graph.ts
@@ -1,0 +1,132 @@
+import { encryptText, decryptText } from './crypto-util';
+import { clearTokenSet, loadTokenSet, saveTokenSet } from './token-store';
+
+export const MS_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
+export const MS_TENANT_ID = '60737a1b-9707-4d7f-9909-0ee943a1ffff';
+export const MS_REDIRECT_URI = 'https://aktonz.com/api/microsoft/callback';
+export const SCOPES = 'offline_access Mail.Send User.Read';
+export const ALLOWED_UPN = 'info@aktonz.com';
+
+const TOKEN_ENDPOINT = `https://login.microsoftonline.com/${MS_TENANT_ID}/oauth2/v2.0/token`;
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+interface RefreshResponse {
+  token_type?: string;
+  scope?: string;
+  expires_in?: number;
+  ext_expires_in?: number;
+  access_token: string;
+  refresh_token: string;
+}
+
+export function getClientSecret(): string {
+  const secret = process.env.MS_CLIENT_SECRET;
+  if (!secret) {
+    throw new Error('MS_CLIENT_SECRET environment variable is required');
+  }
+
+  return secret;
+}
+
+export async function getValidAccessToken(): Promise<string> {
+  const tokenSet = await loadTokenSet();
+
+  if (!tokenSet) {
+    throw new Error('Microsoft Graph connector is not yet configured. Connect via the admin dashboard.');
+  }
+
+  const now = Date.now();
+  const refreshThreshold = now + 60_000; // refresh 60 seconds before expiry
+
+  if (tokenSet.expiresAt > refreshThreshold) {
+    return decryptText(tokenSet.encryptedAccessToken);
+  }
+
+  const refreshToken = decryptText(tokenSet.encryptedRefreshToken);
+  const params = new URLSearchParams({
+    client_id: MS_CLIENT_ID,
+    scope: SCOPES,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+    client_secret: getClientSecret(),
+  });
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+
+  if (!response.ok) {
+    await clearTokenSet();
+    throw new Error(`Failed to refresh Microsoft Graph tokens (${response.status})`);
+  }
+
+  const result = (await response.json()) as RefreshResponse;
+
+  if (!result.access_token || !result.refresh_token) {
+    await clearTokenSet();
+    throw new Error('Microsoft Graph token refresh returned an unexpected payload');
+  }
+
+  const expiresInSeconds = result.expires_in ?? 0;
+  const expiresAt = Date.now() + Math.max(0, expiresInSeconds - 60) * 1000; // 60-second safety window
+
+  await saveTokenSet({
+    encryptedAccessToken: encryptText(result.access_token),
+    encryptedRefreshToken: encryptText(result.refresh_token),
+    expiresAt,
+    scope: result.scope,
+    tokenType: result.token_type,
+  });
+
+  return result.access_token;
+}
+
+export interface SendMailOptions {
+  subject: string;
+  html: string;
+  to: string[];
+  replyTo?: string;
+}
+
+export async function sendMailGraph(options: SendMailOptions): Promise<void> {
+  const accessToken = await getValidAccessToken();
+
+  const toRecipients = options.to.map((address) => ({
+    emailAddress: { address },
+  }));
+
+  const payload = {
+    message: {
+      subject: options.subject,
+      body: {
+        contentType: 'HTML',
+        content: options.html,
+      },
+      toRecipients,
+      replyTo: options.replyTo
+        ? [
+            {
+              emailAddress: { address: options.replyTo },
+            },
+          ]
+        : undefined,
+    },
+    saveToSentItems: false,
+  };
+
+  const response = await fetch(`${GRAPH_BASE_URL}/users/${encodeURIComponent(ALLOWED_UPN)}/sendMail`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Microsoft Graph sendMail failed (${response.status}): ${errorText}`);
+  }
+}

--- a/lib/ms-oauth.ts
+++ b/lib/ms-oauth.ts
@@ -1,0 +1,94 @@
+import { encryptText } from './crypto-util';
+import { ALLOWED_UPN, MS_CLIENT_ID, MS_TENANT_ID, SCOPES, getClientSecret } from './ms-graph';
+import { saveTokenSet } from './token-store';
+
+const TOKEN_ENDPOINT = `https://login.microsoftonline.com/${MS_TENANT_ID}/oauth2/v2.0/token`;
+const GRAPH_ME_ENDPOINT = 'https://graph.microsoft.com/v1.0/me?$select=displayName,userPrincipalName,mail';
+
+interface TokenResponse {
+  token_type?: string;
+  scope?: string;
+  expires_in?: number;
+  access_token: string;
+  refresh_token: string;
+}
+
+interface GraphUser {
+  displayName?: string;
+  userPrincipalName?: string;
+  mail?: string;
+}
+
+export interface OAuthResult {
+  accountUpn: string;
+}
+
+export async function handleOAuthCallback(code: string, redirectUri: string): Promise<OAuthResult> {
+  const tokens = await exchangeAuthorizationCode(code, redirectUri);
+  const profile = await fetchProfile(tokens.access_token);
+  const accountUpn = (profile.userPrincipalName ?? profile.mail ?? '').toLowerCase();
+
+  if (accountUpn !== ALLOWED_UPN.toLowerCase()) {
+    throw new Error('The signed-in account is not authorised for aktonz.com');
+  }
+
+  const expiresInSeconds = tokens.expires_in ?? 0;
+  const expiresAt = Date.now() + Math.max(0, expiresInSeconds - 60) * 1000; // refresh 1 minute early
+
+  await saveTokenSet({
+    encryptedAccessToken: encryptText(tokens.access_token),
+    encryptedRefreshToken: encryptText(tokens.refresh_token),
+    expiresAt,
+    scope: tokens.scope,
+    tokenType: tokens.token_type,
+  });
+
+  return {
+    accountUpn: profile.userPrincipalName ?? profile.mail ?? ALLOWED_UPN,
+  };
+}
+
+async function exchangeAuthorizationCode(code: string, redirectUri: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    client_id: MS_CLIENT_ID,
+    scope: SCOPES,
+    redirect_uri: redirectUri,
+    grant_type: 'authorization_code',
+    code,
+    client_secret: getClientSecret(),
+  });
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Microsoft identity platform token exchange failed (${response.status}): ${text}`);
+  }
+
+  const payload = (await response.json()) as TokenResponse;
+
+  if (!payload.access_token || !payload.refresh_token) {
+    throw new Error('Microsoft identity platform did not return both access and refresh tokens');
+  }
+
+  return payload;
+}
+
+async function fetchProfile(accessToken: string): Promise<GraphUser> {
+  const response = await fetch(GRAPH_ME_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Unable to fetch Microsoft profile (${response.status}): ${text}`);
+  }
+
+  return (await response.json()) as GraphUser;
+}

--- a/lib/token-store.ts
+++ b/lib/token-store.ts
@@ -1,0 +1,46 @@
+import { kv } from '@vercel/kv';
+import {
+  EncryptedPayload,
+  deserializeEncryptedPayload,
+  serializeEncryptedPayload,
+} from './crypto-util';
+
+const TOKEN_KEY = 'aktonz:ms:tokens';
+
+export interface StoredTokenSet {
+  encryptedAccessToken: EncryptedPayload;
+  encryptedRefreshToken: EncryptedPayload;
+  expiresAt: number;
+  scope?: string;
+  tokenType?: string;
+}
+
+export async function saveTokenSet(tokenSet: StoredTokenSet): Promise<void> {
+  await kv.hset(TOKEN_KEY, {
+    access: serializeEncryptedPayload(tokenSet.encryptedAccessToken),
+    refresh: serializeEncryptedPayload(tokenSet.encryptedRefreshToken),
+    expiresAt: tokenSet.expiresAt.toString(),
+    scope: tokenSet.scope ?? '',
+    tokenType: tokenSet.tokenType ?? '',
+  });
+}
+
+export async function loadTokenSet(): Promise<StoredTokenSet | null> {
+  const record = await kv.hgetall<Record<string, string>>(TOKEN_KEY);
+
+  if (!record || !record.access || !record.refresh || !record.expiresAt) {
+    return null;
+  }
+
+  return {
+    encryptedAccessToken: deserializeEncryptedPayload(record.access),
+    encryptedRefreshToken: deserializeEncryptedPayload(record.refresh),
+    expiresAt: Number.parseInt(record.expiresAt, 10),
+    scope: record.scope || undefined,
+    tokenType: record.tokenType || undefined,
+  };
+}
+
+export async function clearTokenSet(): Promise<void> {
+  await kv.del(TOKEN_KEY);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@vercel/kv": "^3.0.0",
         "leaflet": "^1.9.4",
         "next": "^15.5.2",
         "nodemailer": "^6.9.11",
@@ -24,8 +25,10 @@
       },
       "devDependencies": {
         "@turf/turf": "^7.2.0",
+        "@types/react": "19.1.14",
         "https-proxy-agent": "^7.0.6",
-        "jest": "^30.1.3"
+        "jest": "^30.1.3",
+        "typescript": "5.9.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3939,6 +3942,16 @@
         "undici-types": "~7.11.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.14.tgz",
+      "integrity": "sha512-ukd93VGzaNPMAUPy0gRDSC57UuQbnH9Kussp7HBjM06YFi9uZTFhOvMSO2OKqXm1rSgzOE+pVx1k1PYHGwlc8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4238,6 +4251,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.4",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.4.tgz",
+      "integrity": "sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -4840,6 +4874,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "1.2.4",
@@ -7827,6 +7868,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.19.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "cache": "node scripts/cacheListings.mjs",
     "check-pr": "node scripts/check-pr.mjs",
     "check-ms-connector": "node scripts/check-ms-connector.mjs",
-
     "monitor": "node scripts/monitor-prices.js",
     "sync:scraye": "node scripts/syncScraye.mjs"
   },
@@ -20,6 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@vercel/kv": "^3.0.0",
     "leaflet": "^1.9.4",
     "next": "^15.5.2",
     "nodemailer": "^6.9.11",
@@ -35,7 +35,9 @@
   },
   "devDependencies": {
     "@turf/turf": "^7.2.0",
+    "@types/react": "19.1.14",
     "https-proxy-agent": "^7.0.6",
-    "jest": "^30.1.3"
+    "jest": "^30.1.3",
+    "typescript": "5.9.2"
   }
 }

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,95 @@
+import Head from 'next/head';
+import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+
+const AdminPage: NextPage = () => {
+  const router = useRouter();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    if (router.query.connected === '1') {
+      setStatus('success');
+    } else if (router.query.error) {
+      setStatus('error');
+    }
+  }, [router.isReady, router.query]);
+
+  const statusMessage = useMemo(() => {
+    switch (status) {
+      case 'success':
+        return 'Microsoft Graph connection updated successfully.';
+      case 'error':
+        return 'Unable to complete Microsoft Graph connection. Please try again.';
+      default:
+        return null;
+    }
+  }, [status]);
+
+  const handleConnectClick = () => {
+    setIsRedirecting(true);
+    window.location.href = '/api/microsoft/connect';
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Admin — Microsoft Graph Email</title>
+      </Head>
+      <main
+        style={{
+          maxWidth: '640px',
+          margin: '0 auto',
+          padding: '3rem 1.5rem',
+          fontFamily: 'Arial, sans-serif',
+        }}
+      >
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem' }}>Microsoft Graph Email</h1>
+        <p style={{ marginBottom: '1.5rem', lineHeight: 1.5 }}>
+          Connect the aktonz.com shared mailbox to Microsoft Graph. You will be redirected to sign in
+          with the authorised account (<strong>info@aktonz.com</strong>). Once completed, encrypted tokens are
+          stored in Vercel KV for sending transactional emails.
+        </p>
+        <button
+          onClick={handleConnectClick}
+          type="button"
+          disabled={isRedirecting}
+          style={{
+            padding: '0.75rem 1.5rem',
+            fontSize: '1rem',
+            fontWeight: 600,
+            borderRadius: '0.5rem',
+            border: 'none',
+            color: '#fff',
+            backgroundColor: isRedirecting ? '#94a3b8' : '#2563eb',
+            cursor: isRedirecting ? 'not-allowed' : 'pointer',
+            transition: 'background-color 0.2s ease',
+          }}
+        >
+          {isRedirecting ? 'Redirecting…' : 'Connect to Microsoft'}
+        </button>
+        {statusMessage && (
+          <p
+            role="status"
+            style={{
+              marginTop: '1.5rem',
+              padding: '1rem',
+              borderRadius: '0.5rem',
+              backgroundColor: status === 'success' ? '#dcfce7' : '#fee2e2',
+              color: status === 'success' ? '#166534' : '#991b1b',
+            }}
+          >
+            {statusMessage}
+          </p>
+        )}
+      </main>
+    </>
+  );
+};
+
+export default AdminPage;

--- a/pages/api/admin/email/microsoft/callback.ts
+++ b/pages/api/admin/email/microsoft/callback.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleOAuthCallback } from '../../../../../lib/ms-oauth';
+
+const DEV_REDIRECT_URI = 'http://localhost:3000/api/admin/email/microsoft/callback';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { code, error } = req.query;
+
+  if (error) {
+    res.status(400).json({ error: String(error) });
+    return;
+  }
+
+  if (typeof code !== 'string' || !code) {
+    res.status(400).json({ error: 'Missing authorization code' });
+    return;
+  }
+
+  try {
+    await handleOAuthCallback(code, DEV_REDIRECT_URI);
+    res.redirect(302, '/admin?connected=1');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Microsoft Graph connection failed';
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/book-viewing.ts
+++ b/pages/api/book-viewing.ts
@@ -1,0 +1,107 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { sendMailGraph } from '../../lib/ms-graph';
+
+type FormBody = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  message?: string;
+  propertyId?: string;
+  [key: string]: unknown;
+};
+
+const RECIPIENTS = ['info@aktonz.com'];
+const FORM_TITLE = 'Book a viewing request';
+const SUBJECT = 'aktonz.com book a viewing form';
+
+function normaliseBody(req: NextApiRequest): FormBody {
+  if (!req.body) {
+    return {};
+  }
+
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body) as FormBody;
+    } catch (error) {
+      throw new Error('Invalid JSON payload');
+    }
+  }
+
+  return req.body as FormBody;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildHtml(body: FormBody): string {
+  const baseRows = [
+    ['Name', body.name ?? ''],
+    ['Email', body.email ?? ''],
+    ['Phone', body.phone ?? ''],
+    ['Property ID', body.propertyId ?? ''],
+    ['Message', body.message ?? ''],
+  ];
+
+  const additionalRows = Object.entries(body)
+    .filter(([key]) => !['name', 'email', 'phone', 'message', 'propertyId'].includes(key))
+    .map(([key, value]) => [key, value]);
+
+  const rows = [...baseRows, ...additionalRows]
+    .map(
+      ([label, value]) =>
+        `<tr><th align="left" style="padding:4px 8px;background:#f7f7f7;border:1px solid #ddd;">${escapeHtml(
+          label,
+        )}</th><td style="padding:4px 8px;border:1px solid #ddd;">${escapeHtml(value)}</td></tr>`,
+    )
+    .join('');
+
+  return `
+    <h2 style="font-family:Arial,sans-serif;">${escapeHtml(FORM_TITLE)}</h2>
+    <table style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">${rows}</table>
+  `;
+}
+
+function resolveReplyTo(email: unknown): string | undefined {
+  if (typeof email !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = email.trim();
+  return trimmed.includes('@') ? trimmed : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body: FormBody;
+
+  try {
+    body = normaliseBody(req);
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request body' });
+    return;
+  }
+
+  try {
+    await sendMailGraph({
+      subject: SUBJECT,
+      html: buildHtml(body),
+      to: RECIPIENTS,
+      replyTo: resolveReplyTo(body.email),
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to send email' });
+  }
+}

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,0 +1,103 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { sendMailGraph } from '../../lib/ms-graph';
+
+type FormBody = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  message?: string;
+  [key: string]: unknown;
+};
+
+const RECIPIENTS = ['info@aktonz.com'];
+
+function normaliseBody(req: NextApiRequest): FormBody {
+  if (!req.body) {
+    return {};
+  }
+
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body) as FormBody;
+    } catch (error) {
+      throw new Error('Invalid JSON payload');
+    }
+  }
+
+  return req.body as FormBody;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildHtml(body: FormBody): string {
+  const baseRows = [
+    ['Name', body.name ?? ''],
+    ['Email', body.email ?? ''],
+    ['Phone', body.phone ?? ''],
+    ['Message', body.message ?? ''],
+  ];
+
+  const additionalRows = Object.entries(body)
+    .filter(([key]) => !['name', 'email', 'phone', 'message'].includes(key))
+    .map(([key, value]) => [key, value]);
+
+  const rows = [...baseRows, ...additionalRows]
+    .map(
+      ([label, value]) =>
+        `<tr><th align="left" style="padding:4px 8px;background:#f7f7f7;border:1px solid #ddd;">${escapeHtml(
+          label,
+        )}</th><td style="padding:4px 8px;border:1px solid #ddd;">${escapeHtml(value)}</td></tr>`,
+    )
+    .join('');
+
+  return `
+    <h2 style="font-family:Arial,sans-serif;">New contact form submission</h2>
+    <table style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">${rows}</table>
+  `;
+}
+
+function resolveReplyTo(email: unknown): string | undefined {
+  if (typeof email !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = email.trim();
+  return trimmed.includes('@') ? trimmed : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body: FormBody;
+
+  try {
+    body = normaliseBody(req);
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request body' });
+    return;
+  }
+
+  try {
+    await sendMailGraph({
+      subject: 'aktonz.com contact form',
+      html: buildHtml(body),
+      to: RECIPIENTS,
+      replyTo: resolveReplyTo(body.email),
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to send email' });
+  }
+}

--- a/pages/api/microsoft/callback.ts
+++ b/pages/api/microsoft/callback.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { MS_REDIRECT_URI } from '../../../lib/ms-graph';
+import { handleOAuthCallback } from '../../../lib/ms-oauth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { code, error } = req.query;
+
+  if (error) {
+    res.status(400).json({ error: String(error) });
+    return;
+  }
+
+  if (typeof code !== 'string' || !code) {
+    res.status(400).json({ error: 'Missing authorization code' });
+    return;
+  }
+
+  try {
+    await handleOAuthCallback(code, MS_REDIRECT_URI);
+    res.redirect(302, '/admin?connected=1');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Microsoft Graph connection failed';
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/microsoft/connect.ts
+++ b/pages/api/microsoft/connect.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { MS_CLIENT_ID, MS_REDIRECT_URI, MS_TENANT_ID, SCOPES } from '../../../lib/ms-graph';
+
+const DEV_REDIRECT_URI = 'http://localhost:3000/api/admin/email/microsoft/callback';
+
+function resolveRedirectUri(req: NextApiRequest): string {
+  const host = req.headers.host ?? '';
+  const isLocal = host.includes('localhost') || host.startsWith('127.0.0.1');
+  return isLocal ? DEV_REDIRECT_URI : MS_REDIRECT_URI;
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse): void {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const redirectUri = resolveRedirectUri(req);
+  const params = new URLSearchParams({
+    client_id: MS_CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    response_mode: 'query',
+    scope: SCOPES,
+    prompt: 'consent',
+  });
+
+  const authorizeUrl = `https://login.microsoftonline.com/${MS_TENANT_ID}/oauth2/v2.0/authorize?${params.toString()}`;
+  res.redirect(authorizeUrl);
+}

--- a/pages/api/microsoft/self.ts
+++ b/pages/api/microsoft/self.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getValidAccessToken } from '../../../lib/ms-graph';
+
+const GRAPH_ME_URL = 'https://graph.microsoft.com/v1.0/me?$select=displayName,userPrincipalName,mail,id';
+
+type GraphMeResponse = {
+  displayName?: string;
+  userPrincipalName?: string;
+  mail?: string;
+  id?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ connected: true; account: GraphMeResponse } | { error: string }>,
+): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const accessToken = await getValidAccessToken();
+    const response = await fetch(GRAPH_ME_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      res.status(response.status).json({ error: `Graph /me request failed (${response.status}): ${errorText}` });
+      return;
+    }
+
+    const payload = (await response.json()) as GraphMeResponse;
+    res.status(200).json({ connected: true, account: payload });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/microsoft/status.ts
+++ b/pages/api/microsoft/status.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { loadTokenSet } from '../../../lib/token-store';
+
+interface StatusResponse {
+  connected: boolean;
+  expiresAt?: number;
+  expiresInSeconds?: number;
+  scope?: string | null;
+  tokenType?: string | null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<StatusResponse | { error: string }>,
+): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const tokenSet = await loadTokenSet();
+
+    if (!tokenSet) {
+      res.status(200).json({ connected: false });
+      return;
+    }
+
+    const expiresInSeconds = Math.max(0, Math.round((tokenSet.expiresAt - Date.now()) / 1000));
+
+    res.status(200).json({
+      connected: true,
+      expiresAt: tokenSet.expiresAt,
+      expiresInSeconds,
+      scope: tokenSet.scope ?? null,
+      tokenType: tokenSet.tokenType ?? null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/offers.ts
+++ b/pages/api/offers.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { sendMailGraph } from '../../lib/ms-graph';
+
+type FormBody = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  offerAmount?: string;
+  propertyId?: string;
+  message?: string;
+  [key: string]: unknown;
+};
+
+const RECIPIENTS = ['info@aktonz.com'];
+const FORM_TITLE = 'Offer submission';
+const SUBJECT = 'aktonz.com offer submission';
+
+function normaliseBody(req: NextApiRequest): FormBody {
+  if (!req.body) {
+    return {};
+  }
+
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body) as FormBody;
+    } catch (error) {
+      throw new Error('Invalid JSON payload');
+    }
+  }
+
+  return req.body as FormBody;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildHtml(body: FormBody): string {
+  const baseRows = [
+    ['Name', body.name ?? ''],
+    ['Email', body.email ?? ''],
+    ['Phone', body.phone ?? ''],
+    ['Offer amount', body.offerAmount ?? ''],
+    ['Property ID', body.propertyId ?? ''],
+    ['Message', body.message ?? ''],
+  ];
+
+  const additionalRows = Object.entries(body)
+    .filter(([key]) => !['name', 'email', 'phone', 'offerAmount', 'propertyId', 'message'].includes(key))
+    .map(([key, value]) => [key, value]);
+
+  const rows = [...baseRows, ...additionalRows]
+    .map(
+      ([label, value]) =>
+        `<tr><th align="left" style="padding:4px 8px;background:#f7f7f7;border:1px solid #ddd;">${escapeHtml(
+          label,
+        )}</th><td style="padding:4px 8px;border:1px solid #ddd;">${escapeHtml(value)}</td></tr>`,
+    )
+    .join('');
+
+  return `
+    <h2 style="font-family:Arial,sans-serif;">${escapeHtml(FORM_TITLE)}</h2>
+    <table style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">${rows}</table>
+  `;
+}
+
+function resolveReplyTo(email: unknown): string | undefined {
+  if (typeof email !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = email.trim();
+  return trimmed.includes('@') ? trimmed : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body: FormBody;
+
+  try {
+    body = normaliseBody(req);
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request body' });
+    return;
+  }
+
+  try {
+    await sendMailGraph({
+      subject: SUBJECT,
+      html: buildHtml(body),
+      to: RECIPIENTS,
+      replyTo: resolveReplyTo(body.email),
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to send email' });
+  }
+}

--- a/pages/api/valuations.ts
+++ b/pages/api/valuations.ts
@@ -1,0 +1,107 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { sendMailGraph } from '../../lib/ms-graph';
+
+type FormBody = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  propertyAddress?: string;
+  message?: string;
+  [key: string]: unknown;
+};
+
+const RECIPIENTS = ['valuations@aktonz.com'];
+const FORM_TITLE = 'Valuation request';
+const SUBJECT = 'aktonz.com valuation form';
+
+function normaliseBody(req: NextApiRequest): FormBody {
+  if (!req.body) {
+    return {};
+  }
+
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body) as FormBody;
+    } catch (error) {
+      throw new Error('Invalid JSON payload');
+    }
+  }
+
+  return req.body as FormBody;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildHtml(body: FormBody): string {
+  const baseRows = [
+    ['Name', body.name ?? ''],
+    ['Email', body.email ?? ''],
+    ['Phone', body.phone ?? ''],
+    ['Property address', body.propertyAddress ?? ''],
+    ['Message', body.message ?? ''],
+  ];
+
+  const additionalRows = Object.entries(body)
+    .filter(([key]) => !['name', 'email', 'phone', 'propertyAddress', 'message'].includes(key))
+    .map(([key, value]) => [key, value]);
+
+  const rows = [...baseRows, ...additionalRows]
+    .map(
+      ([label, value]) =>
+        `<tr><th align="left" style="padding:4px 8px;background:#f7f7f7;border:1px solid #ddd;">${escapeHtml(
+          label,
+        )}</th><td style="padding:4px 8px;border:1px solid #ddd;">${escapeHtml(value)}</td></tr>`,
+    )
+    .join('');
+
+  return `
+    <h2 style="font-family:Arial,sans-serif;">${escapeHtml(FORM_TITLE)}</h2>
+    <table style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">${rows}</table>
+  `;
+}
+
+function resolveReplyTo(email: unknown): string | undefined {
+  if (typeof email !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = email.trim();
+  return trimmed.includes('@') ? trimmed : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body: FormBody;
+
+  try {
+    body = normaliseBody(req);
+  } catch (error) {
+    res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid request body' });
+    return;
+  }
+
+  try {
+    await sendMailGraph({
+      subject: SUBJECT,
+      html: buildHtml(body),
+      to: RECIPIENTS,
+      replyTo: resolveReplyTo(body.email),
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to send email' });
+  }
+}

--- a/scripts/ms-oauth-tests.sh
+++ b/scripts/ms-oauth-tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# scripts/ms-oauth-tests.sh
+# Usage:
+#   chmod +x scripts/ms-oauth-tests.sh
+#   BASE_URL="https://aktonz.com" ./scripts/ms-oauth-tests.sh
+#   # or for local:
+#   BASE_URL="http://localhost:3000" ./scripts/ms-oauth-tests.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+
+echo "== Aktonz Microsoft Graph Smoke Tests =="
+echo "Target: $BASE_URL"
+echo
+
+echo "[1/6] Checking Microsoft OAuth connection status..."
+curl -fsS "$BASE_URL/api/microsoft/status" | jq . || { echo "❌ status check failed"; exit 1; }
+echo "✅ status OK"
+echo
+
+echo "[2/6] Checking Microsoft Graph /me (sanity)..."
+curl -fsS "$BASE_URL/api/microsoft/self" | jq . || { echo "❌ /me check failed"; exit 1; }
+echo "✅ /me OK"
+echo
+
+echo "[3/6] POST /api/contact ..."
+curl -fsS -X POST "$BASE_URL/api/contact" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test User","email":"test@example.com","message":"Hello from Aktonz smoke test"}' | jq . && echo "✅ contact OK"
+echo
+
+echo "[4/6] POST /api/book-viewing ..."
+curl -fsS -X POST "$BASE_URL/api/book-viewing" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Viewer","email":"v@example.com","phone":"+44 7000 000000","propertyId":"AKT-123","preferredTime":"Tomorrow 2pm"}' | jq . && echo "✅ book-viewing OK"
+echo
+
+echo "[5/6] POST /api/offers ..."
+curl -fsS -X POST "$BASE_URL/api/offers" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Buyer","email":"b@example.com","phone":"+44 7000 000001","offerAmount":350000,"propertyId":"AKT-456","notes":"Cash buyer"}' | jq . && echo "✅ offers OK"
+echo
+
+echo "[6/6] POST /api/valuations ..."
+curl -fsS -X POST "$BASE_URL/api/valuations" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Owner","email":"o@example.com","phone":"+44 7000 000002","address":"33 Abersham Road, London E8 2LN","details":"2-bed flat"}' | jq . && echo "✅ valuations OK"
+echo
+
+echo "🎉 All smoke tests completed."

--- a/scripts/vercel-env-commands.sh
+++ b/scripts/vercel-env-commands.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+vercel link
+printf "04651e3a-82c5-4e03-ba50-574b2bb79cac" | vercel env add MS_CLIENT_ID
+printf "60737a1b-9707-4d7f-9909-0ee943a1ffff" | vercel env add MS_TENANT_ID
+printf "https://aktonz.com/api/microsoft/callback" | vercel env add MS_REDIRECT_URI
+printf "offline_access Mail.Send User.Read" | vercel env add MS_SCOPES
+printf "<NEW_CLIENT_SECRET_VALUE>" | vercel env add MS_CLIENT_SECRET
+printf "<LONG_RANDOM_BASE64_FROM_OPENSSL>" | vercel env add TOKEN_ENCRYPTION_KEY
+echo "vercel deploy --prod"
+echo "KV envs required: KV_REST_API_URL (or KV_URL) and KV_REST_API_TOKEN"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- replace the OAuth smoke-test helper with an executable script that checks connection health and exercises all form APIs
- add `/api/microsoft/status` and `/api/microsoft/self` endpoints so the script can verify token freshness and Microsoft Graph access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d753498008832e99613837870b304a