### PR TITLE
Validate Microsoft OAuth redirect URIs

### DIFF
--- a/lib/ms-graph.ts
+++ b/lib/ms-graph.ts
@@ -4,7 +4,25 @@ import { clearTokens, readTokens, saveTokens } from './token-store';
 
 export const MS_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
 export const MS_TENANT_ID = '60737a1b-9707-4d7f-9909-0ee943a1ffff';
-export const MS_REDIRECT_URI = 'https://aktonz.com/api/microsoft/callback';
+
+const DEFAULT_PROD_REDIRECT_URI = 'https://aktonz.com/api/microsoft/callback';
+const DEFAULT_DEV_REDIRECT_URI = 'http://localhost:3000/api/admin/email/microsoft/callback';
+
+function requireAbsoluteUrl(value: string, label: string): string {
+  try {
+    return new URL(value).toString();
+  } catch {
+    throw new Error(`${label} must be set to a valid absolute URL`);
+  }
+}
+
+function getRedirectUri(envKey: string, fallback: string): string {
+  const value = process.env[envKey] ?? fallback;
+  return requireAbsoluteUrl(value, envKey);
+}
+
+export const MS_REDIRECT_URI = getRedirectUri('MS_REDIRECT_URI', DEFAULT_PROD_REDIRECT_URI);
+export const MS_DEV_REDIRECT_URI = getRedirectUri('MS_DEV_REDIRECT_URI', DEFAULT_DEV_REDIRECT_URI);
 export const SCOPES = 'offline_access Mail.Send User.Read';
 export const ALLOWED_UPN = 'info@aktonz.com';
 

--- a/pages/api/microsoft/connect.ts
+++ b/pages/api/microsoft/connect.ts
@@ -1,12 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { MS_CLIENT_ID, MS_REDIRECT_URI, MS_TENANT_ID, SCOPES } from '../../../lib/ms-graph';
-
-const DEV_REDIRECT_URI = 'http://localhost:3000/api/admin/email/microsoft/callback';
+import { MS_CLIENT_ID, MS_DEV_REDIRECT_URI, MS_REDIRECT_URI, MS_TENANT_ID, SCOPES } from '../../../lib/ms-graph';
 
 function resolveRedirectUri(req: NextApiRequest): string {
   const host = req.headers.host ?? '';
   const isLocal = host.includes('localhost') || host.startsWith('127.0.0.1');
-  return isLocal ? DEV_REDIRECT_URI : MS_REDIRECT_URI;
+  return isLocal ? MS_DEV_REDIRECT_URI : MS_REDIRECT_URI;
 }
 
 export default function handler(req: NextApiRequest, res: NextApiResponse): void {


### PR DESCRIPTION
## Summary
- validate Microsoft redirect URIs as absolute URLs and allow configuration via environment variables
- surface a dev redirect URI helper so the connect endpoint consistently resolves the correct callback URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d766293e34832ea2e75eb37c58c87e