### PR TITLE
Add script to verify Redis connectivity

### DIFF
--- a/README-aktonz-email.md
+++ b/README-aktonz-email.md
@@ -13,6 +13,15 @@ Set the following in the Production and Preview environments:
 - `TOKEN_ENCRYPTION_KEY` – 32-byte random value encoded with `openssl rand -base64 32`.
 - `REDIS_URL` – connection string from Redis Cloud (must start with `rediss://`).
 
+### Redis connectivity sanity check
+After updating the `REDIS_URL`, confirm the connection with:
+
+```bash
+npm run ping-redis
+```
+
+The script automatically enables TLS when the URL begins with `rediss://` or the host ends with `redis-cloud.com`, sends `PING`, and prints the Redis response.
+
 
 ## Redirect URIs
 - Production: `https://aktonz.com/api/microsoft/callback`

--- a/README-aktonz-email.md
+++ b/README-aktonz-email.md
@@ -20,7 +20,7 @@ After updating the `REDIS_URL`, confirm the connection with:
 npm run ping-redis
 ```
 
-The script automatically enables TLS when the URL begins with `rediss://` or the host ends with `redis-cloud.com`, sends `PING`, and prints the Redis response.
+The script automatically enables TLS when the URL begins with `rediss://` or the host ends with `redis-cloud.com`, upgrades `redis://` URLs to `rediss://` when needed, sends `PING`, and prints the Redis response.
 
 
 ## Redirect URIs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check-pr": "node scripts/check-pr.mjs",
     "check-ms-connector": "node scripts/check-ms-connector.mjs",
     "monitor": "node scripts/monitor-prices.js",
+    "ping-redis": "node scripts/ping-redis.mjs",
     "sync:scraye": "node scripts/syncScraye.mjs"
   },
   "keywords": [],

--- a/scripts/ping-redis.mjs
+++ b/scripts/ping-redis.mjs
@@ -17,7 +17,7 @@ try {
 }
 
 const needsTls = parsedUrl.protocol === 'rediss:' || parsedUrl.hostname.endsWith('redis-cloud.com');
-const options = needsTls ? { tls: { rejectUnauthorized: false } } : undefined;
+const options = needsTls ? { tls: { servername: parsedUrl.hostname } } : undefined;
 
 const redis = new Redis(redisUrl, options);
 

--- a/scripts/ping-redis.mjs
+++ b/scripts/ping-redis.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import Redis from 'ioredis';
+
+const redisUrl = process.env.REDIS_URL;
+
+if (!redisUrl) {
+  console.error('REDIS_URL environment variable must be set');
+  process.exit(1);
+}
+
+let parsedUrl;
+try {
+  parsedUrl = new URL(redisUrl);
+} catch (error) {
+  console.error('REDIS_URL is not a valid URL');
+  process.exit(1);
+}
+
+const needsTls = parsedUrl.protocol === 'rediss:' || parsedUrl.hostname.endsWith('redis-cloud.com');
+const options = needsTls ? { tls: { rejectUnauthorized: false } } : undefined;
+
+const redis = new Redis(redisUrl, options);
+
+async function main() {
+  try {
+    const response = await redis.ping();
+    console.log('PING:', response);
+  } catch (error) {
+    console.error('Redis ping failed:', error);
+    process.exitCode = 1;
+  } finally {
+    redis.disconnect();
+  }
+}
+
+main();

--- a/scripts/ping-redis.mjs
+++ b/scripts/ping-redis.mjs
@@ -17,9 +17,14 @@ try {
 }
 
 const needsTls = parsedUrl.protocol === 'rediss:' || parsedUrl.hostname.endsWith('redis-cloud.com');
+
+if (needsTls && parsedUrl.protocol !== 'rediss:') {
+  parsedUrl.protocol = 'rediss:';
+}
+
 const options = needsTls ? { tls: { servername: parsedUrl.hostname } } : undefined;
 
-const redis = new Redis(redisUrl, options);
+const redis = new Redis(parsedUrl.toString(), options);
 
 async function main() {
   try {


### PR DESCRIPTION
## Summary
- add a reusable `ping-redis` helper script that checks TLS requirements and issues a Redis PING
- document how to run the new helper in the email setup README
- expose the helper via an npm script for easy execution

## Testing
- not run (helper requires a valid REDIS_URL to exercise)


------
https://chatgpt.com/codex/tasks/task_e_68d7610ea678832e9b270fb7d3b2f950