### PR TITLE
Ensure homepage featured sections show five same-road cards

### DIFF
--- a/components/PropertyList.js
+++ b/components/PropertyList.js
@@ -11,12 +11,20 @@ export default function PropertyList({ properties }) {
           return null;
         }
         const propertyId = resolvePropertyIdentifier(property);
+        const explicitKey = property?._cardKey;
 
         const cardProps =
           propertyId && property?.id !== propertyId
             ? { ...property, id: propertyId }
             : property;
-        const key = propertyId ?? `${property?.title ?? 'property'}-${index}`;
+        const keyBase =
+          propertyId ??
+          property?.id ??
+          property?.reference ??
+          property?.fullReference ??
+          property?.title ??
+          'property';
+        const key = explicitKey ?? `${keyBase}-${index}`;
 
         const externalUrl = property.externalUrl;
         if (!propertyId) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,113 @@ import Stats from '../components/Stats';
 import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import styles from '../styles/Home.module.css';
 
+const FEATURED_COUNT = 5;
+
+function extractRoadName(property) {
+  if (!property || typeof property !== 'object') {
+    return null;
+  }
+
+  const displayAddress =
+    typeof property.displayAddress === 'string'
+      ? property.displayAddress.split(',')[0]
+      : null;
+
+  const candidates = [property.address2, displayAddress, property.address1];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
+}
+
+function createCardKeyBase(property, fallback = 'property') {
+  const candidates = [
+    property?.id,
+    property?.listingId,
+    property?.listing_id,
+    property?.reference,
+    property?.fullReference,
+    property?.slug,
+    property?.title,
+    property?.displayAddress,
+    property?.address1,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate != null) {
+      const str = String(candidate).trim();
+      if (str) {
+        return str.replace(/\s+/g, '-');
+      }
+    }
+  }
+
+  return fallback;
+}
+
+function clonePropertiesForDisplay(selected, sourcePool, targetCount) {
+  if (!Array.isArray(sourcePool) || sourcePool.length === 0) {
+    return [];
+  }
+
+  const clones = [];
+  const baseSelection = Array.isArray(selected) && selected.length > 0 ? selected : sourcePool;
+  const initial = baseSelection.slice(0, Math.min(baseSelection.length, targetCount));
+
+  initial.forEach((property, index) => {
+    const keyBase = createCardKeyBase(property, `property-${index}`);
+    clones.push({ ...property, _cardKey: `${keyBase}-card-${index}` });
+  });
+
+  let nextIndex = clones.length;
+  while (clones.length < targetCount) {
+    const source = sourcePool[nextIndex % sourcePool.length];
+    const keyBase = createCardKeyBase(source, `property-${nextIndex}`);
+    clones.push({ ...source, _cardKey: `${keyBase}-card-${nextIndex}` });
+    nextIndex += 1;
+  }
+
+  return clones;
+}
+
+function selectPropertiesOnSameRoad(properties, targetCount = FEATURED_COUNT) {
+  if (!Array.isArray(properties) || properties.length === 0) {
+    return [];
+  }
+
+  const roadGroups = new Map();
+
+  for (const property of properties) {
+    const road = extractRoadName(property);
+    if (!road) {
+      continue;
+    }
+    const key = road.toLowerCase();
+    if (!roadGroups.has(key)) {
+      roadGroups.set(key, { road, items: [] });
+    }
+    roadGroups.get(key).items.push(property);
+  }
+
+  const grouped = Array.from(roadGroups.values()).sort(
+    (a, b) => b.items.length - a.items.length,
+  );
+
+  const preferredGroup =
+    grouped.find((group) => group.items.length >= targetCount) ?? grouped[0];
+
+  const sourcePool = preferredGroup ? preferredGroup.items : properties;
+
+  return clonePropertiesForDisplay(preferredGroup?.items, sourcePool, targetCount);
+}
+
 export default function Home({ sales, lettings, archiveSales }) {
   return (
     <>
@@ -49,15 +156,13 @@ export async function getStaticProps() {
   const isAvailable = (p) => p.status && normalize(p.status) === 'available';
   const isSold = (p) => p.status && normalize(p.status) === 'sold';
 
-  const sales = allSale
-    .filter((p) => isAvailable(p) && p.featured)
-    .slice(0, 5);
+  const availableSales = allSale.filter((p) => isAvailable(p) && p.featured);
+  const availableLettings = allRent.filter((p) => isAvailable(p) && p.featured);
 
-  const lettings = allRent
-    .filter((p) => isAvailable(p) && p.featured)
-    .slice(0, 5);
+  const sales = selectPropertiesOnSameRoad(availableSales, FEATURED_COUNT);
+  const lettings = selectPropertiesOnSameRoad(availableLettings, FEATURED_COUNT);
 
-  const archiveSales = allSale.filter(isSold).slice(0, 5);
+  const archiveSales = allSale.filter(isSold).slice(0, FEATURED_COUNT);
 
   return { props: { sales, lettings, archiveSales } };
 }


### PR DESCRIPTION
## Summary
- ensure the homepage featured sales and lettings sections pull five listings that share a road when possible
- add helpers to clone and key properties so duplicate cards can be rendered without React key conflicts
- allow property list entries to honour explicit card keys generated for cloned listings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d772374128832eb3f08d27bea8c968