### PR TITLE
Use redirect resolver in Next Microsoft handlers

### DIFF
--- a/__tests__/ms-redirect.test.js
+++ b/__tests__/ms-redirect.test.js
@@ -1,0 +1,127 @@
+const { resolveMicrosoftRedirectUri, _internal } = require('../lib/ms-redirect');
+
+describe('resolveMicrosoftRedirectUri', () => {
+  const originalEnv = { ...process.env };
+  const redirectEnvKeys = [
+    'MS_REDIRECT_URI',
+    'MICROSOFT_REDIRECT_URI',
+    'MICROSOFT_REDIRECT_URL',
+    'NEXT_PUBLIC_MICROSOFT_REDIRECT_URI',
+    'NEXT_PUBLIC_MICROSOFT_REDIRECT_URL',
+    'AZURE_AD_REDIRECT_URI',
+    'AZURE_AD_REDIRECT_URL',
+    'MS_DEV_REDIRECT_URI',
+    'MICROSOFT_DEV_REDIRECT_URI',
+    'MICROSOFT_DEV_REDIRECT_URL',
+    'NEXT_PUBLIC_MICROSOFT_DEV_REDIRECT_URI',
+    'NEXT_PUBLIC_MICROSOFT_DEV_REDIRECT_URL',
+  ];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  beforeEach(() => {
+    for (const key of redirectEnvKeys) {
+      delete process.env[key];
+    }
+  });
+
+  function buildRequest({ host = 'aktonz.com', proto = 'https', headers = {} } = {}) {
+    return {
+      headers: {
+        host,
+        'x-forwarded-proto': proto,
+        ...headers,
+      },
+    };
+  }
+
+  it('returns configured absolute production redirect', () => {
+    process.env.MS_REDIRECT_URI = 'https://example.com/callback';
+    const req = buildRequest();
+    expect(resolveMicrosoftRedirectUri(req)).toBe('https://example.com/callback');
+  });
+
+  it('resolves relative production redirect using host', () => {
+    process.env.MS_REDIRECT_URI = '/api/microsoft/callback';
+    const req = buildRequest({ host: 'aktonz.com' });
+    expect(resolveMicrosoftRedirectUri(req)).toBe('https://aktonz.com/api/microsoft/callback');
+  });
+
+  it('falls back to default local redirect', () => {
+    delete process.env.MS_DEV_REDIRECT_URI;
+    const req = buildRequest({ host: 'localhost:3000', proto: 'http' });
+    expect(resolveMicrosoftRedirectUri(req)).toBe('http://localhost:3000/api/microsoft/callback');
+  });
+
+  it('uses forwarded host header when provided', () => {
+    process.env.MS_REDIRECT_URI = '/api/microsoft/callback';
+    const req = buildRequest({
+      host: 'internal:3000',
+      headers: { 'x-forwarded-host': 'preview.aktonz.com' },
+    });
+    expect(resolveMicrosoftRedirectUri(req)).toBe('https://preview.aktonz.com/api/microsoft/callback');
+  });
+
+  it('throws when no host for relative URL', () => {
+    process.env.MS_REDIRECT_URI = '/api/microsoft/callback';
+    const req = buildRequest({ host: '' });
+    expect(() => resolveMicrosoftRedirectUri(req)).toThrow('MS_REDIRECT_URI');
+  });
+});
+
+describe('ensureAbsoluteUrl', () => {
+  const { ensureAbsoluteUrl } = _internal;
+
+  it('returns absolute url unchanged', () => {
+    expect(
+      ensureAbsoluteUrl('https://aktonz.com/api/microsoft/callback', {
+        host: 'aktonz.com',
+        isLocal: false,
+        label: 'TEST_REDIRECT',
+      }),
+    ).toBe('https://aktonz.com/api/microsoft/callback');
+  });
+
+  it('resolves relative paths with https by default', () => {
+    expect(
+      ensureAbsoluteUrl('/api/microsoft/callback', {
+        host: 'aktonz.com',
+        isLocal: false,
+        label: 'TEST_REDIRECT',
+      }),
+    ).toBe('https://aktonz.com/api/microsoft/callback');
+  });
+
+  it('uses http for local relative paths', () => {
+    expect(
+      ensureAbsoluteUrl('/api/microsoft/callback', {
+        host: 'localhost:3000',
+        isLocal: true,
+        label: 'TEST_REDIRECT',
+      }),
+    ).toBe('http://localhost:3000/api/microsoft/callback');
+  });
+
+  it('prefers forwarded protocol when provided', () => {
+    expect(
+      ensureAbsoluteUrl('/api/microsoft/callback', {
+        host: 'preview.aktonz.com',
+        isLocal: false,
+        label: 'TEST_REDIRECT',
+        protocol: 'http',
+      }),
+    ).toBe('http://preview.aktonz.com/api/microsoft/callback');
+  });
+
+  it('throws for invalid values', () => {
+    expect(() =>
+      ensureAbsoluteUrl('not-a-valid-url', {
+        host: 'aktonz.com',
+        isLocal: false,
+        label: 'TEST_REDIRECT',
+      }),
+    ).toThrow('TEST_REDIRECT');
+  });
+});

--- a/lib/ms-oauth.js
+++ b/lib/ms-oauth.js
@@ -1,5 +1,6 @@
 const { saveTokens } = require("./token-store");
 const { encryptToken } = require("./ms-graph");
+const { resolveMicrosoftRedirectUri } = require("./ms-redirect");
 
 function redirect(res, url) {
   res.writeHead(302, { Location: url });
@@ -27,9 +28,15 @@ async function handleMicrosoftCallback(req, res) {
   const tokenUrl = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   const clientId = process.env.MS_CLIENT_ID;
   const clientSecret = process.env.MS_CLIENT_SECRET;
-  const redirectUri = process.env.MS_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
+  if (!clientId || !clientSecret) {
     return redirectWithError(res, "missing_ms_config");
+  }
+  let redirectUri;
+  try {
+    redirectUri = resolveMicrosoftRedirectUri(req);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'invalid_redirect_uri';
+    return redirectWithError(res, `invalid_redirect_uri#${encodeURIComponent(message)}`);
   }
   const body = new URLSearchParams({
     client_id: clientId,

--- a/lib/ms-redirect.d.ts
+++ b/lib/ms-redirect.d.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest } from 'next';
+
+type HeaderValue = string | string[] | undefined;
+
+export interface RedirectRequestLike {
+  headers: Partial<Record<string, HeaderValue>>;
+}
+
+export interface EnsureAbsoluteUrlOptions {
+  host?: string;
+  isLocal?: boolean;
+  label: string;
+  protocol?: string;
+}
+
+export declare function resolveMicrosoftRedirectUri(req: RedirectRequestLike | NextApiRequest): string;
+export declare const DEFAULT_PROD_REDIRECT_URI: string;
+export declare const DEFAULT_DEV_REDIRECT_URI: string;
+
+export declare const _internal: {
+  pickEnvValue(keys: string[]): string | undefined;
+  ensureAbsoluteUrl(value: string, options: EnsureAbsoluteUrlOptions): string;
+  getRequestHost(req: RedirectRequestLike | NextApiRequest): string;
+  getForwardedProtocol(req: RedirectRequestLike | NextApiRequest): string | undefined;
+};

--- a/lib/ms-redirect.js
+++ b/lib/ms-redirect.js
@@ -1,0 +1,99 @@
+const DEFAULT_PROD_REDIRECT_URI = 'https://aktonz.com/api/microsoft/callback';
+const DEFAULT_DEV_REDIRECT_URI = 'http://localhost:3000/api/microsoft/callback';
+
+const PROD_REDIRECT_ENV_KEYS = [
+  'MS_REDIRECT_URI',
+  'MICROSOFT_REDIRECT_URI',
+  'MICROSOFT_REDIRECT_URL',
+  'NEXT_PUBLIC_MICROSOFT_REDIRECT_URI',
+  'NEXT_PUBLIC_MICROSOFT_REDIRECT_URL',
+  'AZURE_AD_REDIRECT_URI',
+  'AZURE_AD_REDIRECT_URL',
+];
+
+const DEV_REDIRECT_ENV_KEYS = [
+  'MS_DEV_REDIRECT_URI',
+  'MICROSOFT_DEV_REDIRECT_URI',
+  'MICROSOFT_DEV_REDIRECT_URL',
+  'NEXT_PUBLIC_MICROSOFT_DEV_REDIRECT_URI',
+  'NEXT_PUBLIC_MICROSOFT_DEV_REDIRECT_URL',
+];
+
+function pickEnvValue(keys) {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getRequestHost(req) {
+  const forwardedHost = req.headers['x-forwarded-host'];
+  const hostHeader = Array.isArray(forwardedHost)
+    ? forwardedHost[0]
+    : forwardedHost ?? req.headers.host ?? '';
+  return typeof hostHeader === 'string' ? hostHeader.trim() : '';
+}
+
+function getForwardedProtocol(req) {
+  const forwardedProto = req.headers['x-forwarded-proto'];
+  if (Array.isArray(forwardedProto)) {
+    return forwardedProto[0]?.split(',')[0]?.trim();
+  }
+  if (typeof forwardedProto === 'string') {
+    return forwardedProto.split(',')[0]?.trim();
+  }
+  return undefined;
+}
+
+function ensureAbsoluteUrl(rawValue, { host, isLocal, label, protocol }) {
+  const trimmed = rawValue.trim();
+  try {
+    const url = new URL(trimmed);
+    if (!url.protocol || !url.hostname) {
+      throw new Error('Missing protocol or host');
+    }
+    return url.toString();
+  } catch (error) {
+    if (trimmed.startsWith('/')) {
+      if (!host) {
+        throw new Error(`${label} must be an absolute URL or the request must include a valid Host header`);
+      }
+      const safeHost = host.replace(/\s/g, '').replace(/\/$/, '');
+      const resolvedProtocol = protocol || (isLocal ? 'http' : 'https');
+      return `${resolvedProtocol}://${safeHost}${trimmed}`;
+    }
+    throw new Error(`${label} must be a valid absolute URL`);
+  }
+}
+
+function resolveMicrosoftRedirectUri(req) {
+  const host = getRequestHost(req);
+  const lowerHost = host.toLowerCase();
+  const isLocal = lowerHost.includes('localhost') || lowerHost.startsWith('127.0.0.1');
+  const envKeys = isLocal ? DEV_REDIRECT_ENV_KEYS : PROD_REDIRECT_ENV_KEYS;
+  const fallback = isLocal ? DEFAULT_DEV_REDIRECT_URI : DEFAULT_PROD_REDIRECT_URI;
+  const label = isLocal ? 'MS_DEV_REDIRECT_URI' : 'MS_REDIRECT_URI';
+  const rawValue = pickEnvValue(envKeys) ?? fallback;
+  const forwardedProtocol = getForwardedProtocol(req);
+  return ensureAbsoluteUrl(rawValue, {
+    host,
+    isLocal,
+    label,
+    protocol: forwardedProtocol,
+  });
+}
+
+module.exports = {
+  resolveMicrosoftRedirectUri,
+  DEFAULT_PROD_REDIRECT_URI,
+  DEFAULT_DEV_REDIRECT_URI,
+  _internal: {
+    pickEnvValue,
+    ensureAbsoluteUrl,
+    getRequestHost,
+    getForwardedProtocol,
+  },
+};

--- a/pages/api/microsoft/connect.js
+++ b/pages/api/microsoft/connect.js
@@ -1,11 +1,22 @@
+const { resolveMicrosoftRedirectUri } = require("../../../lib/ms-redirect");
+
 module.exports = function handler(req, res) {
   const clientId = process.env.MS_CLIENT_ID;
-  const redirectUri = process.env.MS_REDIRECT_URI;
   const scopes = process.env.MS_SCOPES || 'offline_access Mail.Send User.Read';
   const tenant = process.env.MS_TENANT_ID || 'common';
 
-  if (!clientId || !redirectUri) {
+  if (!clientId) {
     res.status(500).json({ error: "missing_ms_config" });
+    return;
+  }
+
+  let redirectUri;
+  try {
+    redirectUri = resolveMicrosoftRedirectUri(req);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'invalid_redirect_uri';
+    console.error('Microsoft connect redirect URI error', message);
+    res.status(500).json({ error: "invalid_redirect_uri" });
     return;
   }
 


### PR DESCRIPTION
## Summary
- import the shared redirect resolver into the Next.js Microsoft connect and callback handlers so they always send absolute URLs
- handle resolver failures gracefully in those routes to surface misconfiguration errors
- add TypeScript declarations for the redirect helper so API routes can consume it safely

## Testing
- npm test -- ms-redirect

------
https://chatgpt.com/codex/tasks/task_e_68d773177520832e989e7c4cd0b67efd