### PR TITLE
Add account shortcut to header when signed in

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -2,12 +2,18 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import styles from '../styles/Header.module.css';
+import { useSession } from './SessionProvider';
 
 export default function Header() {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [sellOpen, setSellOpen] = useState(false);
   const [landlordOpen, setLandlordOpen] = useState(false);
+  const { user, loading: sessionLoading } = useSession();
+
+  const isLoggedIn = Boolean(user) && !sessionLoading;
+  const accountHref = user?.role === 'admin' ? '/admin' : '/account';
+  const accountLabel = user?.role === 'admin' ? 'Go to admin dashboard' : 'Go to your account';
 
   const isPathActive = (href) => router.pathname === href;
   const isSectionActive = (href) =>
@@ -178,10 +184,30 @@ export default function Header() {
       >
         Get a valuation
       </Link>
-      <Link href="/login" className={styles.login} onClick={closeMenu}>
-        Login
-
-      </Link>
+      {isLoggedIn ? (
+        <Link
+          href={accountHref}
+          className={`${styles.login} ${styles.accountLink}`}
+          onClick={closeMenu}
+          aria-label={accountLabel}
+        >
+          <span className={styles.accountIcon} aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+              <path
+                d="M12 12.75a5.25 5.25 0 1 0-5.25-5.25A5.25 5.25 0 0 0 12 12.75Zm0-1.5a3.75 3.75 0 1 1 3.75-3.75A3.75 3.75 0 0 1 12 11.25Zm0 2.25A8.25 8.25 0 0 0 3.75 21h1.5a6.75 6.75 0 0 1 13.5 0h1.5A8.25 8.25 0 0 0 12 13.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <span className={styles.accountText}>
+            {user?.firstName || user?.name || 'My account'}
+          </span>
+        </Link>
+      ) : (
+        <Link href="/login" className={styles.login} onClick={closeMenu}>
+          Login
+        </Link>
+      )}
     </>
   );
 

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -161,8 +161,39 @@
   text-decoration: none;
 }
 
+.accountLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-mid);
+  background: var(--color-background);
+}
+
+.accountIcon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  color: var(--color-primary);
+}
+
+.accountIcon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.accountText {
+  display: none;
+  margin-left: var(--spacing-sm);
+  font-size: 0.95rem;
+}
+
 .actions .cta,
-.actions .login {
+.actions .login,
+.actions .accountLink {
   display: none;
 }
 
@@ -195,9 +226,29 @@
 }
 
 .mobileMenu .cta,
-.mobileMenu .login {
+.mobileMenu .login,
+.mobileMenu .accountLink {
   display: block;
 
+}
+
+.mobileMenu .accountLink {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  border: none;
+  padding: var(--spacing-xs) 0;
+}
+
+.mobileMenu .accountIcon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-primary);
+}
+
+.mobileMenu .accountText {
+  display: inline;
 }
 
 .mobileMenu .dropdown {
@@ -228,7 +279,8 @@
   }
 
   .actions .cta,
-  .actions .login {
+  .actions .login,
+  .actions .accountLink {
     display: inline-block;
   }
 


### PR DESCRIPTION
## Summary
- wire the main site header to the shared session state to detect signed-in users
- replace the Login action with an account/admin shortcut that uses a user icon and label styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d775ecb188832e96329a047ebc32f1