### PR TITLE
Handle undefined Microsoft tenant IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ settings.
 | --- | --- |
 | `MS_CLIENT_ID` | The **Application (client) ID** from Azure App Registration. Equivalent fallbacks supported: `MICROSOFT_CLIENT_ID`, `NEXT_PUBLIC_MICROSOFT_CLIENT_ID`, `AZURE_AD_CLIENT_ID`, `MSAL_CLIENT_ID`. |
 | `MS_REDIRECT_URI` | The redirect URI you configure on the app registration. Use `https://<your-domain>/api/admin/email/microsoft/callback`. Public fallbacks are supported: `MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URL`, `AZURE_AD_REDIRECT_URI`, `AZURE_AD_REDIRECT_URL`. |
-| `MS_TENANT_ID` | (Optional) Your tenant ID. Leave unset to default to `common` for multi-tenant apps. Synonymous environment keys such as `MICROSOFT_TENANT_ID`, `AZURE_DIRECTORY_ID`, `AZURE_TENANT_ID`, or `AZURE_AD_TENANT_ID` are also detected. |
+| `MS_TENANT_ID` | (Optional) Your tenant ID. Leave unset to default to `common` for multi-tenant apps. Synonymous environment keys such as `MICROSOFT_TENANT_ID`, `AZURE_DIRECTORY_ID`, `AZURE_TENANT_ID`, or `AZURE_AD_TENANT_ID` are also detected. Values like `"undefined"` or `"null"` are ignored so a blank dashboard setting does not break sign-in. |
 | `MS_SCOPES` | (Optional) Custom OAuth scopes. Defaults to `offline_access https://graph.microsoft.com/.default`. |
 
 Once the environment variables are present, restart the server and press

--- a/__tests__/ms-tenant.test.js
+++ b/__tests__/ms-tenant.test.js
@@ -1,0 +1,66 @@
+const TENANT_ENV_KEYS = [
+  'MS_TENANT_ID',
+  'MICROSOFT_TENANT_ID',
+  'MICROSOFT_TENANT',
+  'AZURE_TENANT_ID',
+  'AZURE_DIRECTORY_ID',
+  'AZURE_AD_TENANT_ID',
+  'MS_DIRECTORY_ID',
+  'MS_TENANT',
+  'NEXT_PUBLIC_MS_TENANT_ID',
+  'NEXT_PUBLIC_MICROSOFT_TENANT_ID',
+];
+
+const DEFAULT_TENANT = 'common';
+const ORIGINAL_ENV = process.env;
+
+function clearTenantEnv() {
+  for (const key of TENANT_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function loadResolver() {
+  return require('../lib/ms-graph.js').resolveTenantId;
+}
+
+describe('resolveTenantId', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    clearTenantEnv();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('defaults to common when tenant is not provided', () => {
+    const resolveTenantId = loadResolver();
+    expect(resolveTenantId()).toBe(DEFAULT_TENANT);
+  });
+
+  test('trims whitespace around tenant values', () => {
+    process.env.MS_TENANT_ID = '  contoso.onmicrosoft.com  ';
+    const resolveTenantId = loadResolver();
+    expect(resolveTenantId()).toBe('contoso.onmicrosoft.com');
+  });
+
+  test('treats the literal string "undefined" as unset', () => {
+    process.env.MS_TENANT_ID = 'undefined';
+    const resolveTenantId = loadResolver();
+    expect(resolveTenantId()).toBe(DEFAULT_TENANT);
+  });
+
+  test('treats the literal string "null" as unset', () => {
+    process.env.AZURE_DIRECTORY_ID = 'null';
+    const resolveTenantId = loadResolver();
+    expect(resolveTenantId()).toBe(DEFAULT_TENANT);
+  });
+
+  test('supports alternative environment variable names', () => {
+    process.env.AZURE_AD_TENANT_ID = 'tenant-from-alias';
+    const resolveTenantId = loadResolver();
+    expect(resolveTenantId()).toBe('tenant-from-alias');
+  });
+});

--- a/lib/ms-graph.js
+++ b/lib/ms-graph.js
@@ -35,6 +35,47 @@ function decryptToken(b64) {
   }
 }
 
+const TENANT_ENV_KEYS = [
+  "MS_TENANT_ID",
+  "MICROSOFT_TENANT_ID",
+  "MICROSOFT_TENANT",
+  "AZURE_TENANT_ID",
+  "AZURE_DIRECTORY_ID",
+  "AZURE_AD_TENANT_ID",
+  "MS_DIRECTORY_ID",
+  "MS_TENANT",
+  "NEXT_PUBLIC_MS_TENANT_ID",
+  "NEXT_PUBLIC_MICROSOFT_TENANT_ID",
+];
+
+const DEFAULT_TENANT_ID = "common";
+
+function pickEnvValue(keys) {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveTenantId() {
+  const raw = pickEnvValue(TENANT_ENV_KEYS);
+  if (!raw) {
+    return DEFAULT_TENANT_ID;
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return DEFAULT_TENANT_ID;
+  }
+  const lowered = trimmed.toLowerCase();
+  if (lowered === "undefined" || lowered === "null") {
+    return DEFAULT_TENANT_ID;
+  }
+  return trimmed;
+}
+
 async function refresh(access) {
   const clientId = process.env.MS_CLIENT_ID;
   const clientSecret = process.env.MS_CLIENT_SECRET;
@@ -42,7 +83,7 @@ async function refresh(access) {
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error("missing_ms_config");
   }
-  const tenant = process.env.MS_TENANT_ID || 'common';
+  const tenant = resolveTenantId();
   const tokenUrl = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   const body = new URLSearchParams({
     client_id: clientId,
@@ -118,4 +159,5 @@ module.exports = {
   decryptToken,
   getValidAccessToken,
   sendMailGraph,
+  resolveTenantId,
 };

--- a/lib/ms-graph.ts
+++ b/lib/ms-graph.ts
@@ -3,7 +3,46 @@ import { clearTokens, readTokens, saveTokens } from './token-store';
 
 
 export const MS_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
-export const MS_TENANT_ID = '60737a1b-9707-4d7f-9909-0ee943a1ffff';
+
+const TENANT_ENV_KEYS = [
+  'MS_TENANT_ID',
+  'MICROSOFT_TENANT_ID',
+  'MICROSOFT_TENANT',
+  'AZURE_TENANT_ID',
+  'AZURE_DIRECTORY_ID',
+  'AZURE_AD_TENANT_ID',
+  'MS_DIRECTORY_ID',
+  'MS_TENANT',
+  'NEXT_PUBLIC_MS_TENANT_ID',
+  'NEXT_PUBLIC_MICROSOFT_TENANT_ID',
+];
+
+const DEFAULT_TENANT_ID = 'common';
+
+function normalizeTenantId(raw: string | undefined): string {
+  if (!raw) {
+    return DEFAULT_TENANT_ID;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return DEFAULT_TENANT_ID;
+  }
+
+  const lowered = trimmed.toLowerCase();
+  if (lowered === 'undefined' || lowered === 'null') {
+    return DEFAULT_TENANT_ID;
+  }
+
+  return trimmed;
+}
+
+export function resolveTenantId(): string {
+  const envValue = pickEnvValue(TENANT_ENV_KEYS);
+  return normalizeTenantId(envValue);
+}
+
+export const MS_TENANT_ID = resolveTenantId();
 
 const DEFAULT_PROD_REDIRECT_URI = 'https://aktonz.com/api/microsoft/callback';
 const DEFAULT_DEV_REDIRECT_URI = 'http://localhost:3000/api/admin/email/microsoft/callback';

--- a/lib/ms-oauth.js
+++ b/lib/ms-oauth.js
@@ -1,5 +1,5 @@
 const { saveTokens } = require("./token-store");
-const { encryptToken } = require("./ms-graph");
+const { encryptToken, resolveTenantId } = require("./ms-graph");
 const { resolveMicrosoftRedirectUri } = require("./ms-redirect");
 
 function redirect(res, url) {
@@ -24,7 +24,7 @@ async function handleMicrosoftCallback(req, res) {
     return redirectWithError(res, "missing_code");
   }
 
-  const tenant = process.env.MS_TENANT_ID || 'common';
+  const tenant = resolveTenantId();
   const tokenUrl = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   const clientId = process.env.MS_CLIENT_ID;
   const clientSecret = process.env.MS_CLIENT_SECRET;

--- a/pages/api/microsoft/connect.js
+++ b/pages/api/microsoft/connect.js
@@ -1,9 +1,10 @@
 const { resolveMicrosoftRedirectUri } = require("../../../lib/ms-redirect");
+const { resolveTenantId } = require("../../../lib/ms-graph");
 
 module.exports = function handler(req, res) {
   const clientId = process.env.MS_CLIENT_ID;
   const scopes = process.env.MS_SCOPES || 'offline_access Mail.Send User.Read';
-  const tenant = process.env.MS_TENANT_ID || 'common';
+  const tenant = resolveTenantId();
 
   if (!clientId) {
     res.status(500).json({ error: "missing_ms_config" });


### PR DESCRIPTION
## Summary
- normalize Microsoft tenant environment variables and default to `common` when unset or set to placeholder strings
- update OAuth flows to reuse the sanitized tenant resolution and document the behaviour in the README
- add unit coverage to ensure `resolveTenantId` handles aliases and ignored values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7773e4104832ea882b86f8b220fa2