### PR TITLE
Fix Microsoft token expiry calculation

### DIFF
--- a/pages/api/microsoft/status.ts
+++ b/pages/api/microsoft/status.ts
@@ -29,7 +29,7 @@ export default async function handler(
       return;
     }
 
-    const expiresAt = tokens.obtained_at + tokens.expires_in * 1000;
+    const expiresAt = (tokens.obtained_at + tokens.expires_in) * 1000;
     const expiresInSeconds = Math.max(0, Math.round((expiresAt - Date.now()) / 1000));
 
     res.status(200).json({


### PR DESCRIPTION
## Summary
- convert the stored Microsoft token timestamp to milliseconds before computing the expiry time so the status API reports the correct remaining lifetime

## Testing
- curl -s http://localhost:3000/api/microsoft/status | jq

------
https://chatgpt.com/codex/tasks/task_e_68d77cc891dc832ea045bd084b516bed