### PR TITLE
Allow MS refresh to honour redirect fallbacks

### DIFF
--- a/__tests__/ms-graph-refresh.test.js
+++ b/__tests__/ms-graph-refresh.test.js
@@ -1,0 +1,59 @@
+const originalEnv = { ...process.env };
+
+jest.mock('../lib/token-store', () => ({
+  readTokens: jest.fn(),
+  saveTokens: jest.fn(),
+}));
+
+describe('ms-graph refresh', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete global.fetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    delete global.fetch;
+  });
+
+  it('uses the dev redirect URI when only MS_DEV_REDIRECT_URI is configured', async () => {
+    process.env.MS_CLIENT_ID = 'client-id';
+    process.env.MS_CLIENT_SECRET = 'client-secret';
+    delete process.env.MS_REDIRECT_URI;
+    process.env.MS_DEV_REDIRECT_URI = 'http://localhost:3000/api/microsoft/callback';
+    process.env.TOKEN_ENCRYPTION_KEY = 'unit-test-key';
+    process.env.NODE_ENV = 'development';
+
+    const tokenStore = require('../lib/token-store');
+    tokenStore.readTokens.mockResolvedValue({
+      access_token_enc: Buffer.from('expired-token', 'utf8').toString('base64'),
+      refresh_token_enc: Buffer.from('refresh-token', 'utf8').toString('base64'),
+      expires_in: 60,
+      obtained_at: 0,
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+      }),
+    });
+
+    global.fetch = fetchMock;
+
+    const { getValidAccessToken } = require('../lib/ms-graph');
+    const token = await getValidAccessToken();
+
+    expect(token).toBe('new-access-token');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit.method).toBe('POST');
+    expect(requestInit.body).toBeInstanceOf(URLSearchParams);
+    expect(requestInit.body.get('redirect_uri')).toBe(process.env.MS_DEV_REDIRECT_URI);
+  });
+});

--- a/lib/ms-graph.js
+++ b/lib/ms-graph.js
@@ -1,4 +1,5 @@
 const crypto = require("crypto");
+const { resolveMicrosoftRedirectUriFromEnv } = require("./ms-redirect");
 const { readTokens, saveTokens } = require("./token-store");
 
 function getKey() {
@@ -79,7 +80,7 @@ function resolveTenantId() {
 async function refresh(access) {
   const clientId = process.env.MS_CLIENT_ID;
   const clientSecret = process.env.MS_CLIENT_SECRET;
-  const redirectUri = process.env.MS_REDIRECT_URI;
+  const redirectUri = resolveMicrosoftRedirectUriFromEnv();
   if (!clientId || !clientSecret || !redirectUri) {
     throw new Error("missing_ms_config");
   }

--- a/lib/ms-redirect.d.ts
+++ b/lib/ms-redirect.d.ts
@@ -13,7 +13,15 @@ export interface EnsureAbsoluteUrlOptions {
   protocol?: string;
 }
 
+export interface ResolveMicrosoftRedirectUriFromEnvOptions {
+  ensureAbsolute?: boolean;
+  host?: string;
+  preferLocal?: boolean;
+  protocol?: string;
+}
+
 export declare function resolveMicrosoftRedirectUri(req: RedirectRequestLike | NextApiRequest): string;
+export declare function resolveMicrosoftRedirectUriFromEnv(options?: ResolveMicrosoftRedirectUriFromEnvOptions): string;
 export declare const DEFAULT_PROD_REDIRECT_URI: string;
 export declare const DEFAULT_DEV_REDIRECT_URI: string;
 
@@ -22,4 +30,18 @@ export declare const _internal: {
   ensureAbsoluteUrl(value: string, options: EnsureAbsoluteUrlOptions): string;
   getRequestHost(req: RedirectRequestLike | NextApiRequest): string;
   getForwardedProtocol(req: RedirectRequestLike | NextApiRequest): string | undefined;
+  selectRedirectSource(args: {
+    devValue?: string;
+    prodValue?: string;
+    isLocal: boolean;
+  }): {
+    rawValue: string;
+    label: string;
+    isLocal: boolean;
+  };
+  determinePreferredLocal(args: {
+    devValue?: string;
+    prodValue?: string;
+    preferLocal?: boolean;
+  }): boolean;
 };

--- a/lib/ms-redirect.js
+++ b/lib/ms-redirect.js
@@ -19,6 +19,58 @@ const DEV_REDIRECT_ENV_KEYS = [
   'NEXT_PUBLIC_MICROSOFT_DEV_REDIRECT_URL',
 ];
 
+function selectRedirectSource({ devValue, prodValue, isLocal }) {
+  const label = isLocal ? 'MS_DEV_REDIRECT_URI' : 'MS_REDIRECT_URI';
+  const fallback = isLocal ? DEFAULT_DEV_REDIRECT_URI : DEFAULT_PROD_REDIRECT_URI;
+  const chosen = isLocal ? devValue : prodValue;
+  const trimmed = typeof chosen === 'string' ? chosen.trim() : undefined;
+  return {
+    rawValue: trimmed && trimmed !== '' ? trimmed : fallback,
+    label,
+    isLocal,
+  };
+}
+
+function determinePreferredLocal({ devValue, prodValue, preferLocal }) {
+  if (typeof preferLocal === 'boolean') {
+    return preferLocal;
+  }
+  if (prodValue && !devValue) {
+    return false;
+  }
+  if (!prodValue && devValue) {
+    return true;
+  }
+  if (!prodValue && !devValue) {
+    return process.env.NODE_ENV !== 'production';
+  }
+  return process.env.NODE_ENV !== 'production';
+}
+
+function resolveMicrosoftRedirectUriFromEnv(options = {}) {
+  const prodValue = pickEnvValue(PROD_REDIRECT_ENV_KEYS);
+  const devValue = pickEnvValue(DEV_REDIRECT_ENV_KEYS);
+  const isLocal = determinePreferredLocal({
+    devValue,
+    prodValue,
+    preferLocal: options.preferLocal,
+  });
+  const { rawValue, label } = selectRedirectSource({
+    devValue,
+    prodValue,
+    isLocal,
+  });
+  if (options.ensureAbsolute) {
+    return ensureAbsoluteUrl(rawValue, {
+      host: options.host,
+      isLocal,
+      label,
+      protocol: options.protocol,
+    });
+  }
+  return rawValue;
+}
+
 function pickEnvValue(keys) {
   for (const key of keys) {
     const value = process.env[key];
@@ -73,11 +125,14 @@ function resolveMicrosoftRedirectUri(req) {
   const host = getRequestHost(req);
   const lowerHost = host.toLowerCase();
   const isLocal = lowerHost.includes('localhost') || lowerHost.startsWith('127.0.0.1');
-  const envKeys = isLocal ? DEV_REDIRECT_ENV_KEYS : PROD_REDIRECT_ENV_KEYS;
-  const fallback = isLocal ? DEFAULT_DEV_REDIRECT_URI : DEFAULT_PROD_REDIRECT_URI;
-  const label = isLocal ? 'MS_DEV_REDIRECT_URI' : 'MS_REDIRECT_URI';
-  const rawValue = pickEnvValue(envKeys) ?? fallback;
   const forwardedProtocol = getForwardedProtocol(req);
+  const prodValue = pickEnvValue(PROD_REDIRECT_ENV_KEYS);
+  const devValue = pickEnvValue(DEV_REDIRECT_ENV_KEYS);
+  const { rawValue, label } = selectRedirectSource({
+    devValue,
+    prodValue,
+    isLocal,
+  });
   return ensureAbsoluteUrl(rawValue, {
     host,
     isLocal,
@@ -88,6 +143,7 @@ function resolveMicrosoftRedirectUri(req) {
 
 module.exports = {
   resolveMicrosoftRedirectUri,
+  resolveMicrosoftRedirectUriFromEnv,
   DEFAULT_PROD_REDIRECT_URI,
   DEFAULT_DEV_REDIRECT_URI,
   _internal: {
@@ -95,5 +151,7 @@ module.exports = {
     ensureAbsoluteUrl,
     getRequestHost,
     getForwardedProtocol,
+    selectRedirectSource,
+    determinePreferredLocal,
   },
 };


### PR DESCRIPTION
## Summary
- share the Microsoft redirect URI selection logic between request handlers and the refresh routine
- allow the refresh token exchange to fall back to dev redirect configuration when prod values are absent
- add a regression test to cover the refresh flow using MS_DEV_REDIRECT_URI only

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77cccbb74832e92677a37bcde81cc