### PR TITLE
Update Microsoft redirect URI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ resulting identifiers through environment variables:
    * **Supported account types:** keep **Accounts in this organizational
      directory only** unless you explicitly need multi-tenant access.
    * **Redirect URI:** choose **Web** and enter
-     `https://<your-domain>/api/admin/email/microsoft/callback` (replace
-     `<your-domain>` with the host serving your admin dashboard).
+     `https://<your-domain>/api/microsoft/callback` for production (replace
+     `<your-domain>` with the host serving your admin dashboard). You can add
+     the local testing URL (`http://localhost:3000/api/microsoft/callback`) in a
+     later step.
    * On the **Register an application** screen (the one shown in the screenshot),
      double-check the values, then press **Register** in the bottom-left corner to
      create the app registration.
@@ -79,9 +81,12 @@ resulting identifiers through environment variables:
 6. Still within the app registration, open **Authentication** in the left-hand
    menu (the screen shown in your latest screenshot). If the web redirect URI
    you entered earlier is not listed, click **Add a platform** → **Web**, paste
-   `https://<your-domain>/api/admin/email/microsoft/callback`, and press
-   **Configure**. Confirm the platform now appears under **Redirect URIs**, then
-   choose **Save** at the bottom of the page so Azure accepts the change.
+   `https://<your-domain>/api/microsoft/callback`, and press **Configure**.
+   After the production URL is in place, click **Add URI** and include the local
+   development callback `http://localhost:3000/api/microsoft/callback` so Azure
+   recognises both environments. Confirm the platform now appears under
+   **Redirect URIs**, then choose **Save** at the bottom of the page so Azure
+   accepts the change.
 7. Add the value to `.env.local` for local development or to your hosting
    platform’s environment variable manager for production. Restart the server
    or redeploy so the new configuration is loaded.
@@ -127,7 +132,7 @@ settings.
 | Variable | Description |
 | --- | --- |
 | `MS_CLIENT_ID` | The **Application (client) ID** from Azure App Registration. Equivalent fallbacks supported: `MICROSOFT_CLIENT_ID`, `NEXT_PUBLIC_MICROSOFT_CLIENT_ID`, `AZURE_AD_CLIENT_ID`, `MSAL_CLIENT_ID`. |
-| `MS_REDIRECT_URI` | The redirect URI you configure on the app registration. Use `https://<your-domain>/api/admin/email/microsoft/callback`. Public fallbacks are supported: `MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URL`, `AZURE_AD_REDIRECT_URI`, `AZURE_AD_REDIRECT_URL`. |
+| `MS_REDIRECT_URI` | The production redirect URI you configure on the app registration. Use `https://<your-domain>/api/microsoft/callback` and register the local testing URI `http://localhost:3000/api/microsoft/callback` under the same platform. Public fallbacks are supported: `MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URI`, `NEXT_PUBLIC_MICROSOFT_REDIRECT_URL`, `AZURE_AD_REDIRECT_URI`, `AZURE_AD_REDIRECT_URL`. |
 | `MS_TENANT_ID` | (Optional) Your tenant ID. Leave unset to default to `common` for multi-tenant apps. Synonymous environment keys such as `MICROSOFT_TENANT_ID`, `AZURE_DIRECTORY_ID`, `AZURE_TENANT_ID`, or `AZURE_AD_TENANT_ID` are also detected. Values like `"undefined"` or `"null"` are ignored so a blank dashboard setting does not break sign-in. |
 | `MS_SCOPES` | (Optional) Custom OAuth scopes. Defaults to `offline_access https://graph.microsoft.com/.default`. |
 
@@ -223,7 +228,7 @@ environment variables (or share them with the wider team, if needed):
 | **Application (client) ID** | Azure portal → **Azure Active Directory** → **App registrations** → *Your registration* → **Overview**. Copy the **Application (client) ID** value and store it as `MS_CLIENT_ID` (or one of the accepted aliases such as `MICROSOFT_CLIENT_ID`). |
 | **Directory (tenant) ID** | The same Overview screen lists **Directory (tenant) ID**. Copy it if you intend to keep the app single-tenant and configure it as `MS_TENANT_ID` (or `MICROSOFT_TENANT_ID` if you prefer the older naming); otherwise you can leave the environment variable unset to default to `common` for multi-tenant sign-in. |
 | **Client secret value** | Azure portal → *Your registration* → **Certificates & secrets** → **Client secrets**. Select **New client secret**, give it a description/expiry, click **Add**, then immediately copy the **Value** column (this is the only time Azure reveals it). Store the value securely—this repo does **not** commit secrets. |
-| **Redirect URI** | Use `https://<your-domain>/api/microsoft/callback` for production and `http://localhost:3000/api/admin/email/microsoft/callback` when testing locally. Register both under **Authentication → Web** so Azure AD recognises each environment. |
+| **Redirect URI** | Use `https://<your-domain>/api/microsoft/callback` for production and `http://localhost:3000/api/microsoft/callback` when testing locally. Register both under **Authentication → Web** so Azure AD recognises each environment. |
 | **Single-tenant or multi-tenant?** | Step 4 of the registration form controls this. Keeping **Accounts in this organizational directory only** selected produces a single-tenant app scoped to `aktonz.com`. Switch to multi-tenant only if you plan to allow other Azure AD tenants. |
 
 > 💡 Tip: keep a secure record (e.g. password manager entry) with the client ID,
@@ -245,7 +250,8 @@ These answers cover the follow-up questions about the Next.js project itself:
 ### Token handling and storage guidance
 
 The Microsoft OAuth flow is implemented in `pages/api/microsoft/connect.js`,
-`pages/api/microsoft/callback.js`, and `pages/api/admin/email/microsoft/callback.js`.
+`pages/api/microsoft/callback.js`, and the legacy-compatible route
+`pages/api/admin/email/microsoft/callback.js`.
 `lib/ms-oauth.js` performs the token exchange, verifies that the signed-in user is
 `info@aktonz.com`, and saves the encrypted bundle through `lib/token-store.js`.
 


### PR DESCRIPTION
## Summary
- align the Microsoft admin setup steps with the current /api/microsoft/callback production redirect and clarify the local testing URL
- refresh the MS_REDIRECT_URI environment variable documentation and note the legacy callback route for context

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d77d104538832eae0bbf578dd31217