### PR TITLE
Refine Redis client usage

### DIFF
--- a/app/api/redis/route.ts
+++ b/app/api/redis/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getRedisClient } from '@/lib/redis-client';
+
+export async function POST() {
+  const redis = getRedisClient();
+  const result = await redis.get('item');
+
+  return NextResponse.json({ result });
+}

--- a/lib/redis-client.ts
+++ b/lib/redis-client.ts
@@ -1,0 +1,42 @@
+import Redis, { RedisOptions } from 'ioredis';
+
+let redisClient: Redis | null = null;
+
+function buildRedisOptions(url: URL): RedisOptions {
+  const options: RedisOptions = {
+    maxRetriesPerRequest: 2,
+    enableOfflineQueue: false,
+  };
+
+  const shouldForceTls =
+    url.protocol === 'rediss:' || /\.redis-cloud\.com$/i.test(url.hostname);
+
+  if (shouldForceTls) {
+    options.tls = {
+      rejectUnauthorized: true,
+    };
+  }
+
+  return options;
+}
+
+export function getRedisClient(): Redis {
+  if (redisClient) {
+    return redisClient;
+  }
+
+  const redisUrl = process.env.REDIS_URL;
+
+  if (!redisUrl) {
+    throw new Error('REDIS_URL environment variable must be set');
+  }
+
+  const parsedUrl = new URL(redisUrl);
+  const options = buildRedisOptions(parsedUrl);
+
+  redisClient = new Redis(redisUrl, options);
+
+  return redisClient;
+}
+
+export type { Redis };

--- a/lib/token-store.ts
+++ b/lib/token-store.ts
@@ -1,4 +1,4 @@
-import Redis, { RedisOptions } from 'ioredis';
+import { getRedisClient } from './redis-client';
 
 export type StoredTokens = {
   access_token_enc: string;
@@ -10,37 +10,6 @@ export type StoredTokens = {
 
 
 const TOKEN_KEY = 'aktonz:ms:tokens';
-
-let redisClient: Redis | null = null;
-
-function getRedisClient(): Redis {
-  if (redisClient) {
-    return redisClient;
-  }
-
-  const redisUrl = process.env.REDIS_URL;
-  if (!redisUrl) {
-    throw new Error('REDIS_URL environment variable must be set');
-  }
-
-  const parsedUrl = new URL(redisUrl);
-  const shouldForceTls =
-    parsedUrl.protocol === 'rediss:' || /\.redis-cloud\.com$/i.test(parsedUrl.hostname);
-
-  const options: RedisOptions = {
-    maxRetriesPerRequest: 2,
-    enableOfflineQueue: false,
-  };
-
-  if (shouldForceTls) {
-    options.tls = {
-      rejectUnauthorized: true,
-    };
-  }
-
-  redisClient = new Redis(redisUrl, options);
-  return redisClient;
-}
 
 export async function saveTokens(data: StoredTokens): Promise<void> {
   const client = getRedisClient();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "ioredis": "^5.8.0",
-
         "leaflet": "^1.9.4",
         "next": "^15.5.2",
         "nodemailer": "^6.9.11",
@@ -4259,27 +4258,6 @@
         "win32"
       ]
     },
-    "node_modules/@upstash/redis": {
-      "version": "1.35.4",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.4.tgz",
-      "integrity": "sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/@vercel/kv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
-      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@upstash/redis": "^1.34.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -7969,7 +7947,6 @@
         "node": ">=14.17"
       }
     },
-
     "node_modules/undici": {
       "version": "6.19.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "ISC",
   "dependencies": {
     "ioredis": "^5.8.0",
-
     "leaflet": "^1.9.4",
     "next": "^15.5.2",
     "nodemailer": "^6.9.11",


### PR DESCRIPTION
## Summary
- extract a reusable Redis client helper that reuses TLS and retry configuration
- update the Redis API route and existing token store utilities to use the shared helper
- remove the unused `redis` package dependency now that the project standardizes on `ioredis`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77eb2d424832e8139636207b6e06d