### PR TITLE
Restore vendor-prefixed Leaflet CSS

### DIFF
--- a/node_modules/leaflet/dist/leaflet.css
+++ b/node_modules/leaflet/dist/leaflet.css
@@ -20,28 +20,25 @@
 .leaflet-tile,
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        -webkit-user-drag: none;
-        user-drag: none;
-        }
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	        user-select: none;
+	  -webkit-user-drag: none;
+	}
 /* Prevents IE11 from highlighting tiles in blue */
 .leaflet-tile::selection {
 	background: transparent;
 }
 /* Safari renders non-retina tile on retina better with this, but Chrome is worse */
 .leaflet-safari .leaflet-tile {
-        /* Legacy: image-rendering: -webkit-optimize-contrast; */
-        }
+	image-rendering: -webkit-optimize-contrast;
+	}
 /* hack that prevents hw layers "stretching" when loading new tiles */
 .leaflet-safari .leaflet-tile-container {
-        width: 1600px;
-        height: 1600px;
-        transform-origin: 0 0;
-        /* Legacy: -webkit-transform-origin: 0 0; */
-        }
+	width: 1600px;
+	height: 1600px;
+	-webkit-transform-origin: 0 0;
+	}
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
 	display: block;
@@ -69,24 +66,24 @@
 }
 
 .leaflet-container.leaflet-touch-zoom {
-        touch-action: pan-x pan-y;
-        /* Legacy: -ms-touch-action: pan-x pan-y; */
-        }
+	-ms-touch-action: pan-x pan-y;
+	touch-action: pan-x pan-y;
+	}
 .leaflet-container.leaflet-touch-drag {
-        /* Fallback for FF which doesn't support pinch-zoom */
-        touch-action: none;
-        touch-action: pinch-zoom;
-        /* Legacy: -ms-touch-action: pinch-zoom; */
+	-ms-touch-action: pinch-zoom;
+	/* Fallback for FF which doesn't support pinch-zoom */
+	touch-action: none;
+	touch-action: pinch-zoom;
 }
 .leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
-        touch-action: none;
-        /* Legacy: -ms-touch-action: none; */
+	-ms-touch-action: none;
+	touch-action: none;
 }
 .leaflet-container {
-        /* Legacy: -webkit-tap-highlight-color: transparent; */
+	-webkit-tap-highlight-color: transparent;
 }
 .leaflet-container a {
-        /* Legacy: -webkit-tap-highlight-color: rgba(51, 181, 229, 0.4); */
+	-webkit-tap-highlight-color: rgba(51, 181, 229, 0.4);
 }
 .leaflet-tile {
 	filter: inherit;
@@ -96,19 +93,16 @@
 	visibility: inherit;
 	}
 .leaflet-zoom-box {
-        width: 0;
-        height: 0;
-        box-sizing: border-box;
-        /* Legacy: -moz-box-sizing: border-box; */
-        z-index: 800;
-        }
+	width: 0;
+	height: 0;
+	-moz-box-sizing: border-box;
+	     box-sizing: border-box;
+	z-index: 800;
+	}
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
 .leaflet-overlay-pane svg {
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        }
+	-moz-user-select: none;
+	}
 
 .leaflet-pane         { z-index: 400; }
 
@@ -183,36 +177,34 @@
 /* zoom and fade animations */
 
 .leaflet-fade-anim .leaflet-popup {
-        opacity: 0;
-        transition: opacity 0.2s linear;
-        /* Legacy transitions:
-           -webkit-transition: opacity 0.2s linear;
-           -moz-transition: opacity 0.2s linear; */
-        }
+	opacity: 0;
+	-webkit-transition: opacity 0.2s linear;
+	   -moz-transition: opacity 0.2s linear;
+	        transition: opacity 0.2s linear;
+	}
 .leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
 	opacity: 1;
 	}
 .leaflet-zoom-animated {
-        transform-origin: 0 0;
-        /* Legacy: -webkit-transform-origin: 0 0; -ms-transform-origin: 0 0; */
-        }
+	-webkit-transform-origin: 0 0;
+	    -ms-transform-origin: 0 0;
+	        transform-origin: 0 0;
+	}
 svg.leaflet-zoom-animated {
 	will-change: transform;
 }
 
 .leaflet-zoom-anim .leaflet-zoom-animated {
-        transition: transform 0.25s cubic-bezier(0,0,0.25,1);
-        /* Legacy transitions:
-           -webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
-           -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1); */
-        }
+	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
+	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
+	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
+	}
 .leaflet-zoom-anim .leaflet-tile,
 .leaflet-pan-anim .leaflet-tile {
-        transition: none;
-        /* Legacy transitions:
-           -webkit-transition: none;
-           -moz-transition: none; */
-        }
+	-webkit-transition: none;
+	   -moz-transition: none;
+	        transition: none;
+	}
 
 .leaflet-zoom-anim .leaflet-zoom-hide {
 	visibility: hidden;
@@ -225,11 +217,10 @@ svg.leaflet-zoom-animated {
 	cursor: pointer;
 	}
 .leaflet-grab {
-        cursor: grab;
-        /* Legacy cursors:
-           cursor: -webkit-grab;
-           cursor: -moz-grab; */
-        }
+	cursor: -webkit-grab;
+	cursor:    -moz-grab;
+	cursor:         grab;
+	}
 .leaflet-crosshair,
 .leaflet-crosshair .leaflet-interactive {
 	cursor: crosshair;
@@ -241,12 +232,11 @@ svg.leaflet-zoom-animated {
 .leaflet-dragging .leaflet-grab,
 .leaflet-dragging .leaflet-grab .leaflet-interactive,
 .leaflet-dragging .leaflet-marker-draggable {
-        cursor: move;
-        cursor: grabbing;
-        /* Legacy cursors:
-           cursor: -webkit-grabbing;
-           cursor: -moz-grabbing; */
-        }
+	cursor: move;
+	cursor: -webkit-grabbing;
+	cursor:    -moz-grabbing;
+	cursor:         grabbing;
+	}
 
 /* marker & overlays interactivity */
 .leaflet-marker-icon,
@@ -456,8 +446,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	line-height: 1.1;
 	padding: 2px 5px 1px;
 	white-space: nowrap;
-        box-sizing: border-box;
-        /* Legacy: -moz-box-sizing: border-box; */
+	-moz-box-sizing: border-box;
+	     box-sizing: border-box;
 	background: rgba(255, 255, 255, 0.8);
 	text-shadow: 1px 1px #fff;
 	}
@@ -523,12 +513,11 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	margin: -10px auto 0;
 	pointer-events: auto;
 
-        transform: rotate(45deg);
-        /* Legacy transforms:
-           -webkit-transform: rotate(45deg);
-           -moz-transform: rotate(45deg);
-           -ms-transform: rotate(45deg); */
-        }
+	-webkit-transform: rotate(45deg);
+	   -moz-transform: rotate(45deg);
+	    -ms-transform: rotate(45deg);
+	        transform: rotate(45deg);
+	}
 .leaflet-popup-content-wrapper,
 .leaflet-popup-tip {
 	background: white;
@@ -557,16 +546,15 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 .leaflet-oldie .leaflet-popup-content-wrapper {
-        zoom: 1;
-        /* Legacy: -ms-zoom: 1; */
-        }
+	-ms-zoom: 1;
+	}
 .leaflet-oldie .leaflet-popup-tip {
-        width: 24px;
-        margin: 0 auto;
+	width: 24px;
+	margin: 0 auto;
 
-        /* Legacy: -ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)"; */
-        filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
-        }
+	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
+	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	}
 
 .leaflet-oldie .leaflet-control-zoom,
 .leaflet-oldie .leaflet-control-layers,
@@ -593,14 +581,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border: 1px solid #fff;
 	border-radius: 3px;
 	color: #222;
-        white-space: nowrap;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        pointer-events: none;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.4);
-        }
+	white-space: nowrap;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+	}
 .leaflet-tooltip.leaflet-interactive {
 	cursor: pointer;
 	pointer-events: auto;
@@ -667,7 +655,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 @media print {
 	/* Prevent printers from removing background-images of controls. */
 	.leaflet-control {
-                print-color-adjust: exact;
-                /* Legacy: -webkit-print-color-adjust: exact; */
-                }
+		-webkit-print-color-adjust: exact;
+		print-color-adjust: exact;
+		}
 	}


### PR DESCRIPTION
## Summary
- restore vendor-prefixed CSS declarations in the Leaflet distribution stylesheet to maintain compatibility with legacy browsers

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d78350d4c4832ea721b31c8f75d3c3