### PR TITLE
Fix Microsoft OAuth defaults when env vars missing

### DIFF
--- a/lib/ms-graph.js
+++ b/lib/ms-graph.js
@@ -2,6 +2,12 @@ const crypto = require("crypto");
 const { resolveMicrosoftRedirectUriFromEnv } = require("./ms-redirect");
 const { readTokens, saveTokens } = require("./token-store");
 
+const DEFAULT_CLIENT_ID = "04651e3a-82c5-4e03-ba50-574b2bb79cac";
+const DEFAULT_SCOPES = "offline_access Mail.Send User.Read";
+
+const MS_CLIENT_ID = process.env.MS_CLIENT_ID || DEFAULT_CLIENT_ID;
+const SCOPES = process.env.MS_SCOPES || DEFAULT_SCOPES;
+
 function getKey() {
   const raw = process.env.TOKEN_ENCRYPTION_KEY;
   if (!raw || raw.length === 0) {
@@ -78,7 +84,7 @@ function resolveTenantId() {
 }
 
 async function refresh(access) {
-  const clientId = process.env.MS_CLIENT_ID;
+  const clientId = MS_CLIENT_ID;
   const clientSecret = process.env.MS_CLIENT_SECRET;
   const redirectUri = resolveMicrosoftRedirectUriFromEnv();
   if (!clientId || !clientSecret || !redirectUri) {
@@ -92,6 +98,7 @@ async function refresh(access) {
     grant_type: "refresh_token",
     refresh_token: decryptToken(access.refresh_token_enc),
     redirect_uri: redirectUri,
+    scope: SCOPES,
   });
   const response = await fetch(tokenUrl, {
     method: "POST",
@@ -155,10 +162,15 @@ async function sendMailGraph({ to, subject, html, text }) {
   }
 }
 
+const MS_TENANT_ID = resolveTenantId();
+
 module.exports = {
   encryptToken,
   decryptToken,
   getValidAccessToken,
   sendMailGraph,
   resolveTenantId,
+  MS_CLIENT_ID,
+  MS_TENANT_ID,
+  SCOPES,
 };

--- a/lib/ms-graph.ts
+++ b/lib/ms-graph.ts
@@ -2,7 +2,10 @@ import { encryptText, decryptText, deserializeEncryptedPayload, serializeEncrypt
 import { clearTokens, readTokens, saveTokens } from './token-store';
 
 
-export const MS_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
+const DEFAULT_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
+const DEFAULT_SCOPES = 'offline_access Mail.Send User.Read';
+
+export const MS_CLIENT_ID = process.env.MS_CLIENT_ID ?? DEFAULT_CLIENT_ID;
 
 const TENANT_ENV_KEYS = [
   'MS_TENANT_ID',
@@ -100,7 +103,7 @@ function getRedirectUri(envKeys: string[], fallback: string, label: string): str
 export const MS_REDIRECT_URI = getRedirectUri(PROD_REDIRECT_ENV_KEYS, DEFAULT_PROD_REDIRECT_URI, 'MS_REDIRECT_URI');
 export const MS_DEV_REDIRECT_URI = getRedirectUri(DEV_REDIRECT_ENV_KEYS, DEFAULT_DEV_REDIRECT_URI, 'MS_DEV_REDIRECT_URI');
 
-export const SCOPES = 'offline_access Mail.Send User.Read';
+export const SCOPES = process.env.MS_SCOPES ?? DEFAULT_SCOPES;
 export const ALLOWED_UPN = 'info@aktonz.com';
 
 const TOKEN_ENDPOINT = `https://login.microsoftonline.com/${MS_TENANT_ID}/oauth2/v2.0/token`;

--- a/pages/api/microsoft/connect.js
+++ b/pages/api/microsoft/connect.js
@@ -1,15 +1,10 @@
 const { resolveMicrosoftRedirectUri } = require("../../../lib/ms-redirect");
-const { resolveTenantId } = require("../../../lib/ms-graph");
+const { resolveTenantId, MS_CLIENT_ID, SCOPES } = require("../../../lib/ms-graph");
 
 module.exports = function handler(req, res) {
-  const clientId = process.env.MS_CLIENT_ID;
-  const scopes = process.env.MS_SCOPES || 'offline_access Mail.Send User.Read';
+  const clientId = MS_CLIENT_ID;
+  const scopes = SCOPES;
   const tenant = resolveTenantId();
-
-  if (!clientId) {
-    res.status(500).json({ error: "missing_ms_config" });
-    return;
-  }
 
   let redirectUri;
   try {


### PR DESCRIPTION
## Summary
- ensure the legacy Microsoft Graph helper exports client ID, tenant, and scopes with sensible defaults
- align TypeScript helper to honour environment overrides for client ID and scopes
- update the connect API route to rely on the shared helper exports so OAuth URLs are never generated with `undefined`

## Testing
- npm test -- ms-tenant
- npm test -- ms-redirect

------
https://chatgpt.com/codex/tasks/task_e_68d78496e140832e8f7cc0f198a0d358