### PR TITLE
Update Microsoft client ID defaults and add AADSTS700016 guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ MS_SCOPES="offline_access Mail.Send User.Read"
 TOKEN_ENCRYPTION_KEY=<generate a long random string>
 ```
 
+#### Error: `AADSTS700016` when signing in
+
+If Microsoft returns **AADSTS700016** with the message *"Application with
+identifier '04651e3a-82c5-4e03-ba50-574b2bb79cac' was not found in the
+directory 'Aktonz'"*, the sign-in attempt is still using the deprecated default
+app registration ID. Resolve it with the checklist below:
+
+1. **Update the client ID.** Set `MS_CLIENT_ID` (or any of the accepted
+   aliases) to `28c9d37b-2c2b-4d49-9ac4-4c180967bc7c`. Redeploy or restart the
+   server after changing the environment variable.
+2. **Double-check tenant routing.** For the single-tenant connector keep
+   `MS_TENANT_ID` set to `60737a1b-9707-4d7f-9909-0ee943a1ffff`. If you prefer
+   multi-tenant sign-in, remove the variable entirely so the code falls back to
+   `common`.
+3. **Confirm the redirect URIs.** Ensure the production
+   `https://aktonz.com/api/microsoft/callback` and local development
+   `http://localhost:3000/api/admin/email/microsoft/callback` URLs are still
+   registered under **Authentication → Web** in the Azure portal.
+4. **Retry the connection.** Clear any cached auth tabs, then click **Connect
+   Microsoft** again. The login prompt should now reference the updated client
+   ID.
+
+Running `npm run check-ms-connector` after updating the environment variables
+verifies that the connector will no longer fall back to the old identifier.
+
 > **Current production secret (September 2025):** `aktonz-email-connector-2`
 > (secret ID `5ac90759-6286-48c0-98b2-5a2aa19d7e6d`). Copy the secret **Value**
 > directly from Azure and update the `MS_CLIENT_SECRET` environment variable in

--- a/lib/ms-graph.js
+++ b/lib/ms-graph.js
@@ -2,7 +2,7 @@ const crypto = require("crypto");
 const { resolveMicrosoftRedirectUriFromEnv } = require("./ms-redirect");
 const { readTokens, saveTokens } = require("./token-store");
 
-const DEFAULT_CLIENT_ID = "04651e3a-82c5-4e03-ba50-574b2bb79cac";
+const DEFAULT_CLIENT_ID = "28c9d37b-2c2b-4d49-9ac4-4c180967bc7c";
 const DEFAULT_SCOPES = "offline_access Mail.Send User.Read";
 
 const MS_CLIENT_ID = process.env.MS_CLIENT_ID || DEFAULT_CLIENT_ID;

--- a/lib/ms-graph.ts
+++ b/lib/ms-graph.ts
@@ -2,7 +2,7 @@ import { encryptText, decryptText, deserializeEncryptedPayload, serializeEncrypt
 import { clearTokens, readTokens, saveTokens } from './token-store';
 
 
-const DEFAULT_CLIENT_ID = '04651e3a-82c5-4e03-ba50-574b2bb79cac';
+const DEFAULT_CLIENT_ID = '28c9d37b-2c2b-4d49-9ac4-4c180967bc7c';
 const DEFAULT_SCOPES = 'offline_access Mail.Send User.Read';
 
 export const MS_CLIENT_ID = process.env.MS_CLIENT_ID ?? DEFAULT_CLIENT_ID;

--- a/scripts/check-ms-connector.mjs
+++ b/scripts/check-ms-connector.mjs
@@ -75,7 +75,7 @@ function reportGroup(label, keys, { optional = false, fallback = null } = {}) {
 }
 
 const DEFAULTS = {
-  clientId: '04651e3a-82c5-4e03-ba50-574b2bb79cac',
+  clientId: '28c9d37b-2c2b-4d49-9ac4-4c180967bc7c',
   redirectUri: 'https://aktonz.com/api/microsoft/callback',
   devRedirectUri: 'http://localhost:3000/api/admin/email/microsoft/callback',
   tenantId: '60737a1b-9707-4d7f-9909-0ee943a1ffff',

--- a/scripts/vercel-env-commands.sh
+++ b/scripts/vercel-env-commands.sh
@@ -2,7 +2,7 @@
 npm uninstall @vercel/kv
 npm install ioredis
 
-printf "04651e3a-82c5-4e03-ba50-574b2bb79cac" | vercel env add MS_CLIENT_ID
+printf "28c9d37b-2c2b-4d49-9ac4-4c180967bc7c" | vercel env add MS_CLIENT_ID
 printf "60737a1b-9707-4d7f-9909-0ee943a1ffff" | vercel env add MS_TENANT_ID
 printf "https://aktonz.com/api/microsoft/callback" | vercel env add MS_REDIRECT_URI
 printf "offline_access Mail.Send User.Read" | vercel env add MS_SCOPES

--- a/scripts/vercel_finalize.sh
+++ b/scripts/vercel_finalize.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # 0) Vars
-APP_ID="${APP_ID:-04651e3a-82c5-4e03-ba50-574b2bb79cac}"
+APP_ID="${APP_ID:-28c9d37b-2c2b-4d49-9ac4-4c180967bc7c}"
 TENANT_ID="${TENANT_ID:-60737a1b-9707-4d7f-9909-0ee943a1ffff}"
 BASE_URL="${BASE_URL:-https://aktonz.com}"
 
@@ -45,7 +45,7 @@ NEW_SECRET="$(
 )"
 
 # 5) Vercel envs
-printf '%s\n' '04651e3a-82c5-4e03-ba50-574b2bb79cac' | vercel env add MS_CLIENT_ID
+printf '%s\n' '28c9d37b-2c2b-4d49-9ac4-4c180967bc7c' | vercel env add MS_CLIENT_ID
 printf '%s\n' '60737a1b-9707-4d7f-9909-0ee943a1ffff' | vercel env add MS_TENANT_ID
 printf '%s\n' 'https://aktonz.com/api/microsoft/callback' | vercel env add MS_REDIRECT_URI
 printf '%s\n' 'offline_access Mail.Send User.Read' | vercel env add MS_SCOPES


### PR DESCRIPTION
## Summary
- switch the Microsoft Graph connector fallback client ID to the active Aktonz registration
- refresh automation scripts to push the new identifier into Vercel environments
- document how to resolve the AADSTS700016 sign-in error when the old app ID is still referenced

## Testing
- npm run check-ms-connector *(fails locally: missing MS_CLIENT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68d78623638c832ea9fd80fc8d430cd0