### PR TITLE
Persist offers and return deposit details

### DIFF
--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -75,13 +75,14 @@ export default function OfferDrawer({ property }) {
           email,
           ...(phone ? { phone } : {}),
           ...(message ? { message } : {}),
-          depositAmount: isSaleListing ? 0 : undefined,
         }),
       });
 
       if (!res.ok) throw new Error('Request failed');
       const payload = await res.json();
-      setOffer(payload?.offer || null);
+      if (payload?.offer) {
+        setOffer(payload.offer);
+      }
       setStatus({
         tone: 'success',
         message: 'Offer submitted successfully. We will be in touch shortly.',

--- a/lib/offers.js
+++ b/lib/offers.js
@@ -40,7 +40,7 @@ function getDefaultDepositAmount() {
 export async function addOffer({
   propertyId,
   propertyTitle,
-  price,
+  offerAmount,
   frequency,
   name,
   email,
@@ -51,12 +51,13 @@ export async function addOffer({
   const now = new Date().toISOString();
   const resolvedDeposit =
     toNumber(depositAmount, undefined) ?? getDefaultDepositAmount();
+  const resolvedPrice = toNumber(offerAmount, undefined);
 
   const offer = {
     id,
     propertyId,
     propertyTitle,
-    price,
+    price: resolvedPrice ?? null,
     frequency,
     name,
     email,

--- a/pages/api/offers.ts
+++ b/pages/api/offers.ts
@@ -139,7 +139,7 @@ function validateBody(body: FormBody): { data?: ValidatedOffer; errors?: string[
 
   return {
     data: {
-      propertyId,
+      propertyId: propertyId!,
       propertyTitle,
       offerAmount: offerAmount!,
       frequency: frequency || undefined,

--- a/pages/api/offers.ts
+++ b/pages/api/offers.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { sendMailGraph } from '../../lib/ms-graph';
+import { addOffer } from '../../lib/offers.js';
 
 type FormBody = {
   name?: string;
   email?: string;
   phone?: string;
-  offerAmount?: string;
+  offerAmount?: string | number;
   propertyId?: string;
   message?: string;
   propertyTitle?: string;
@@ -81,6 +82,74 @@ function hasValue(value: unknown): boolean {
   }
 
   return true;
+}
+
+function normaliseString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+type ValidatedOffer = {
+  propertyId: string;
+  propertyTitle?: string;
+  offerAmount: number;
+  frequency?: string;
+  name: string;
+  email: string;
+  phone?: string;
+  message?: string;
+  depositAmount?: string | number;
+};
+
+function validateBody(body: FormBody): { data?: ValidatedOffer; errors?: string[] } {
+  const errors: string[] = [];
+
+  const propertyId = normaliseString(body.propertyId);
+  if (!propertyId) {
+    errors.push('Property reference is required.');
+  }
+
+  const offerAmount = toNumber(body.offerAmount);
+  if (offerAmount === null || offerAmount <= 0) {
+    errors.push('Offer amount must be a positive number.');
+  }
+
+  const name = normaliseString(body.name);
+  if (!name) {
+    errors.push('Name is required.');
+  }
+
+  const email = normaliseString(body.email);
+  if (!email) {
+    errors.push('Email is required.');
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  const frequency = normaliseString(body.frequency);
+  const propertyTitle = normaliseString(body.propertyTitle);
+  const phone = normaliseString(body.phone);
+  const message = normaliseString(body.message);
+
+  return {
+    data: {
+      propertyId,
+      propertyTitle,
+      offerAmount: offerAmount!,
+      frequency: frequency || undefined,
+      name: name!,
+      email: email!,
+      phone: phone || undefined,
+      message: message || undefined,
+      depositAmount: body.depositAmount,
+    },
+  };
 }
 
 function buildHtml(body: FormBody): string {
@@ -181,14 +250,46 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    await sendMailGraph({
-      subject: resolveSubject(body),
-      html: buildHtml(body),
-      to: RECIPIENTS,
-      replyTo: resolveReplyTo(body.email),
+    const { data, errors } = validateBody(body);
+    if (!data || errors) {
+      res.status(400).json({
+        error: 'Invalid request body',
+        details: errors,
+      });
+      return;
+    }
+
+    const offer = await addOffer({
+      propertyId: data.propertyId,
+      propertyTitle: data.propertyTitle,
+      offerAmount: data.offerAmount,
+      frequency: data.frequency,
+      name: data.name,
+      email: data.email,
+      depositAmount: data.depositAmount,
     });
 
-    res.status(200).json({ ok: true });
+    const emailBody: FormBody = {
+      ...body,
+      propertyId: data.propertyId,
+      propertyTitle: data.propertyTitle,
+      offerAmount: offer.price ?? data.offerAmount,
+      frequency: data.frequency,
+      name: data.name,
+      email: data.email,
+      phone: data.phone,
+      message: data.message,
+      depositAmount: offer.depositAmount,
+    };
+
+    await sendMailGraph({
+      subject: resolveSubject(emailBody),
+      html: buildHtml(emailBody),
+      to: RECIPIENTS,
+      replyTo: resolveReplyTo(data.email),
+    });
+
+    res.status(200).json({ offer });
   } catch (error) {
     res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to send email' });
   }


### PR DESCRIPTION
## Summary
- validate offer submissions and persist them before notifying the team
- ensure stored offer pricing/deposit values are returned to the client and email copy
- update the offer drawer and API tests to use the stored offer metadata

## Testing
- npm test -- offers-api

------
https://chatgpt.com/codex/tasks/task_e_68d9cb067a4c832e87090c9d703f91c5