### PR TITLE
Load admin offers from persisted store

### DIFF
--- a/__tests__/admin-offers.test.js
+++ b/__tests__/admin-offers.test.js
@@ -1,0 +1,100 @@
+const path = require('path');
+const { promises: fs } = require('fs');
+
+const loadTs = require('./helpers/load-ts');
+const agentsData = require('../data/agents.json');
+const supportData = require('../data/ai-support.json');
+
+const DATA_PATH = path.join(process.cwd(), 'data', 'offers.json');
+
+function createMockRes() {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  res.setHeader = jest.fn();
+  res.end = jest.fn();
+  return res;
+}
+
+describe('admin offers API', () => {
+  let originalContent = '[]';
+
+  beforeAll(async () => {
+    try {
+      originalContent = await fs.readFile(DATA_PATH, 'utf8');
+    } catch {
+      originalContent = '[]';
+    }
+  });
+
+  afterAll(async () => {
+    await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
+    await fs.writeFile(DATA_PATH, originalContent, 'utf8');
+  });
+
+  beforeEach(async () => {
+    await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
+    await fs.writeFile(DATA_PATH, '[]', 'utf8');
+    jest.resetModules();
+  });
+
+  test('returns persisted offers with deposit and payment details', async () => {
+    const offersModule = loadTs('../lib/offers.js', __dirname);
+    const savedOffer = await offersModule.addOffer({
+      propertyId: 'SCRAYE-950002',
+      propertyTitle: 'Stylish Four Bedroom Apartment',
+      offerAmount: '1800',
+      frequency: 'pcm',
+      name: 'Test Tenant',
+      email: 'tenant@example.com',
+      depositAmount: '950',
+    });
+
+    const readSessionMock = jest.fn(() => ({ adminId: 'ops-admin', role: 'admin' }));
+    const offersAdminModule = loadTs('../lib/offers-admin.mjs', __dirname, {
+      overrides: {
+        '../data/agents.json': agentsData,
+        '../data/ai-support.json': supportData,
+        './offers.js': offersModule,
+        [require.resolve('../data/agents.json')]: agentsData,
+        [require.resolve('../data/ai-support.json')]: supportData,
+        [require.resolve('../lib/offers.js')]: offersModule,
+      },
+    });
+    const handler = loadTs('../pages/api/admin/offers.js', __dirname, {
+      overrides: {
+        '../../../lib/session.js': { readSession: readSessionMock },
+        '../../../lib/offers-admin.mjs': offersAdminModule,
+        [require.resolve('../lib/session.js')]: { readSession: readSessionMock },
+        [require.resolve('../lib/offers-admin.mjs')]: offersAdminModule,
+      },
+    }).default;
+
+    const req = { method: 'GET', headers: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledTimes(1);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(Array.isArray(payload.offers)).toBe(true);
+
+    expect(payload.offers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: savedOffer.id,
+          depositAmount: savedOffer.depositAmount,
+          paymentStatus: savedOffer.paymentStatus,
+          payments: savedOffer.payments,
+          propertyTitle: savedOffer.propertyTitle,
+          property: expect.objectContaining({
+            id: 'SCRAYE-950002',
+            title: 'Stylish Four Bedroom Apartment',
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -1,5 +1,6 @@
-import agents from '../data/agents.json';
-import supportData from '../data/ai-support.json';
+import agents from '../data/agents.json' with { type: 'json' };
+import supportData from '../data/ai-support.json' with { type: 'json' };
+import { readOffers } from './offers.js';
 
 function normalizeListingId(listing) {
   const rawId = listing?.id != null ? String(listing.id).trim() : '';
@@ -58,17 +59,31 @@ function buildAgentMap() {
   return new Map(agentEntries.map((agent) => [String(agent.id), agent]));
 }
 
-export function listOffersForAdmin() {
+function normalizeDate(value) {
+  if (!value) {
+    return 0;
+  }
+
+  const date = new Date(value);
+  const timestamp = date.getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export async function listOffersForAdmin() {
   const listingMap = buildListingMap();
   const contactMap = buildContactMap(listingMap);
   const agentMap = buildAgentMap();
-  const offers = Array.isArray(supportData.offers) ? supportData.offers : [];
+  const offers = await readOffers();
 
   return offers
     .map((offer) => {
-      const contact = contactMap.get(offer.contactId) || null;
-      const property = offer.propertyId ? listingMap.get(offer.propertyId) || null : null;
-      const agent = offer.agentId ? agentMap.get(String(offer.agentId)) || null : null;
+      const contactId = offer.contactId ? String(offer.contactId) : '';
+      const propertyId = offer.propertyId ? String(offer.propertyId) : '';
+      const agentId = offer.agentId ? String(offer.agentId) : '';
+
+      const contact = contactId ? contactMap.get(contactId) || null : null;
+      const property = propertyId ? listingMap.get(propertyId) || null : null;
+      const agent = agentId ? agentMap.get(agentId) || null : null;
 
       return {
         ...offer,
@@ -77,5 +92,9 @@ export function listOffersForAdmin() {
         agent,
       };
     })
-    .sort((a, b) => new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime());
+    .sort((a, b) => {
+      const right = normalizeDate(b.updatedAt || b.createdAt || b.date);
+      const left = normalizeDate(a.updatedAt || a.createdAt || a.date);
+      return right - left;
+    });
 }

--- a/pages/api/admin/offers.js
+++ b/pages/api/admin/offers.js
@@ -14,7 +14,7 @@ function requireAdmin(req, res) {
   return admin;
 }
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (!requireAdmin(req, res)) {
     return;
   }
@@ -25,7 +25,7 @@ export default function handler(req, res) {
 
   if (req.method === 'GET') {
     try {
-      const offers = listOffersForAdmin();
+      const offers = await listOffersForAdmin();
       return res.status(200).json({ offers });
     } catch (error) {
       console.error('Failed to list offers for admin', error);


### PR DESCRIPTION
## Summary
- read offers from the persisted store in the admin loader and enrich them with listing metadata
- await the updated loader in the admin offers API handler so real offers are returned
- add a Jest test that saves an offer and verifies the admin API response includes deposit and payment details

## Testing
- npm test -- admin-offers

------
https://chatgpt.com/codex/tasks/task_e_68d9d00b0454832e8d84842b2a4c367c