### PR TITLE
Ensure admin offers fallback to submitter contact details

### DIFF
--- a/__tests__/offers-api.test.js
+++ b/__tests__/offers-api.test.js
@@ -45,6 +45,8 @@ describe('offer API email delivery', () => {
       frequency: 'pcm',
       name: 'Buyer Example',
       email: 'buyer@example.com',
+      phone: '+44 7700 900123',
+      message: 'Please consider my offer.',
       status: 'new',
       paymentStatus: 'pending',
       depositAmount: 1200,
@@ -83,6 +85,8 @@ describe('offer API email delivery', () => {
         propertyId: 'AKT-123',
         offerAmount: 450000,
         depositAmount: '1200',
+        phone: '+44 7700 900123',
+        message: 'Please consider my offer.',
       })
     );
     expect(res.status).toHaveBeenCalledWith(200);

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -84,7 +84,42 @@ export async function listOffersForAdmin() {
       const propertyId = offer.propertyId ? String(offer.propertyId) : '';
       const agentId = offer.agentId ? String(offer.agentId) : '';
 
-      const contact = contactId ? contactMap.get(contactId) || null : null;
+      const fallbackContact = (() => {
+        const details = {};
+        if (offer.name) {
+          details.name = offer.name;
+        }
+        if (offer.email) {
+          details.email = offer.email;
+        }
+        if (offer.phone) {
+          details.phone = offer.phone;
+        }
+
+        return Object.keys(details).length ? details : null;
+      })();
+
+      const rawContact = contactId ? contactMap.get(contactId) || null : null;
+      let contact = null;
+
+      if (rawContact) {
+        contact = {
+          ...rawContact,
+        };
+
+        if (fallbackContact?.name && !contact.name) {
+          contact.name = fallbackContact.name;
+        }
+        if (fallbackContact?.email && !contact.email) {
+          contact.email = fallbackContact.email;
+        }
+        if (fallbackContact?.phone && !contact.phone) {
+          contact.phone = fallbackContact.phone;
+        }
+      } else if (fallbackContact) {
+        contact = fallbackContact;
+      }
+
       const property = propertyId ? listingMap.get(propertyId) || null : null;
       const agent = agentId ? agentMap.get(agentId) || null : null;
 

--- a/lib/offers.js
+++ b/lib/offers.js
@@ -44,7 +44,11 @@ export async function addOffer({
   frequency,
   name,
   email,
+  phone,
+  message,
   depositAmount,
+  contactId,
+  agentId,
 }) {
   const offers = await readOffers();
   const id = randomUUID();
@@ -61,6 +65,8 @@ export async function addOffer({
     frequency,
     name,
     email,
+    ...(phone !== undefined ? { phone } : {}),
+    ...(message !== undefined ? { message } : {}),
     status: 'new',
     paymentStatus: 'pending',
     depositAmount: resolvedDeposit,
@@ -69,6 +75,14 @@ export async function addOffer({
     notes: '',
     payments: [],
   };
+
+  if (contactId !== undefined) {
+    offer.contactId = contactId;
+  }
+
+  if (agentId !== undefined) {
+    offer.agentId = agentId;
+  }
 
   offers.push(offer);
   await writeOffers(offers);

--- a/pages/api/offers.ts
+++ b/pages/api/offers.ts
@@ -266,6 +266,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       frequency: data.frequency,
       name: data.name,
       email: data.email,
+      phone: data.phone,
+      message: data.message,
       depositAmount: data.depositAmount,
     });
 


### PR DESCRIPTION
## Summary
- persist optional contact details when saving offers and expose them to admin listing
- propagate phone/message through the public offer API and merge submitter data when CRM lookups miss
- extend admin offers coverage to assert fallback contact info for the UI

## Testing
- npm test -- admin-offers.test.js offers-api.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d52fb7f0832e9ff03460f08abd71