### PR TITLE
Populate admin offers with presentation metadata

### DIFF
--- a/__tests__/admin-offers.test.js
+++ b/__tests__/admin-offers.test.js
@@ -96,6 +96,15 @@ describe('admin offers API', () => {
         }),
       ])
     );
+
+    const savedEntry = payload.offers.find((entry) => entry.id === savedOffer.id);
+    expect(savedEntry).toBeDefined();
+    expect(savedEntry.amount).toBe('£1800 pcm');
+    expect(savedEntry.date).toBe(savedOffer.createdAt);
+    expect(savedEntry.type).toBe('rent');
+    expect(savedEntry.price).toBe(savedOffer.price);
+    expect(savedEntry.frequency).toBe(savedOffer.frequency);
+    expect(savedEntry.createdAt).toBe(savedOffer.createdAt);
   });
 
   test('falls back to submitter contact details when CRM lookup fails', async () => {

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const agents = require('../data/agents.json');
 const supportData = require('../data/ai-support.json');
+import { formatPriceGBP, formatRentFrequency } from './format.mjs';
 import { readOffers } from './offers.js';
 
 function normalizeListingId(listing) {
@@ -72,6 +73,73 @@ function normalizeDate(value) {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
+const RENT_FREQUENCY_TOKENS = new Set([
+  'w',
+  'pw',
+  'perweek',
+  'weekly',
+  'week',
+  'm',
+  'pm',
+  'pcm',
+  'permonth',
+  'monthly',
+  'month',
+  'q',
+  'pq',
+  'perquarter',
+  'quarterly',
+  'quarter',
+  'y',
+  'pa',
+  'perannum',
+  'annually',
+  'year',
+  'yearly',
+]);
+
+function normalizeFrequencyToken(value) {
+  if (!value) {
+    return '';
+  }
+
+  return String(value).trim().toLowerCase().replace(/[^a-z]/g, '');
+}
+
+function getOfferType(offer) {
+  const token = normalizeFrequencyToken(offer?.frequency);
+  if (token && RENT_FREQUENCY_TOKENS.has(token)) {
+    return 'rent';
+  }
+
+  return 'sale';
+}
+
+function formatOfferAmount(offer, type) {
+  const price = offer?.price;
+  const formattedPrice =
+    price != null ? formatPriceGBP(price, { isSale: type === 'sale' }) : '';
+  if (!formattedPrice) {
+    return '';
+  }
+
+  if (type === 'rent') {
+    const frequency = offer?.frequency;
+    const frequencyLabel = formatRentFrequency(frequency);
+    return frequencyLabel ? `${formattedPrice} ${frequencyLabel}` : formattedPrice;
+  }
+
+  return formattedPrice;
+}
+
+function buildOfferPresentation(offer) {
+  const type = getOfferType(offer);
+  const amount = formatOfferAmount(offer, type);
+  const date = offer?.createdAt || offer?.updatedAt || null;
+
+  return { amount, date, type };
+}
+
 export async function listOffersForAdmin() {
   const listingMap = buildListingMap();
   const contactMap = buildContactMap(listingMap);
@@ -123,8 +191,11 @@ export async function listOffersForAdmin() {
       const property = propertyId ? listingMap.get(propertyId) || null : null;
       const agent = agentId ? agentMap.get(agentId) || null : null;
 
+      const presentation = buildOfferPresentation(offer);
+
       return {
         ...offer,
+        ...presentation,
         contact,
         property,
         agent,


### PR DESCRIPTION
## Summary
- derive amount, date, and type metadata for admin offers while keeping raw price and frequency values intact
- reuse shared formatting helpers to generate human-readable amounts for rent and sale offers
- extend the admin offers API test to cover the new presentation fields returned for each offer

## Testing
- npx jest __tests__/admin-offers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9d88dbd70832ea6aeebeba8427087