### PR TITLE
Normalize offer frequency defaults

### DIFF
--- a/__tests__/helpers/load-ts.js
+++ b/__tests__/helpers/load-ts.js
@@ -43,3 +43,11 @@ module.exports = (relativePath, callerDir = __dirname, options = {}) => {
   compiledModule._compile(outputText, filename);
   return compiledModule.exports;
 };
+
+if (typeof describe === 'function') {
+  describe('load-ts helper', () => {
+    test('exposes a loader function', () => {
+      expect(typeof module.exports).toBe('function');
+    });
+  });
+}

--- a/__tests__/offer-frequency.test.js
+++ b/__tests__/offer-frequency.test.js
@@ -1,0 +1,25 @@
+describe('offer frequency helpers', () => {
+  test('defaults pcm rentals to per month cadence', async () => {
+    const { resolveOfferFrequency } = await import('../lib/offer-frequency.mjs');
+
+    const property = {
+      id: 'SCRAYE-PCM',
+      transactionType: 'rent',
+      rentFrequency: 'M',
+    };
+
+    expect(resolveOfferFrequency(property)).toBe('pcm');
+  });
+
+  test('omits frequency for sale listings', async () => {
+    const { resolveOfferFrequency } = await import('../lib/offer-frequency.mjs');
+
+    const property = {
+      id: 'AKT-SALE',
+      transactionType: 'sale',
+      rentFrequency: 'M',
+    };
+
+    expect(resolveOfferFrequency(property)).toBe('');
+  });
+});

--- a/components/OfferDrawer.js
+++ b/components/OfferDrawer.js
@@ -1,19 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import PropertyActionDrawer from './PropertyActionDrawer';
 import styles from '../styles/OfferDrawer.module.css';
+import {
+  isSaleListing as determineSaleListing,
+  resolveOfferFrequency,
+} from '../lib/offer-frequency.mjs';
 
 export default function OfferDrawer({ property }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [offerAmount, setOfferAmount] = useState('');
-  const transactionType = property?.transactionType
-    ? String(property.transactionType).toLowerCase()
-    : null;
-  const isSaleListing = transactionType
-    ? transactionType === 'sale'
-    : !property?.rentFrequency;
-  const defaultFrequency = isSaleListing ? '' : 'pw';
+  const propertyId = property?.id;
+  const propertyTitle = property?.title || '';
+  const isSaleListing = useMemo(
+    () => determineSaleListing(property),
+    [property?.rentFrequency, property?.transactionType]
+  );
+  const defaultFrequency = useMemo(
+    () => resolveOfferFrequency(property),
+    [propertyId, property?.rentFrequency, property?.transactionType]
+  );
   const [frequency, setFrequency] = useState(defaultFrequency);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -24,9 +31,6 @@ export default function OfferDrawer({ property }) {
   const [offer, setOffer] = useState(null);
   const [paymentLoading, setPaymentLoading] = useState(false);
   const [paymentError, setPaymentError] = useState(null);
-
-  const propertyId = property?.id;
-  const propertyTitle = property?.title || '';
 
   useEffect(() => {
     setFrequency(defaultFrequency);

--- a/lib/offer-frequency.mjs
+++ b/lib/offer-frequency.mjs
@@ -1,0 +1,33 @@
+import { formatRentFrequency } from './format.mjs';
+
+const SUPPORTED_RENT_FREQUENCIES = new Set(['pw', 'pcm', 'pq', 'pa']);
+
+export function isSaleListing(property) {
+  const transactionType = property?.transactionType
+    ? String(property.transactionType).toLowerCase()
+    : null;
+
+  if (transactionType) {
+    return transactionType === 'sale';
+  }
+
+  return !property?.rentFrequency;
+}
+
+export function resolveOfferFrequency(property) {
+  if (isSaleListing(property)) {
+    return '';
+  }
+
+  const normalized = formatRentFrequency(property?.rentFrequency);
+
+  if (SUPPORTED_RENT_FREQUENCIES.has(normalized)) {
+    return normalized;
+  }
+
+  if (normalized) {
+    return normalized;
+  }
+
+  return 'pw';
+}


### PR DESCRIPTION
## Summary
- derive offer default frequency state from property metadata and share logic for identifying sale listings
- add helper module and tests to confirm PCM rentals default to "per month" while sales omit cadence values
- ensure the load-ts helper participates in Jest runs without causing empty-suite failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9deacaf74832e92d4b7516f639b83