### PR TITLE
Normalize offer frequency labels across UI surfaces

### DIFF
--- a/__tests__/format.test.js
+++ b/__tests__/format.test.js
@@ -16,6 +16,12 @@ describe('formatRentFrequency', () => {
     expect(formatRentFrequency('Y')).toBe('pa');
   });
 
+  test('normalizes descriptive rent cadence strings', () => {
+    expect(formatRentFrequency('per week')).toBe('pw');
+    expect(formatRentFrequency('Quarterly')).toBe('pq');
+    expect(formatRentFrequency('per annum')).toBe('pa');
+  });
+
   test('returns original value for unknown codes', () => {
     expect(formatRentFrequency('X')).toBe('X');
   });

--- a/__tests__/offer-frequency.test.js
+++ b/__tests__/offer-frequency.test.js
@@ -38,6 +38,94 @@ describe('offer frequency helpers', () => {
   });
 });
 
+describe('formatOfferFrequencyLabel', () => {
+  test('maps quarterly inputs to the per quarter label', async () => {
+    const { formatOfferFrequencyLabel } = await import('../lib/offer-frequency.mjs');
+
+    expect(formatOfferFrequencyLabel('Q')).toBe('Per quarter');
+    expect(formatOfferFrequencyLabel('pq')).toBe('Per quarter');
+    expect(formatOfferFrequencyLabel('quarterly')).toBe('Per quarter');
+  });
+
+  test('maps annual inputs to the per annum label', async () => {
+    const { formatOfferFrequencyLabel } = await import('../lib/offer-frequency.mjs');
+
+    expect(formatOfferFrequencyLabel('pa')).toBe('Per annum');
+    expect(formatOfferFrequencyLabel('per annum')).toBe('Per annum');
+    expect(formatOfferFrequencyLabel('annually')).toBe('Per annum');
+  });
+});
+
+describe('offer frequency presentation', () => {
+  test('offer emails display the formatted quarterly label', async () => {
+    const { buildHtml } = await import('../pages/api/offers.ts');
+
+    const html = buildHtml({
+      name: 'Quarter Tenant',
+      email: 'tenant@example.com',
+      frequency: 'quarterly',
+    });
+
+    expect(html).toContain('Offer frequency');
+    expect(html).toContain('Per quarter');
+    expect(html).not.toContain('quarterly');
+  });
+
+  test('admin offer amount formatting uses the annual label', async () => {
+    const { formatOfferAmount } = await import('../lib/offers-admin.mjs');
+
+    expect(
+      formatOfferAmount({ price: 5000, frequency: 'per annum' }, 'rent')
+    ).toBe('£5000 Per annum');
+  });
+
+  test('property cards surface the annual frequency label', async () => {
+    const property = {
+      title: 'Annual rental property',
+      price: '£5250',
+      rentFrequency: 'pa',
+    };
+
+    const previousActEnv = global.IS_REACT_ACT_ENVIRONMENT;
+
+    try {
+      jest.resetModules();
+      global.IS_REACT_ACT_ENVIRONMENT = true;
+
+      await jest.isolateModulesAsync(async () => {
+        const React = await import('react');
+        const { act } = React;
+        const { createRoot } = await import('react-dom/client');
+        const PropertyCardModule = await import('../components/PropertyCard.js');
+        const propertyCardExport = PropertyCardModule.default ?? PropertyCardModule;
+        const PropertyCard =
+          typeof propertyCardExport === 'object' && propertyCardExport !== null
+            ? propertyCardExport.default ?? propertyCardExport
+            : propertyCardExport;
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const root = createRoot(container);
+
+        await act(async () => {
+          root.render(React.createElement(PropertyCard, { property }));
+        });
+
+        const priceElement = container.querySelector('.price');
+        expect(priceElement).toBeTruthy();
+        expect(priceElement.textContent).toContain('Per annum');
+
+        act(() => {
+          root.unmount();
+        });
+        container.remove();
+      });
+    } finally {
+      global.IS_REACT_ACT_ENVIRONMENT = previousActEnv;
+    }
+  });
+});
+
 describe('OfferDrawer frequency selection', () => {
   test('preselects quarterly frequency and preserves submission token', async () => {
     const property = {
@@ -65,6 +153,14 @@ describe('OfferDrawer frequency selection', () => {
         jest.doMock('../lib/offer-frequency.mjs', () => ({
           isSaleListing: () => false,
           resolveOfferFrequency: () => 'pq',
+          formatOfferFrequencyLabel: (value) => {
+            if (!value) return '';
+            const normalized = String(value).toLowerCase();
+            if (normalized === 'q' || normalized === 'pq') {
+              return 'Per quarter';
+            }
+            return String(value);
+          },
           OFFER_FREQUENCY_OPTIONS: [
             { value: 'pw', label: 'Per week' },
             { value: 'pcm', label: 'Per month' },

--- a/components/PropertyActionDrawer.js
+++ b/components/PropertyActionDrawer.js
@@ -1,13 +1,14 @@
 import { useId } from 'react';
 import { FaBath, FaBed, FaCouch } from 'react-icons/fa';
-import { formatRentFrequency } from '../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 import styles from '../styles/PropertyActionDrawer.module.css';
 
 function formatPrice(property = {}) {
   if (!property?.price) return '';
   if (property?.rentFrequency) {
-    return `${property.price} ${formatRentFrequency(property.rentFrequency)}`;
+    const frequencyLabel = formatOfferFrequencyLabel(property.rentFrequency);
+    return frequencyLabel ? `${property.price} ${frequencyLabel}` : `${property.price}`;
   }
   return property.price;
 }

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { formatRentFrequency, formatPricePrefix } from '../lib/format.mjs';
+import { formatPricePrefix } from '../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 
@@ -106,6 +107,10 @@ export default function PropertyCard({ property }) {
     !property.rentFrequency && property.pricePrefix
       ? formatPricePrefix(property.pricePrefix)
       : '';
+
+  const rentFrequencyLabel = property.rentFrequency
+    ? formatOfferFrequencyLabel(property.rentFrequency)
+    : '';
 
   const isSaleListing = property?.transactionType
     ? String(property.transactionType).toLowerCase() === 'sale'
@@ -217,8 +222,7 @@ export default function PropertyCard({ property }) {
           <p className="price">
             {property.price}
             {pricePrefixLabel && ` ${pricePrefixLabel}`}
-            {property.rentFrequency &&
-              ` ${formatRentFrequency(property.rentFrequency)}`}
+            {rentFrequencyLabel && ` ${rentFrequencyLabel}`}
           </p>
         )}
         {(property.receptions != null || property.bedrooms != null || property.bathrooms != null) && (

--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { formatRentFrequency } from '../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 
 export default function PropertyMap({
   properties = [],
@@ -67,13 +67,19 @@ export default function PropertyMap({
             icon: getIcon(p.propertyType),
           }).addTo(map);
 
-          const priceText = p.price
-            ? p.rentFrequency
-              ? `${p.price} ${formatRentFrequency(p.rentFrequency)}`
-              : p.tenure
-              ? `${p.price} ${p.tenure}`
-              : p.price
-            : '';
+          const priceText = (() => {
+            if (!p.price) {
+              return '';
+            }
+            if (p.rentFrequency) {
+              const frequencyLabel = formatOfferFrequencyLabel(p.rentFrequency);
+              return frequencyLabel ? `${p.price} ${frequencyLabel}` : p.price;
+            }
+            if (p.tenure) {
+              return `${p.price} ${p.tenure}`;
+            }
+            return p.price;
+          })();
 
           const imgHtml = p.image
             ? `<img src="${p.image}" alt="${p.title}" style="width:100px;height:auto;display:block;"/>`

--- a/lib/format.mjs
+++ b/lib/format.mjs
@@ -1,12 +1,60 @@
 export function formatRentFrequency(freq) {
   if (!freq) return '';
-  const map = {
+
+  const raw = String(freq).trim();
+  if (!raw) return '';
+
+  const upper = raw.toUpperCase();
+  const directMap = {
     W: 'pw',
     M: 'pcm',
     Q: 'pq',
     Y: 'pa',
   };
-  return map[freq] || freq;
+  if (directMap[upper]) {
+    return directMap[upper];
+  }
+
+  const normalized = raw.toLowerCase().replace(/[^a-z]/g, '');
+  if (!normalized) {
+    return '';
+  }
+
+  const aliasMap = {
+    w: 'pw',
+    week: 'pw',
+    weeks: 'pw',
+    weekly: 'pw',
+    perweek: 'pw',
+    pw: 'pw',
+    m: 'pcm',
+    month: 'pcm',
+    months: 'pcm',
+    monthly: 'pcm',
+    permonth: 'pcm',
+    pm: 'pcm',
+    pcm: 'pcm',
+    q: 'pq',
+    quarter: 'pq',
+    quarters: 'pq',
+    quarterly: 'pq',
+    perquarter: 'pq',
+    pq: 'pq',
+    y: 'pa',
+    year: 'pa',
+    years: 'pa',
+    yearly: 'pa',
+    annually: 'pa',
+    perannum: 'pa',
+    peryear: 'pa',
+    pa: 'pa',
+  };
+
+  if (aliasMap[normalized]) {
+    return aliasMap[normalized];
+  }
+
+  return raw;
 }
 
 export function formatPricePrefix(prefix) {

--- a/lib/offer-frequency.mjs
+++ b/lib/offer-frequency.mjs
@@ -10,7 +10,34 @@ export const OFFER_FREQUENCY_OPTIONS = [
 const SUPPORTED_RENT_FREQUENCIES = new Set(
   OFFER_FREQUENCY_OPTIONS.map((option) => option.value)
 );
-const DEFAULT_OFFER_FREQUENCY = OFFER_FREQUENCY_OPTIONS[0]?.value ?? '';
+const DEFAULT_OFFER_FREQUENCY_OPTION =
+  OFFER_FREQUENCY_OPTIONS[0] ?? { value: '', label: '' };
+const DEFAULT_OFFER_FREQUENCY = DEFAULT_OFFER_FREQUENCY_OPTION.value;
+
+export function formatOfferFrequencyLabel(value) {
+  const normalized = formatRentFrequency(value);
+
+  if (!normalized) {
+    return '';
+  }
+
+  const matched = OFFER_FREQUENCY_OPTIONS.find(
+    (option) => option.value === normalized
+  );
+
+  if (matched) {
+    return matched.label;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return normalized;
+}
 
 export function isSaleListing(property) {
   const transactionType = property?.transactionType

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -3,7 +3,8 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const agents = require('../data/agents.json');
 const supportData = require('../data/ai-support.json');
-import { formatPriceGBP, formatRentFrequency } from './format.mjs';
+import { formatOfferFrequencyLabel } from './offer-frequency.mjs';
+import { formatPriceGBP } from './format.mjs';
 import { readOffers } from './offers.js';
 
 function normalizeListingId(listing) {
@@ -115,7 +116,7 @@ function getOfferType(offer) {
   return 'sale';
 }
 
-function formatOfferAmount(offer, type) {
+export function formatOfferAmount(offer, type) {
   const price = offer?.price;
   const formattedPrice =
     price != null ? formatPriceGBP(price, { isSale: type === 'sale' }) : '';
@@ -124,8 +125,7 @@ function formatOfferAmount(offer, type) {
   }
 
   if (type === 'rent') {
-    const frequency = offer?.frequency;
-    const frequencyLabel = formatRentFrequency(frequency);
+    const frequencyLabel = formatOfferFrequencyLabel(offer?.frequency);
     return frequencyLabel ? `${formattedPrice} ${frequencyLabel}` : formattedPrice;
   }
 

--- a/pages/api/offers.ts
+++ b/pages/api/offers.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { sendMailGraph } from '../../lib/ms-graph';
 import { addOffer } from '../../lib/offers.js';
+import { formatOfferFrequencyLabel } from '../../lib/offer-frequency.mjs';
 
 type FormBody = {
   name?: string;
@@ -163,7 +164,7 @@ function validateBody(body: FormBody): { data?: ValidatedOffer; errors?: string[
   };
 }
 
-function buildHtml(body: FormBody): string {
+export function buildHtml(body: FormBody): string {
   const rows: Array<[string, unknown]> = [
     ['Name', body.name ?? ''],
     ['Email', body.email ?? ''],
@@ -178,7 +179,9 @@ function buildHtml(body: FormBody): string {
   }
 
   if (hasValue(body.frequency)) {
-    rows.push(['Offer frequency', body.frequency ?? '']);
+    const frequencyLabel = formatOfferFrequencyLabel(body.frequency);
+    const displayFrequency = frequencyLabel || String(body.frequency ?? '');
+    rows.push(['Offer frequency', displayFrequency]);
   }
 
   if (hasValue(body.depositAmount)) {

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -27,11 +27,8 @@ import {
 } from '../../lib/property-type.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
-import {
-  formatRentFrequency,
-  formatPriceGBP,
-  formatPricePrefix,
-} from '../../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../../lib/offer-frequency.mjs';
+import { formatPriceGBP, formatPricePrefix } from '../../lib/format.mjs';
 
 function parsePriceNumber(value) {
   return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
@@ -160,6 +157,9 @@ async function loadPrebuildPropertyIds(limit = 24) {
 
 export default function Property({ property, recommendations }) {
   const hasLocation = property?.latitude != null && property?.longitude != null;
+  const rentFrequencyLabel = property?.rentFrequency
+    ? formatOfferFrequencyLabel(property.rentFrequency)
+    : '';
   const mapProperties = useMemo(
     () => {
       if (!hasLocation || !property) return [];
@@ -278,8 +278,7 @@ export default function Property({ property, recommendations }) {
             <p className={styles.price}>
               {property.price}
               {pricePrefixLabel && ` ${pricePrefixLabel}`}
-              {property.rentFrequency &&
-                ` ${formatRentFrequency(property.rentFrequency)}`}
+              {rentFrequencyLabel && ` ${rentFrequencyLabel}`}
             </p>
           )}
           <div className={styles.actions}>

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -11,6 +11,7 @@ import { fetchPropertiesByTypeCachedFirst } from '../lib/apex27.mjs';
 import agentsData from '../data/agents.json';
 import homeStyles from '../styles/Home.module.css';
 import rentStyles from '../styles/ToRent.module.css';
+import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 import { formatPriceGBP, formatRentFrequency } from '../lib/format.mjs';
 
 function normalizeStatus(value) {
@@ -322,8 +323,10 @@ export default function ToRent({ properties, agents }) {
   };
 
   const heroAreaCount = insights.topAreas.length;
+  const defaultRentFrequencyLabel = formatOfferFrequencyLabel('pcm') || 'pcm';
+
   const heroAverageRent = insights.averagePrice
-    ? `${formatPriceGBP(insights.averagePrice)} pcm`
+    ? `${formatPriceGBP(insights.averagePrice)} ${defaultRentFrequencyLabel}`
     : '—';
   const heroPopularType = insights.propertyTypes[0]?.label
     ? insights.propertyTypes[0].label
@@ -337,8 +340,16 @@ export default function ToRent({ properties, agents }) {
       const existing = counts.get(freq) ?? 0;
       counts.set(freq, existing + 1);
     });
-    const [topFrequency] = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])[0] || [];
-    return topFrequency || 'pcm';
+    const [topFrequency] =
+      Array.from(counts.entries()).sort((a, b) => b[1] - a[1])[0] || [];
+    const label = formatOfferFrequencyLabel(topFrequency || '');
+    if (label) {
+      return label;
+    }
+    if (topFrequency) {
+      return topFrequency;
+    }
+    return defaultRentFrequencyLabel;
   })();
 
   return (


### PR DESCRIPTION
## Summary
- add formatOfferFrequencyLabel to reuse descriptive offer cadence labels and expand formatRentFrequency normalization
- update offer emails, admin summaries, and rental UI price displays to surface "Per quarter"/"Per annum" labels instead of raw tokens
- extend Jest coverage for the new helper and verify quarterly/annual labels appear in email, admin, and property card outputs

## Testing
- npm test -- --runTestsByPath __tests__/offer-frequency.test.js __tests__/format.test.js *(fails: missing jest-environment-jsdom and @babel/preset-env in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e884abd4832e9e1f8d739a9e7018