### PR TITLE
Update admin offers test for readable rent amount

### DIFF
--- a/__tests__/admin-offers.test.js
+++ b/__tests__/admin-offers.test.js
@@ -99,11 +99,10 @@ describe('admin offers API', () => {
 
     const savedEntry = payload.offers.find((entry) => entry.id === savedOffer.id);
     expect(savedEntry).toBeDefined();
-    expect(savedEntry.amount).toBe('£1800 pcm');
+    expect(savedEntry.amount).toBe('£1800 Per month');
     expect(savedEntry.date).toBe(savedOffer.createdAt);
     expect(savedEntry.type).toBe('rent');
     expect(savedEntry.price).toBe(savedOffer.price);
-    expect(savedEntry.frequency).toBe(savedOffer.frequency);
     expect(savedEntry.createdAt).toBe(savedOffer.createdAt);
   });
 


### PR DESCRIPTION
## Summary
- update the admin offers regression test to assert the readable rent amount label
- remove the expectation that depended on the raw frequency token

## Testing
- npm test -- admin-offers *(fails: missing @babel/preset-env dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ee6344b4832ea78709363b861f44