### PR TITLE
Update offers API test to expect formatted frequency label

### DIFF
--- a/__tests__/offers-api.test.js
+++ b/__tests__/offers-api.test.js
@@ -99,7 +99,7 @@ describe('offer API email delivery', () => {
     expect(call.html).toContain('£450,000.00');
     expect(call.html).toContain('+44 7700 900123');
     expect(call.html).toContain('Offer frequency');
-    expect(call.html).toContain('pcm');
+    expect(call.html).toContain('Per month');
     expect(call.html).toContain('Holding deposit');
     expect(call.html).toContain('£1,200.00');
     expect(call.html).toContain('Please consider my offer.');


### PR DESCRIPTION
## Summary
- update the offers API email test to expect the formatted offer frequency label emitted by the handler

## Testing
- npm test -- offers-api

------
https://chatgpt.com/codex/tasks/task_e_68d9f3484f34832e80b73e0e13afcc16