### PR TITLE
Normalize rent frequency conversions for affordability calculations

### DIFF
--- a/__tests__/rentToMonthly.test.js
+++ b/__tests__/rentToMonthly.test.js
@@ -1,0 +1,35 @@
+let rentToMonthly;
+
+beforeAll(async () => {
+  ({ rentToMonthly } = await import('../lib/rent.mjs'));
+});
+
+describe('rentToMonthly', () => {
+  it('converts weekly rent to monthly using normalized frequency labels', () => {
+    expect(rentToMonthly('£400', 'pw')).toBeCloseTo((400 * 52) / 12);
+  });
+
+  it('converts monthly rent when already monthly', () => {
+    expect(rentToMonthly('1200', 'pcm')).toBe(1200);
+  });
+
+  it('converts quarterly rent to monthly', () => {
+    expect(rentToMonthly('3000', 'pq')).toBe(1000);
+  });
+
+  it('supports descriptive quarterly frequencies via normalization', () => {
+    expect(rentToMonthly('3000', 'Quarterly')).toBe(1000);
+  });
+
+  it('converts yearly rent to monthly', () => {
+    expect(rentToMonthly('24000', 'pa')).toBe(2000);
+  });
+
+  it('falls back to original amount when frequency missing', () => {
+    expect(rentToMonthly('1500')).toBe(1500);
+  });
+
+  it('falls back to original amount when frequency is unknown', () => {
+    expect(rentToMonthly('1500', 'weird')).toBe(1500);
+  });
+});

--- a/lib/rent.mjs
+++ b/lib/rent.mjs
@@ -1,0 +1,37 @@
+import { formatRentFrequency } from './format.mjs';
+
+export function parsePriceNumber(value) {
+  return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
+}
+
+export function rentToMonthly(price, freq) {
+  const amount = parsePriceNumber(price);
+  const normalized = formatRentFrequency(freq);
+  const legacy = typeof freq === 'string' ? freq.trim().toUpperCase() : '';
+
+  switch (normalized) {
+    case 'pw':
+      return (amount * 52) / 12;
+    case 'pcm':
+      return amount;
+    case 'pq':
+      return amount / 3;
+    case 'pa':
+      return amount / 12;
+    default:
+      break;
+  }
+
+  switch (legacy) {
+    case 'W':
+      return (amount * 52) / 12;
+    case 'M':
+      return amount;
+    case 'Q':
+      return amount / 3;
+    case 'Y':
+      return amount / 12;
+    default:
+      return amount;
+  }
+}

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -29,26 +29,7 @@ import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatOfferFrequencyLabel } from '../../lib/offer-frequency.mjs';
 import { formatPriceGBP, formatPricePrefix } from '../../lib/format.mjs';
-
-function parsePriceNumber(value) {
-  return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
-}
-
-function rentToMonthly(price, freq) {
-  const amount = parsePriceNumber(price);
-  switch (freq) {
-    case 'W':
-      return (amount * 52) / 12;
-    case 'M':
-      return amount;
-    case 'Q':
-      return amount / 3;
-    case 'Y':
-      return amount / 12;
-    default:
-      return amount;
-  }
-}
+import { parsePriceNumber, rentToMonthly } from '../../lib/rent.mjs';
 
 function normalizeScrayeReference(value) {
   if (value == null) {


### PR DESCRIPTION
## Summary
- move rent parsing and conversion helpers into a shared module for reuse
- normalize rent frequency codes before calculating monthly rent and cover the modern aliases
- add unit tests confirming the conversions, including quarterly values feeding the affordability calculator

## Testing
- npm test -- rentToMonthly

------
https://chatgpt.com/codex/tasks/task_e_68d9f4dcca4c832e8cef9038526df443