### PR TITLE
Handle read-only offers data file gracefully

### DIFF
--- a/__tests__/readOffers.test.js
+++ b/__tests__/readOffers.test.js
@@ -1,0 +1,75 @@
+const loadTs = require('./helpers/load-ts');
+
+function createFsError(code) {
+  const error = new Error(code);
+  error.code = code;
+  return error;
+}
+
+function createFsMock(overrides = {}) {
+  const promises = {
+    access: jest.fn(),
+    mkdir: jest.fn(),
+    writeFile: jest.fn(),
+    readFile: jest.fn(),
+    ...overrides,
+  };
+
+  return { promises };
+}
+
+describe('readOffers', () => {
+  const callerDir = __dirname;
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('returns an empty array when the data file is missing', async () => {
+    const fsMock = createFsMock({
+      access: jest.fn().mockRejectedValue(createFsError('ENOENT')),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      writeFile: jest.fn().mockResolvedValue(undefined),
+      readFile: jest.fn().mockResolvedValue(''),
+    });
+
+    const offersModule = loadTs('../lib/offers.js', callerDir, {
+      overrides: { fs: fsMock },
+    });
+
+    await expect(offersModule.readOffers()).resolves.toEqual([]);
+    expect(fsMock.promises.mkdir).toHaveBeenCalled();
+    expect(fsMock.promises.writeFile).toHaveBeenCalled();
+    expect(fsMock.promises.readFile).toHaveBeenCalled();
+  });
+
+  test('returns an empty array when the data directory is read-only', async () => {
+    const fsMock = createFsMock({
+      access: jest.fn().mockRejectedValue(createFsError('ENOENT')),
+      mkdir: jest.fn().mockRejectedValue(createFsError('EROFS')),
+    });
+
+    const offersModule = loadTs('../lib/offers.js', callerDir, {
+      overrides: { fs: fsMock },
+    });
+
+    await expect(offersModule.readOffers()).resolves.toEqual([]);
+    expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
+    expect(fsMock.promises.readFile).not.toHaveBeenCalled();
+  });
+
+  test('returns an empty array when writing the offers file fails with EROFS', async () => {
+    const fsMock = createFsMock({
+      access: jest.fn().mockRejectedValue(createFsError('ENOENT')),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      writeFile: jest.fn().mockRejectedValue(createFsError('EROFS')),
+    });
+
+    const offersModule = loadTs('../lib/offers.js', callerDir, {
+      overrides: { fs: fsMock },
+    });
+
+    await expect(offersModule.readOffers()).resolves.toEqual([]);
+    expect(fsMock.promises.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/lib/offers.js
+++ b/lib/offers.js
@@ -1,21 +1,77 @@
 import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
-const DATA_PATH = path.join(process.cwd(), 'data', 'offers.json');
+const fallbackModuleUrl =
+  typeof __filename !== 'undefined' ? pathToFileURL(__filename).href : undefined;
+
+const moduleUrl =
+  typeof import.meta !== 'undefined' && import.meta?.url
+    ? import.meta.url
+    : fallbackModuleUrl;
+
+const DATA_URL = new URL('../data/offers.json', moduleUrl);
+const DATA_FILE_PATH = fileURLToPath(DATA_URL);
+const DATA_DIR_PATH = path.dirname(DATA_FILE_PATH);
+
+const IGNORABLE_FS_CODES = new Set([
+  'EACCES',
+  'EBUSY',
+  'ENOENT',
+  'ENOTDIR',
+  'EPERM',
+  'EROFS',
+]);
+
+function isIgnorableFsError(error) {
+  return Boolean(error?.code && IGNORABLE_FS_CODES.has(error.code));
+}
 
 async function ensureDataFile() {
   try {
-    await fs.access(DATA_PATH);
-  } catch {
-    await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
-    await fs.writeFile(DATA_PATH, '[]', 'utf8');
+    await fs.access(DATA_URL);
+    return true;
+  } catch (accessError) {
+    try {
+      await fs.mkdir(DATA_DIR_PATH, { recursive: true });
+    } catch (mkdirError) {
+      if (mkdirError?.code === 'EEXIST') {
+        // Directory already exists; continue with file creation attempt.
+      } else if (isIgnorableFsError(mkdirError)) {
+        return false;
+      } else {
+        throw mkdirError;
+      }
+    }
+
+    try {
+      await fs.writeFile(DATA_URL, '[]', 'utf8');
+      return true;
+    } catch (writeError) {
+      if (isIgnorableFsError(writeError)) {
+        return false;
+      }
+      throw writeError;
+    }
   }
 }
 
 export async function readOffers() {
-  await ensureDataFile();
-  const raw = await fs.readFile(DATA_PATH, 'utf8');
+  const hasDataFile = await ensureDataFile();
+  if (!hasDataFile) {
+    return [];
+  }
+
+  let raw;
+  try {
+    raw = await fs.readFile(DATA_URL, 'utf8');
+  } catch (readError) {
+    if (isIgnorableFsError(readError)) {
+      return [];
+    }
+    throw readError;
+  }
   try {
     const data = JSON.parse(raw || '[]');
     return Array.isArray(data) ? data : [];
@@ -25,7 +81,7 @@ export async function readOffers() {
 }
 
 async function writeOffers(offers) {
-  await fs.writeFile(DATA_PATH, JSON.stringify(offers, null, 2), 'utf8');
+  await fs.writeFile(DATA_URL, JSON.stringify(offers, null, 2), 'utf8');
 }
 
 function toNumber(value, fallback) {


### PR DESCRIPTION
## Summary
- resolve the offers data file relative to the module and ignore common read/write errors so read operations fall back to an empty list
- update the load-ts helper and existing offer frequency tests to work with modules that rely on `import.meta`
- add dedicated unit coverage for readOffers to prove missing or read-only data files do not throw

## Testing
- npm test -- offer-frequency readOffers

------
https://chatgpt.com/codex/tasks/task_e_68d9f4453184832e8ca89755645bfb00