### PR TITLE
Normalize rental price formatting across property views

### DIFF
--- a/__tests__/rent-format.test.js
+++ b/__tests__/rent-format.test.js
@@ -1,0 +1,16 @@
+let formatPropertyPriceLabel;
+
+beforeAll(async () => {
+  ({ formatPropertyPriceLabel } = await import('../lib/rent.mjs'));
+});
+
+describe('formatPropertyPriceLabel', () => {
+  it('formats rental prices with readable frequency labels', () => {
+    const label = formatPropertyPriceLabel({
+      price: '£1,750 pcm',
+      rentFrequency: 'pcm',
+    });
+
+    expect(label).toBe('£1,750 Per month');
+  });
+});

--- a/components/PropertyActionDrawer.js
+++ b/components/PropertyActionDrawer.js
@@ -1,17 +1,8 @@
 import { useId } from 'react';
 import { FaBath, FaBed, FaCouch } from 'react-icons/fa';
-import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 import styles from '../styles/PropertyActionDrawer.module.css';
-
-function formatPrice(property = {}) {
-  if (!property?.price) return '';
-  if (property?.rentFrequency) {
-    const frequencyLabel = formatOfferFrequencyLabel(property.rentFrequency);
-    return frequencyLabel ? `${property.price} ${frequencyLabel}` : `${property.price}`;
-  }
-  return property.price;
-}
+import { formatPropertyPriceLabel } from '../lib/rent.mjs';
 
 export default function PropertyActionDrawer({
   open,
@@ -29,7 +20,7 @@ export default function PropertyActionDrawer({
       ? 'To rent'
       : 'For sale'
     : '';
-  const priceLabel = formatPrice(summary);
+  const priceLabel = formatPropertyPriceLabel(summary);
   const typeLabel =
     summary.typeLabel ??
     summary.propertyTypeLabel ??

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { formatPricePrefix } from '../lib/format.mjs';
-import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
+import { formatPropertyPriceLabel } from '../lib/rent.mjs';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
 import { formatPropertyTypeLabel } from '../lib/property-type.mjs';
 
@@ -108,9 +108,7 @@ export default function PropertyCard({ property }) {
       ? formatPricePrefix(property.pricePrefix)
       : '';
 
-  const rentFrequencyLabel = property.rentFrequency
-    ? formatOfferFrequencyLabel(property.rentFrequency)
-    : '';
+  const priceLabel = formatPropertyPriceLabel(property);
 
   const isSaleListing = property?.transactionType
     ? String(property.transactionType).toLowerCase() === 'sale'
@@ -218,11 +216,10 @@ export default function PropertyCard({ property }) {
             Scraye ref: <span>{scrayeReference}</span>
           </p>
         )}
-        {property.price && (
+        {priceLabel && (
           <p className="price">
-            {property.price}
+            {priceLabel}
             {pricePrefixLabel && ` ${pricePrefixLabel}`}
-            {rentFrequencyLabel && ` ${rentFrequencyLabel}`}
           </p>
         )}
         {(property.receptions != null || property.bedrooms != null || property.bathrooms != null) && (

--- a/components/PropertyMap.js
+++ b/components/PropertyMap.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
+import { formatPropertyPriceLabel } from '../lib/rent.mjs';
 
 export default function PropertyMap({
   properties = [],
@@ -68,17 +68,14 @@ export default function PropertyMap({
           }).addTo(map);
 
           const priceText = (() => {
-            if (!p.price) {
+            const basePrice = formatPropertyPriceLabel(p);
+            if (!basePrice) {
               return '';
             }
-            if (p.rentFrequency) {
-              const frequencyLabel = formatOfferFrequencyLabel(p.rentFrequency);
-              return frequencyLabel ? `${p.price} ${frequencyLabel}` : p.price;
+            if (!p.rentFrequency && p.tenure) {
+              return `${basePrice} ${p.tenure}`;
             }
-            if (p.tenure) {
-              return `${p.price} ${p.tenure}`;
-            }
-            return p.price;
+            return basePrice;
           })();
 
           const imgHtml = p.image

--- a/lib/rent.mjs
+++ b/lib/rent.mjs
@@ -1,4 +1,5 @@
-import { formatRentFrequency } from './format.mjs';
+import { formatPriceGBP, formatRentFrequency } from './format.mjs';
+import { formatOfferFrequencyLabel } from './offer-frequency.mjs';
 
 export function parsePriceNumber(value) {
   return Number(String(value).replace(/[^0-9.]/g, '')) || 0;
@@ -34,4 +35,37 @@ export function rentToMonthly(price, freq) {
     default:
       return amount;
   }
+}
+
+export function formatPropertyPriceLabel(property = {}) {
+  if (!property || property.price == null) {
+    return '';
+  }
+
+  const rentFrequency = property.rentFrequency;
+  const hasRentFrequency =
+    rentFrequency != null && String(rentFrequency).trim() !== '';
+
+  if (!hasRentFrequency) {
+    return String(property.price);
+  }
+
+  const rawPrice = property.price;
+  const rawPriceString = String(rawPrice).trim();
+  const hasDigits = /\d/.test(rawPriceString);
+  const numericPrice = parsePriceNumber(rawPrice);
+  const formattedPrice = hasDigits
+    ? formatPriceGBP(numericPrice, { isSale: true })
+    : rawPriceString;
+
+  const frequencyLabel = formatOfferFrequencyLabel(rentFrequency);
+
+  if (frequencyLabel) {
+    if (formattedPrice) {
+      return `${formattedPrice} ${frequencyLabel}`;
+    }
+    return frequencyLabel;
+  }
+
+  return formattedPrice;
 }

--- a/pages/property/[id].js
+++ b/pages/property/[id].js
@@ -27,9 +27,12 @@ import {
 } from '../../lib/property-type.mjs';
 import styles from '../../styles/PropertyDetails.module.css';
 import { FaBed, FaBath, FaCouch } from 'react-icons/fa';
-import { formatOfferFrequencyLabel } from '../../lib/offer-frequency.mjs';
 import { formatPriceGBP, formatPricePrefix } from '../../lib/format.mjs';
-import { parsePriceNumber, rentToMonthly } from '../../lib/rent.mjs';
+import {
+  parsePriceNumber,
+  rentToMonthly,
+  formatPropertyPriceLabel,
+} from '../../lib/rent.mjs';
 
 function normalizeScrayeReference(value) {
   if (value == null) {
@@ -138,9 +141,7 @@ async function loadPrebuildPropertyIds(limit = 24) {
 
 export default function Property({ property, recommendations }) {
   const hasLocation = property?.latitude != null && property?.longitude != null;
-  const rentFrequencyLabel = property?.rentFrequency
-    ? formatOfferFrequencyLabel(property.rentFrequency)
-    : '';
+  const priceLabel = formatPropertyPriceLabel(property);
   const mapProperties = useMemo(
     () => {
       if (!hasLocation || !property) return [];
@@ -255,11 +256,10 @@ export default function Property({ property, recommendations }) {
               </span>
             )}
           </div>
-          {property.price && (
+          {priceLabel && (
             <p className={styles.price}>
-              {property.price}
+              {priceLabel}
               {pricePrefixLabel && ` ${pricePrefixLabel}`}
-              {rentFrequencyLabel && ` ${rentFrequencyLabel}`}
             </p>
           )}
           <div className={styles.actions}>


### PR DESCRIPTION
## Summary
- add a shared `formatPropertyPriceLabel` helper to re-render rental prices with readable frequency labels
- update property cards, drawers, maps, and the property details page to use the shared price formatter while retaining sale behaviour
- add a Jest test covering the `£1,750 pcm` rental formatting case

## Testing
- npm test -- rent-format

------
https://chatgpt.com/codex/tasks/task_e_68d9f778c95c832eab1e27031da43815