### PR TITLE
Add 3CX contact lookup webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@ npm run dev
 
 Create a `.env.local` file and set `APEX27_API_KEY` (and optionally `APEX27_BRANCH_ID` for your branch) to fetch real property data from the Apex27 API. Without these variables, no listings will be shown.
 
+### 3CX contact lookup webhook
+
+Configure `THREECX_WEBHOOK_SECRET` to protect the private contact lookup endpoint used by the 3CX phone system. Requests without
+the matching secret are rejected with **401 Unauthorized**.
+
+**Endpoint:** `https://<your-domain>/api/integrations/3cx/contact`
+
+**Authentication header:** `X-3CX-Secret: <value of THREECX_WEBHOOK_SECRET>` (alternatively `Authorization: Bearer <secret>`)
+
+The route accepts `phone` and optional `countryCode` query parameters, normalises them to digits, and searches the Apex27 portal
+for a matching contact. Responses are returned with `Cache-Control: no-store` to avoid stale screen pops, `200 OK` when the
+contact exists, and `404 Not Found` otherwise.
+
+**Example 3CX configuration:**
+
+1. In the 3CX Management Console, open **Settings → CRM** and choose **Add** to create a new HTTP contact lookup.
+2. Set the **Match** URL to `https://<your-domain>/api/integrations/3cx/contact?phone=%CallerNumber%&countryCode=%CallerIDCountry%` and select the **GET** method.
+3. Under **Request Headers**, add `X-3CX-Secret` with the same secret configured in `THREECX_WEBHOOK_SECRET`.
+4. Choose **JSON** as the response format and map the required contact fields (e.g. name, email, reference) from the `contact`
+   object returned by the API.
+5. Save and assign the CRM integration to the desired extensions so incoming calls trigger the lookup and display the contact
+   context automatically.
+
 ### Email configuration
 
 The contact, offer, and viewing forms send transactional email through SMTP. Configure these environment variables wherever the Next.js server runs:

--- a/lib/apex27-portal.js
+++ b/lib/apex27-portal.js
@@ -454,6 +454,141 @@ async function fetchContactByEmail(email) {
   return null;
 }
 
+function normalisePhoneDigits(value) {
+  if (!value) {
+    return null;
+  }
+
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return null;
+  }
+
+  const prefix = stringValue.startsWith('+') ? '+' : '';
+  const digits = stringValue.replace(/\D+/g, '');
+
+  if (!digits) {
+    return null;
+  }
+
+  if (prefix && digits) {
+    return `+${digits}`;
+  }
+
+  return digits;
+}
+
+function normaliseCountryCode(value) {
+  if (!value) {
+    return null;
+  }
+
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return null;
+  }
+
+  if (/^[A-Za-z]{2}$/.test(stringValue)) {
+    return stringValue.toUpperCase();
+  }
+
+  const digits = stringValue.replace(/\D+/g, '');
+  return digits || null;
+}
+
+function buildPhoneLookupCandidates(phone, countryCode) {
+  const candidates = new Set();
+
+  if (!phone) {
+    return candidates;
+  }
+
+  const digitsOnly = phone.replace(/\D+/g, '');
+
+  if (!digitsOnly) {
+    return candidates;
+  }
+
+  const startsWithPlus = phone.startsWith('+');
+  const trimmedLeadingZero = digitsOnly.replace(/^0+/, '') || digitsOnly;
+
+  candidates.add(digitsOnly);
+  candidates.add(trimmedLeadingZero);
+
+  if (startsWithPlus) {
+    candidates.add(`+${digitsOnly}`);
+    candidates.add(`+${trimmedLeadingZero}`);
+  }
+
+  const numericCountry = countryCode && /^\d+$/.test(countryCode) ? countryCode : null;
+
+  if (numericCountry) {
+    const joined = `${numericCountry}${trimmedLeadingZero}`;
+    candidates.add(joined);
+    candidates.add(`+${joined}`);
+  }
+
+  return candidates;
+}
+
+export async function lookupContactByPhone({ phone, countryCode } = {}) {
+  const normalisedPhone = normalisePhoneDigits(phone);
+  const normalisedCountry = normaliseCountryCode(countryCode);
+
+  if (!normalisedPhone) {
+    return null;
+  }
+
+  const candidateNumbers = Array.from(
+    buildPhoneLookupCandidates(normalisedPhone, normalisedCountry)
+  ).filter(Boolean);
+
+  if (!candidateNumbers.length) {
+    return null;
+  }
+
+  const queryKeys = [
+    'phone',
+    'Phone',
+    'telephone',
+    'Telephone',
+    'mobilePhone',
+    'MobilePhone',
+    'homePhone',
+    'HomePhone',
+    'workPhone',
+    'WorkPhone',
+    'phoneNumber',
+    'PhoneNumber',
+    'search',
+    'searchTerm',
+    'SearchTerm',
+  ];
+
+  const endpoints = [];
+
+  for (const number of candidateNumbers) {
+    for (const key of queryKeys) {
+      endpoints.push(`/contacts?${key}=${encodeURIComponent(number)}`);
+    }
+  }
+
+  if (!endpoints.length) {
+    return null;
+  }
+
+  const result = await fetchFromCandidates(endpoints, {
+    method: 'GET',
+    base: API_BASE,
+  });
+
+  if (result?.data) {
+    return normaliseContact(result.data);
+  }
+
+  return null;
+}
+
 export async function resolvePortalContact({ contact, contactId, token, email } = {}) {
   let resolvedContact = contact ? normaliseContact(contact) : null;
   let resolvedContactId = extractContactId(resolvedContact) ?? contactId ?? null;

--- a/pages/api/integrations/3cx/contact.js
+++ b/pages/api/integrations/3cx/contact.js
@@ -1,0 +1,115 @@
+import { applyApiHeaders, handlePreflight } from '../../../../lib/api-helpers.js';
+import { lookupContactByPhone } from '../../../../lib/apex27-portal.js';
+
+const SECRET_HEADER = 'x-3cx-secret';
+
+function readHeaderValue(req, name) {
+  const value = req.headers[name];
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+  return value ?? null;
+}
+
+function readAuthToken(req) {
+  const headerToken = readHeaderValue(req, SECRET_HEADER);
+  if (headerToken) {
+    return String(headerToken).trim();
+  }
+
+  const authorization = readHeaderValue(req, 'authorization');
+  if (!authorization) {
+    return null;
+  }
+
+  const trimmed = String(authorization).trim();
+  if (trimmed.toLowerCase().startsWith('bearer ')) {
+    return trimmed.slice(7).trim();
+  }
+
+  return trimmed || null;
+}
+
+function normalisePhoneDigits(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return null;
+  }
+
+  const digits = stringValue.replace(/\D+/g, '');
+  if (!digits) {
+    return null;
+  }
+
+  if (stringValue.startsWith('+')) {
+    return `+${digits}`;
+  }
+
+  return digits;
+}
+
+function firstQueryValue(value) {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+  return value ?? null;
+}
+
+export default async function handler(req, res) {
+  applyApiHeaders(req, res, { methods: ['GET'] });
+
+  if (handlePreflight(req, res)) {
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const configuredSecret = process.env.THREECX_WEBHOOK_SECRET;
+  if (!configuredSecret) {
+    res.status(500).json({ error: '3CX integration is not configured' });
+    return;
+  }
+
+  const providedSecret = readAuthToken(req);
+  if (!providedSecret || providedSecret !== configuredSecret) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const rawPhone = firstQueryValue(req.query.phone);
+  const rawCountryCode = firstQueryValue(req.query.countryCode);
+
+  const normalisedPhone = normalisePhoneDigits(rawPhone);
+  if (!normalisedPhone) {
+    res.status(400).json({ error: 'Missing or invalid phone query parameter' });
+    return;
+  }
+
+  const normalisedCountryCode = rawCountryCode == null ? null : String(rawCountryCode).trim() || null;
+
+  let contact = null;
+  try {
+    contact = await lookupContactByPhone({ phone: normalisedPhone, countryCode: normalisedCountryCode });
+  } catch (err) {
+    console.error('Failed to query Apex27 contact by phone', err);
+    res.status(502).json({ error: 'Failed to lookup contact' });
+    return;
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+
+  if (!contact) {
+    res.status(404).json({ error: 'Contact not found' });
+    return;
+  }
+
+  res.status(200).json({ contact });
+}


### PR DESCRIPTION
## Summary
- add a 3CX contact lookup API route secured by the THREECX_WEBHOOK_SECRET header
- extend the Apex27 portal helper with a phone lookup utility used by the webhook
- document the integration endpoint and example 3CX configuration in the README

## Testing
- npm test *(fails: Must use import to load ES Module: /workspace/aktonz2/lib/rent.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fa4fcf48832eaf7075ef9ab61d8c