### PR TITLE
Add Apex27 phone utilities and contact context loader

### DIFF
--- a/lib/apex27-portal.js
+++ b/lib/apex27-portal.js
@@ -53,6 +53,28 @@ const EMAIL_KEYS = [
   'contact_email',
 ];
 
+const PHONE_KEYS = [
+  'phone',
+  'phoneNumber',
+  'phone_number',
+  'telephone',
+  'Telephone',
+  'tel',
+  'Tel',
+  'mobile',
+  'mobilePhone',
+  'mobile_phone',
+  'mobileNumber',
+  'mobile_number',
+  'mobilephone',
+  'landline',
+  'Landline',
+  'homePhone',
+  'home_phone',
+  'workPhone',
+  'work_phone',
+];
+
 const TOKEN_KEYS = [
   'token',
   'Token',
@@ -279,6 +301,59 @@ function extractToken(source) {
 }
 
 
+export function normalizePhone(input) {
+  if (input == null) {
+    return null;
+  }
+
+  const trimmed = String(input).trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutExtension = trimmed.replace(/(?:ext\.?|extension|x)\s*\d+$/i, '');
+  let cleaned = withoutExtension.replace(/[^0-9+]/g, '');
+
+  if (!cleaned) {
+    return null;
+  }
+
+  if (cleaned.startsWith('+')) {
+    cleaned = cleaned.replace(/(?!^)\+/g, '');
+    cleaned = cleaned.slice(1);
+    if (cleaned.startsWith('44')) {
+      cleaned = cleaned.slice(2);
+      if (!cleaned.startsWith('0')) {
+        cleaned = `0${cleaned}`;
+      }
+    }
+  } else if (cleaned.startsWith('0044')) {
+    cleaned = cleaned.slice(4);
+    if (!cleaned.startsWith('0')) {
+      cleaned = `0${cleaned}`;
+    }
+  }
+
+  if (cleaned.startsWith('44') && cleaned.length > 10) {
+    cleaned = cleaned.slice(2);
+    if (!cleaned.startsWith('0')) {
+      cleaned = `0${cleaned}`;
+    }
+  }
+
+  cleaned = cleaned.replace(/\D/g, '');
+
+  if (!cleaned) {
+    return null;
+  }
+
+  if (cleaned.startsWith('0')) {
+    cleaned = cleaned.replace(/^0+/, '0');
+  }
+
+  return cleaned;
+}
+
 function buildHeaders({ includeApiKey = true, token } = {}) {
   const headers = {
     accept: 'application/json',
@@ -400,6 +475,52 @@ function normaliseContact(payload) {
   return null;
 }
 
+function extractPhone(source) {
+  if (!source) {
+    return null;
+  }
+
+  const stack = [source];
+  const seen = new WeakSet();
+
+  while (stack.length) {
+    const current = stack.pop();
+
+    if (!current || typeof current !== 'object') {
+      continue;
+    }
+
+    if (seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      for (const entry of current) {
+        stack.push(entry);
+      }
+      continue;
+    }
+
+    for (const key of PHONE_KEYS) {
+      if (current[key] != null && current[key] !== '') {
+        const normalised = normalizePhone(current[key]);
+        if (normalised) {
+          return normalised;
+        }
+      }
+    }
+
+    for (const value of Object.values(current)) {
+      if (value && typeof value === 'object') {
+        stack.push(value);
+      }
+    }
+  }
+
+  return null;
+}
+
 function parsePortalAuthPayload(payload, defaults = {}) {
   const contact = normaliseContact(payload);
   const contactId = extractContactId(contact || payload) ?? null;
@@ -454,16 +575,71 @@ async function fetchContactByEmail(email) {
   return null;
 }
 
-export async function resolvePortalContact({ contact, contactId, token, email } = {}) {
+async function fetchContactByPhone(phone) {
+  const canonical = normalizePhone(phone);
+  if (!canonical) {
+    return null;
+  }
+
+  const variants = new Set([canonical]);
+
+  if (canonical.startsWith('0') && canonical.length > 1) {
+    const withoutZero = canonical.slice(1);
+    if (withoutZero) {
+      variants.add(withoutZero);
+      variants.add(`44${withoutZero}`);
+      variants.add(`+44${withoutZero}`);
+      variants.add(`0044${withoutZero}`);
+    }
+  } else if (canonical.startsWith('44') && canonical.length > 2) {
+    const withoutCode = canonical.slice(2);
+    if (withoutCode) {
+      variants.add(`0${withoutCode}`);
+      variants.add(withoutCode);
+    }
+  }
+
+  const fields = ['phone', 'mobile', 'mobilePhone', 'landline'];
+  const endpointSet = new Set();
+
+  for (const field of fields) {
+    for (const value of variants) {
+      endpointSet.add(`/contacts?${encodeURIComponent(field)}=${encodeURIComponent(value)}`);
+    }
+  }
+
+  const endpoints = Array.from(endpointSet);
+
+  const result = await fetchFromCandidates(endpoints, {
+    method: 'GET',
+    base: API_BASE,
+  });
+
+  if (result?.data) {
+    return normaliseContact(result.data);
+  }
+
+  return null;
+}
+
+export async function resolvePortalContact({ contact, contactId, token, email, phone } = {}) {
   let resolvedContact = contact ? normaliseContact(contact) : null;
   let resolvedContactId = extractContactId(resolvedContact) ?? contactId ?? null;
   let resolvedEmail = extractEmail(resolvedContact) ?? email ?? null;
+  let resolvedPhone = extractPhone(resolvedContact) ?? normalizePhone(phone) ?? null;
 
-  if (resolvedContact && (valueLooksLikeContact(resolvedContact) || resolvedEmail || resolvedContactId != null)) {
+  if (
+    resolvedContact &&
+    (valueLooksLikeContact(resolvedContact) ||
+      resolvedEmail ||
+      resolvedContactId != null ||
+      resolvedPhone)
+  ) {
     return {
       contact: resolvedContact,
       contactId: resolvedContactId ?? extractContactId(resolvedContact) ?? null,
       email: resolvedEmail ?? extractEmail(resolvedContact) ?? null,
+      phone: resolvedPhone ?? extractPhone(resolvedContact) ?? null,
     };
   }
 
@@ -474,9 +650,21 @@ export async function resolvePortalContact({ contact, contactId, token, email } 
         resolvedContact = profile;
         resolvedContactId = extractContactId(profile) ?? resolvedContactId ?? contactId ?? null;
         resolvedEmail = extractEmail(profile) ?? resolvedEmail ?? email ?? null;
+        resolvedPhone = extractPhone(profile) ?? resolvedPhone ?? normalizePhone(phone) ?? null;
 
-        if (resolvedContact && (valueLooksLikeContact(resolvedContact) || resolvedEmail || resolvedContactId != null)) {
-          return { contact: resolvedContact, contactId: resolvedContactId, email: resolvedEmail };
+        if (
+          resolvedContact &&
+          (valueLooksLikeContact(resolvedContact) ||
+            resolvedEmail ||
+            resolvedContactId != null ||
+            resolvedPhone)
+        ) {
+          return {
+            contact: resolvedContact,
+            contactId: resolvedContactId,
+            email: resolvedEmail,
+            phone: resolvedPhone ?? extractPhone(resolvedContact) ?? null,
+          };
         }
       }
     } catch (err) {
@@ -490,10 +678,25 @@ export async function resolvePortalContact({ contact, contactId, token, email } 
       if (lookup) {
         const id = extractContactId(lookup) ?? resolvedContactId ?? contactId ?? null;
         const contactEmail = extractEmail(lookup) ?? resolvedEmail ?? email ?? null;
-        return { contact: lookup, contactId: id, email: contactEmail };
+        const contactPhone = extractPhone(lookup) ?? resolvedPhone ?? normalizePhone(phone) ?? null;
+        return { contact: lookup, contactId: id, email: contactEmail, phone: contactPhone };
       }
     } catch (err) {
       console.warn('Failed to lookup Apex27 contact by email', err);
+    }
+  }
+
+  if (!resolvedContactId && !(resolvedEmail || email) && (resolvedPhone || phone)) {
+    try {
+      const lookup = await fetchContactByPhone(resolvedPhone || phone || null);
+      if (lookup) {
+        const id = extractContactId(lookup) ?? resolvedContactId ?? contactId ?? null;
+        const contactEmail = extractEmail(lookup) ?? resolvedEmail ?? email ?? null;
+        const contactPhone = extractPhone(lookup) ?? resolvedPhone ?? normalizePhone(phone) ?? null;
+        return { contact: lookup, contactId: id, email: contactEmail, phone: contactPhone };
+      }
+    } catch (err) {
+      console.warn('Failed to lookup Apex27 contact by phone', err);
     }
   }
 
@@ -505,8 +708,86 @@ export async function resolvePortalContact({ contact, contactId, token, email } 
     contact: resolvedContact || null,
     contactId: resolvedContactId ?? null,
     email: resolvedEmail ?? email ?? null,
+    phone: resolvedPhone ?? normalizePhone(phone) ?? null,
   };
 
+}
+
+function normaliseCollection(data) {
+  if (!data) {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (typeof data === 'object') {
+    if (Array.isArray(data.results)) {
+      return data.results;
+    }
+    if (Array.isArray(data.items)) {
+      return data.items;
+    }
+    if (Array.isArray(data.data)) {
+      return data.data;
+    }
+  }
+
+  return [];
+}
+
+export async function loadContactContext({ contactId } = {}) {
+  if (!contactId) {
+    throw new Error('Contact ID is required');
+  }
+
+  const encodedId = encodeURIComponent(contactId);
+
+  const [propertiesResult, viewingsResult, appointmentsResult, financialResult] = await Promise.all([
+    fetchFromCandidates(
+      [`/contacts/${encodedId}/properties`, `/contacts/${encodedId}/Properties`],
+      { method: 'GET', base: API_BASE }
+    ),
+    fetchFromCandidates(
+      [`/contacts/${encodedId}/viewings`, `/contacts/${encodedId}/Viewings`],
+      { method: 'GET', base: API_BASE }
+    ),
+    fetchFromCandidates(
+      [`/contacts/${encodedId}/appointments`, `/contacts/${encodedId}/Appointments`],
+      { method: 'GET', base: API_BASE }
+    ),
+    fetchFromCandidates(
+      [`/contacts/${encodedId}/financial`, `/contacts/${encodedId}/financials`, `/contacts/${encodedId}/Financials`],
+      { method: 'GET', base: API_BASE }
+    ),
+  ]);
+
+  const properties = normaliseCollection(propertiesResult?.data);
+  const viewings = normaliseCollection(viewingsResult?.data);
+  const appointments = normaliseCollection(appointmentsResult?.data);
+  const financial = normaliseCollection(financialResult?.data);
+
+  if (propertiesResult?.error) {
+    console.warn('Failed to load Apex27 contact properties', propertiesResult.error);
+  }
+  if (viewingsResult?.error) {
+    console.warn('Failed to load Apex27 contact viewings', viewingsResult.error);
+  }
+  if (appointmentsResult?.error) {
+    console.warn('Failed to load Apex27 contact appointments', appointmentsResult.error);
+  }
+  if (financialResult?.error) {
+    console.warn('Failed to load Apex27 contact financial records', financialResult.error);
+  }
+
+  return {
+    contactId,
+    properties,
+    viewings,
+    appointments,
+    financial,
+  };
 }
 
 function cleanProfileInput(input = {}) {


### PR DESCRIPTION
## Summary
- add phone normalisation helpers for Apex27 contact resolution and lookups
- query contacts by phone when no email/contact id are available and include resolved numbers in responses
- introduce a contact context loader that aggregates properties, viewings, appointments, and financial records

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9fa5658fc832ea7f3c6ec90ebb5c2