### PR TITLE
Add 3CX contact card pop-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ npm install
 npm run dev
 ```
 
+### 3CX contact pop-up
+
+Use the compact contact card when configuring 3CX screen-pops so agents can
+see caller context without loading the full CRM. The route accepts either a
+one-time lookup token or the raw caller ID:
+
+```
+/integrations/3cx/contact-card?token=<lookup-token>
+/integrations/3cx/contact-card?phone=<e164-number>
+```
+
+When hosted at `https://aktonz.com`, reference the page directly in the 3CX
+management console (Settings → CRM → Screen Pop URL). For example, to pop on
+incoming calls using the caller ID placeholder:
+
+```
+https://aktonz.com/integrations/3cx/contact-card?phone=[Call.CallerID]
+```
+
+If your workflow issues time-limited lookup tokens, swap the `phone` query for
+`token` and inject the secure token variable provided by your middleware.
+
 ## Environment Variables
 
 Create a `.env.local` file and set `APEX27_API_KEY` (and optionally `APEX27_BRANCH_ID` for your branch) to fetch real property data from the Apex27 API. Without these variables, no listings will be shown.

--- a/components/contacts/ContactCard.js
+++ b/components/contacts/ContactCard.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import styles from '../../styles/ContactCard.module.css';
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function renderFinancialEntries(financialSummary) {
+  if (!financialSummary) {
+    return null;
+  }
+
+  const entries = Object.entries(financialSummary).filter(([, value]) => value != null && value !== '');
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>Financial summary</h2>
+      <dl className={styles.financialList}>
+        {entries.map(([label, value]) => (
+          <div key={label} className={styles.financialItem}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function ContactCard({ context }) {
+  if (!context) {
+    return null;
+  }
+
+  const {
+    contact = {},
+    properties = [],
+    appointments = [],
+    financialSummary,
+    notes,
+  } = context;
+
+  const { name, stage, email, phone, avatarUrl, company, preferredAgent, tags, searchFocus } = contact;
+
+  const initials = name
+    ? name
+        .split(' ')
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase() ?? '')
+        .join('')
+    : '?';
+
+  return (
+    <div className={styles.card}>
+      <header className={styles.header}>
+        {avatarUrl ? (
+          <img className={styles.avatar} src={avatarUrl} alt={name ? `${name}'s avatar` : 'Contact avatar'} />
+        ) : (
+          <div className={styles.initials} aria-hidden="true">
+            {initials}
+          </div>
+        )}
+        <div className={styles.headerContent}>
+          <h1 className={styles.name}>{name || 'Unknown contact'}</h1>
+          <div className={styles.metaRow}>
+            {stage ? <span className={styles.pill}>{stage}</span> : null}
+            {company ? <span className={styles.metaText}>{company}</span> : null}
+            {preferredAgent?.name ? <span className={styles.metaText}>Agent: {preferredAgent.name}</span> : null}
+          </div>
+          {searchFocus ? <p className={styles.searchFocus}>{searchFocus}</p> : null}
+        </div>
+      </header>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Contact</h2>
+        <div className={styles.contactGrid}>
+          {email ? (
+            <a className={styles.contactLink} href={`mailto:${email}`}>
+              {email}
+            </a>
+          ) : null}
+          {phone ? (
+            <a className={styles.contactLink} href={`tel:${phone}`}>
+              {phone}
+            </a>
+          ) : null}
+        </div>
+        {Array.isArray(tags) && tags.length > 0 ? (
+          <ul className={styles.tagList}>
+            {tags.map((tag) => (
+              <li key={tag}>{tag}</li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      {properties.length > 0 ? (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Associated properties</h2>
+          <ul className={styles.propertyList}>
+            {properties.map((property) => {
+              const key = property.id || property.reference || property.address || property.title;
+              return (
+                <li key={key} className={styles.propertyItem}>
+                  <div className={styles.propertyPrimary}>{property.title || property.address || key}</div>
+                  <div className={styles.propertySecondary}>
+                    {property.status ? <span>{property.status}</span> : null}
+                    {property.price ? <span>{property.price}</span> : null}
+                    {property.type ? <span>{property.type}</span> : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {appointments.length > 0 ? (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Upcoming viewings &amp; appointments</h2>
+          <ul className={styles.appointmentList}>
+            {appointments.map((appointment) => {
+              const appointmentDate = appointment.date || appointment.start || appointment.when;
+              const parsedDate = appointmentDate ? new Date(appointmentDate) : null;
+              const dateLabel = formatDate(parsedDate || appointmentDate);
+              const isoDate = parsedDate && !Number.isNaN(parsedDate.getTime()) ? parsedDate.toISOString() : undefined;
+              const key =
+                appointment.id ||
+                `${appointmentDate || 'unknown'}-${appointment.property?.id || appointment.summary || 'appt'}`;
+              return (
+                <li key={key} className={styles.appointmentItem}>
+                  <div className={styles.appointmentHeader}>
+                    <span className={styles.appointmentType}>{appointment.type || 'Appointment'}</span>
+                    {dateLabel && isoDate ? <time dateTime={isoDate}>{dateLabel}</time> : null}
+                  </div>
+                  <div className={styles.appointmentDetails}>
+                    {appointment.property?.title || appointment.property?.address ? (
+                      <span>{appointment.property.title || appointment.property.address}</span>
+                    ) : null}
+                    {appointment.agent?.name ? <span>With {appointment.agent.name}</span> : null}
+                    {appointment.summary ? <p>{appointment.summary}</p> : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {renderFinancialEntries(financialSummary)}
+
+      {notes ? (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Notes</h2>
+          <p className={styles.notes}>{notes}</p>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+ContactCard.defaultProps = {
+  context: null,
+};
+
+export default ContactCard;

--- a/pages/integrations/3cx/contact-card.tsx
+++ b/pages/integrations/3cx/contact-card.tsx
@@ -1,0 +1,245 @@
+import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
+import ContactCard from '../../../components/contacts/ContactCard';
+import styles from '../../../styles/ContactCard.module.css';
+
+type ContactDetails = {
+  name?: string;
+  stage?: string;
+  email?: string;
+  phone?: string;
+  avatarUrl?: string;
+  company?: string;
+  preferredAgent?: { name?: string } | null;
+  tags?: string[];
+  searchFocus?: string;
+  [key: string]: unknown;
+};
+
+type PropertySummary = {
+  id?: string;
+  reference?: string;
+  title?: string;
+  address?: string;
+  status?: string;
+  price?: string;
+  type?: string;
+  [key: string]: unknown;
+};
+
+type AppointmentSummary = {
+  id?: string;
+  type?: string;
+  date?: string;
+  summary?: string;
+  agent?: { name?: string } | null;
+  property?: { id?: string; title?: string; address?: string } | null;
+  [key: string]: unknown;
+};
+
+type FinancialSummary = Record<string, string | number> | null;
+
+type ContactContext = {
+  contact?: ContactDetails | null;
+  properties?: PropertySummary[];
+  appointments?: AppointmentSummary[];
+  financialSummary?: FinancialSummary;
+  notes?: string;
+  [key: string]: unknown;
+};
+
+type ContactCardPageProps = {
+  status: 'loading' | 'success' | 'not-found' | 'error';
+  context?: ContactContext | null;
+  error?: string | null;
+  lookup?: {
+    token?: string | null;
+    phone?: string | null;
+  };
+};
+
+function buildBaseUrl(req: Parameters<GetServerSideProps>[0]['req']): string {
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined)?.split(',')[0]?.trim();
+  const forwardedHost = (req.headers['x-forwarded-host'] as string | undefined)?.split(',')[0]?.trim();
+  const host = forwardedHost || req.headers.host || 'localhost:3000';
+  const proto = forwardedProto || (host.startsWith('localhost') || host.startsWith('127.') ? 'http' : 'https');
+  return `${proto}://${host}`;
+}
+
+function normaliseQueryValue(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.find((entry) => entry && entry.trim().length > 0);
+  }
+
+  return value.trim() || undefined;
+}
+
+const ContactCardPage = ({ status, context, error, lookup }: ContactCardPageProps) => {
+  const title =
+    status === 'success'
+      ? `${context?.contact?.name ?? 'Contact'} · Aktonz`
+      : status === 'not-found'
+        ? 'Contact not found · Aktonz'
+        : 'Contact lookup · Aktonz';
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <main className={styles.wrapper}>
+        <div className={styles.wrapperInner}>
+          {status === 'success' && context ? (
+            <ContactCard context={context} />
+          ) : (
+            <div
+              className={[
+                styles.statePanel,
+                status === 'error'
+                  ? styles.error
+                  : status === 'not-found'
+                    ? styles.notFound
+                    : status === 'loading'
+                      ? styles.loading
+                      : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              {status === 'loading' ? (
+                <>
+                  <h1>Looking up contact</h1>
+                  <p>Attempting to resolve the caller details...</p>
+                </>
+              ) : null}
+              {status === 'not-found' ? (
+                <>
+                  <h1>Contact not found</h1>
+                  <p>
+                    We could not find a matching record{lookup?.phone ? ` for ${lookup.phone}` : ''}. Double-check the number or
+                    try again with a one-time lookup token.
+                  </p>
+                </>
+              ) : null}
+              {status === 'error' ? (
+                <>
+                  <h1>Something went wrong</h1>
+                  <p>{error || 'The contact context service responded with an unexpected error.'}</p>
+                </>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<ContactCardPageProps> = async (context) => {
+  const { req, res, query } = context;
+  const token =
+    normaliseQueryValue(query.token as string | string[] | undefined) ||
+    normaliseQueryValue(query.lookup as string | string[] | undefined) ||
+    normaliseQueryValue(query.lookupToken as string | string[] | undefined);
+  const phone =
+    normaliseQueryValue(query.phone as string | string[] | undefined) ||
+    normaliseQueryValue(query.callerId as string | string[] | undefined) ||
+    normaliseQueryValue(query.callerid as string | string[] | undefined);
+
+  const lookup = { token: token ?? null, phone: phone ?? null };
+
+  if (!lookup.token && !lookup.phone) {
+    return {
+      props: {
+        status: 'not-found',
+        context: null,
+        error: 'Missing lookup token or phone number.',
+        lookup,
+      },
+    };
+  }
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+
+  const baseUrl = buildBaseUrl(req);
+  const searchParams = new URLSearchParams();
+  if (lookup.token) {
+    searchParams.set('token', lookup.token);
+  }
+  if (lookup.phone) {
+    searchParams.set('phone', lookup.phone);
+  }
+
+  const apiUrl = `${baseUrl}/api/integrations/3cx/contact-context?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(apiUrl, {
+      headers: {
+        cookie: req.headers.cookie ?? '',
+        accept: 'application/json',
+      },
+      method: 'GET',
+    });
+
+    if (response.status === 404) {
+      return {
+        props: {
+          status: 'not-found',
+          context: null,
+          error: null,
+          lookup,
+        },
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        props: {
+          status: 'error',
+          context: null,
+          error: `Lookup failed with status ${response.status}.`,
+          lookup,
+        },
+      };
+    }
+
+    const payload = (await response.json()) as { context?: ContactContext | null } | null;
+    const contactContext = payload?.context ?? null;
+
+    if (!contactContext) {
+      return {
+        props: {
+          status: 'not-found',
+          context: null,
+          error: null,
+          lookup,
+        },
+      };
+    }
+
+    return {
+      props: {
+        status: 'success',
+        context: contactContext,
+        error: null,
+        lookup,
+      },
+    };
+  } catch (error) {
+    return {
+      props: {
+        status: 'error',
+        context: null,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        lookup,
+      },
+    };
+  }
+};
+
+export default ContactCardPage;

--- a/styles/ContactCard.module.css
+++ b/styles/ContactCard.module.css
@@ -1,0 +1,319 @@
+.wrapper {
+  min-height: 100vh;
+  margin: 0;
+  padding: 1.75rem clamp(1rem, 4vw, 2.25rem);
+  background: linear-gradient(180deg, #f6fbfa 0%, #f1f7f5 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.wrapperInner {
+  width: min(440px, 100%);
+}
+
+.statePanel {
+  background: #ffffff;
+  border: 1px solid #cde4e0;
+  border-radius: 18px;
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  padding: 1.75rem 1.75rem 1.5rem;
+  text-align: center;
+  color: #1b403a;
+}
+
+.statePanel h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.statePanel p {
+  margin: 0;
+  color: #49645f;
+  line-height: 1.45;
+}
+
+.statePanel.loading h1 {
+  color: #0b7c6d;
+}
+
+.statePanel.loading {
+  border-color: #9ed7ce;
+}
+
+.statePanel.notFound h1 {
+  color: #8f241d;
+}
+
+.statePanel.notFound {
+  background: #fff8f4;
+  border-color: #f4d7c2;
+}
+
+.statePanel.error h1 {
+  color: #b4411f;
+}
+
+.statePanel.error {
+  background: #fff5f3;
+  border-color: #f3c0b3;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid #cde4e0;
+  box-shadow: 0 25px 60px rgba(13, 86, 75, 0.08);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: #1d3834;
+}
+
+.header {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #e4f3f0;
+}
+
+.initials {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #0b7c6d;
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.headerContent {
+  flex: 1;
+}
+
+.name {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #16312d;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+}
+
+.pill {
+  background: rgba(11, 124, 109, 0.12);
+  color: #0b7c6d;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metaText {
+  color: #49645f;
+  font-size: 0.85rem;
+}
+
+.searchFocus {
+  margin: 0.6rem 0 0;
+  color: #49645f;
+  line-height: 1.5;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: #0b7c6d;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.contactGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.contactLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.65rem 0.85rem;
+  background: #f4fbf9;
+  border-radius: 10px;
+  color: #0b7c6d;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.contactLink:hover,
+.contactLink:focus-visible {
+  background: #0b7c6d;
+  color: #ffffff;
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.tagList li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #edf7f5;
+  color: #1b403a;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.propertyList,
+.appointmentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.propertyItem,
+.appointmentItem {
+  border: 1px solid #e5f2ef;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  background: #f9fdfc;
+  box-shadow: 0 10px 30px rgba(13, 86, 75, 0.08);
+}
+
+.propertyPrimary {
+  font-weight: 600;
+  color: #16312d;
+}
+
+.propertySecondary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  color: #49645f;
+  font-size: 0.85rem;
+}
+
+.appointmentHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.appointmentType {
+  font-weight: 600;
+  color: #0b7c6d;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.appointmentHeader time {
+  color: #49645f;
+  font-size: 0.85rem;
+}
+
+.appointmentDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+  color: #1d3834;
+}
+
+.appointmentDetails p {
+  margin: 0;
+  color: #49645f;
+}
+
+.financialList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  border-top: 1px solid #e5f2ef;
+  padding-top: 1rem;
+}
+
+.financialItem {
+  background: #f2fbf8;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d8eee9;
+}
+
+.financialItem dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5a7b75;
+}
+
+.financialItem dd {
+  margin: 0.35rem 0 0;
+  font-weight: 600;
+  color: #0b7c6d;
+  font-size: 1.05rem;
+}
+
+.notes {
+  margin: 0;
+  color: #49645f;
+  line-height: 1.6;
+}
+
+@media (max-width: 520px) {
+  .wrapper {
+    padding: 1.25rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+
+  .header {
+    gap: 1rem;
+  }
+
+  .avatar,
+  .initials {
+    width: 56px;
+    height: 56px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a server-rendered 3CX contact card route that looks up contact context via the integrations API
- build a reusable contact card component and dedicated styling for the compact pop-up
- document the popup URL format and 3CX screen-pop configuration in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9fa5a7268832e87f692bac7d3c2dc