### PR TITLE
Ensure rent pricing uses locale formatting

### DIFF
--- a/__tests__/listing-insights.test.js
+++ b/__tests__/listing-insights.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('../styles/ListingInsights.module.css', () => ({
+  insights: 'insights',
+  heading: 'heading',
+  grid: 'grid',
+  card: 'card',
+  figure: 'figure',
+  meta: 'meta',
+  subFigure: 'subFigure',
+  count: 'count',
+}), { virtual: true });
+
+jest.mock('../lib/format.mjs', () => {
+  const formatPriceGBP = jest.fn((value, options = {}) => {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return '';
+    return `£${options.isSale ? amount.toLocaleString('en-GB') : String(amount)}`;
+  });
+  return {
+    __esModule: true,
+    formatPriceGBP,
+  };
+});
+
+describe('ListingInsights rent formatting', () => {
+  it('shows comma separators for four-digit rent figures', async () => {
+    const componentModule = await import('../components/ListingInsights.js');
+    const ListingInsights =
+      componentModule.default?.default ?? componentModule.default ?? componentModule;
+    const { formatPriceGBP } = jest.requireMock('../lib/format.mjs');
+
+    const stats = {
+      averagePrice: 2100,
+      medianPrice: 2100,
+      propertyTypes: [],
+      topAreas: [],
+      averageBedrooms: null,
+    };
+
+    const markup = renderToStaticMarkup(
+      <ListingInsights stats={stats} searchTerm="" variant="rent" />
+    );
+
+    expect(markup).toContain('£2,100 pcm');
+    expect(markup).toContain('Median: £2,100 pcm');
+    expect(formatPriceGBP).toHaveBeenCalledTimes(2);
+    expect(formatPriceGBP).toHaveBeenNthCalledWith(1, 2100, { isSale: true });
+    expect(formatPriceGBP).toHaveBeenNthCalledWith(2, 2100, { isSale: true });
+  });
+});

--- a/__tests__/to-rent-page.test.js
+++ b/__tests__/to-rent-page.test.js
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment node
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }) => children,
+}));
+
+jest.mock('../components/PropertyList', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../components/PropertyMap', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../components/ListingFilters', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../components/ListingInsights', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../components/AgentCard', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../lib/format.mjs', () => {
+  const formatPriceGBP = jest.fn((value, options = {}) => {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return '';
+    return `£${options.isSale ? amount.toLocaleString('en-GB') : String(amount)}`;
+  });
+  return {
+    __esModule: true,
+    formatPriceGBP,
+    formatRentFrequency: jest.fn((frequency) => frequency || ''),
+  };
+});
+
+jest.mock('../lib/offer-frequency.mjs', () => ({
+  __esModule: true,
+  formatOfferFrequencyLabel: jest.fn((freq) => (freq ? freq : 'pcm')),
+}));
+
+jest.mock('../lib/apex27.mjs', () => ({
+  __esModule: true,
+  fetchPropertiesByTypeCachedFirst: jest.fn(),
+}));
+
+jest.mock('../styles/Home.module.css', () => ({}), { virtual: true });
+jest.mock('../styles/ToRent.module.css', () => ({
+  hero: 'hero',
+  heroContent: 'heroContent',
+  breadcrumbs: 'breadcrumbs',
+  heroTitle: 'heroTitle',
+  heroSubtitle: 'heroSubtitle',
+  heroStats: 'heroStats',
+  heroStat: 'heroStat',
+  heroStatValue: 'heroStatValue',
+  content: 'content',
+  filtersSection: 'filtersSection',
+  filtersInner: 'filtersInner',
+  activeFilters: 'activeFilters',
+  filterChip: 'filterChip',
+  resultsLayout: 'resultsLayout',
+  listColumn: 'listColumn',
+  resultsHeader: 'resultsHeader',
+  mapColumn: 'mapColumn',
+  mapCard: 'mapCard',
+  mapSummary: 'mapSummary',
+  agentsSection: 'agentsSection',
+  ctaSection: 'ctaSection',
+  ctaButtons: 'ctaButtons',
+  primaryCta: 'primaryCta',
+  secondaryCta: 'secondaryCta',
+}), { virtual: true });
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+const { useRouter } = jest.requireMock('next/router');
+
+describe('ToRent page hero stats', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue({
+      query: {},
+      push: jest.fn(),
+      pathname: '/to-rent',
+      isReady: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders hero average rent with comma separators for four-digit rents', async () => {
+    const pageModule = await import('../pages/to-rent.js');
+    const ToRent = pageModule.default?.default ?? pageModule.default ?? pageModule;
+    const { formatPriceGBP } = jest.requireMock('../lib/format.mjs');
+    expect(typeof ToRent).toBe('function');
+    expect(jest.isMockFunction(formatPriceGBP)).toBe(true);
+
+    const properties = [
+      {
+        id: '1',
+        price: '£2,100 pcm',
+        priceValue: 2100,
+        rentFrequency: 'pcm',
+        status: 'available',
+        propertyType: 'apartment',
+        bedrooms: 2,
+        city: 'London',
+        county: 'Greater London',
+      },
+    ];
+
+    const markup = renderToStaticMarkup(
+      <ToRent properties={properties} agents={[]} />
+    );
+
+    expect(markup).toContain('£2,100 pcm');
+    expect(formatPriceGBP).toHaveBeenCalledWith(2100, { isSale: true });
+  });
+});

--- a/components/ListingInsights.js
+++ b/components/ListingInsights.js
@@ -27,7 +27,7 @@ export default function ListingInsights({ stats, searchTerm, variant = 'sale' })
 
   const averagePriceLabel = isRent
     ? averagePrice
-      ? `${formatPriceGBP(averagePrice)} pcm`
+      ? `${formatPriceGBP(averagePrice, { isSale: true })} pcm`
       : '—'
     : averagePrice
     ? formatPriceGBP(averagePrice, { isSale: true })
@@ -35,7 +35,7 @@ export default function ListingInsights({ stats, searchTerm, variant = 'sale' })
 
   const medianPriceLabel = isRent
     ? medianPrice
-      ? `Median: ${formatPriceGBP(medianPrice)} pcm`
+      ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })} pcm`
       : 'Median rent unavailable'
     : medianPrice
     ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })}`

--- a/pages/to-rent.js
+++ b/pages/to-rent.js
@@ -326,7 +326,7 @@ export default function ToRent({ properties, agents }) {
   const defaultRentFrequencyLabel = formatOfferFrequencyLabel('pcm') || 'pcm';
 
   const heroAverageRent = insights.averagePrice
-    ? `${formatPriceGBP(insights.averagePrice)} ${defaultRentFrequencyLabel}`
+    ? `${formatPriceGBP(insights.averagePrice, { isSale: true })} ${defaultRentFrequencyLabel}`
     : '—';
   const heroPopularType = insights.propertyTypes[0]?.label
     ? insights.propertyTypes[0].label


### PR DESCRIPTION
## Summary
- request locale-aware formatting for rent prices in the to-rent hero and ListingInsights cards
- add focused unit tests that confirm four-digit rents render with comma separators in both locations

## Testing
- npm test -- --runTestsByPath __tests__/to-rent-page.test.js __tests__/listing-insights.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9fc6fd110832e8c0e425ca8bc189b