### PR TITLE
Add shared Apex27 contact phone lookup helper

### DIFF
--- a/lib/apex27-portal.js
+++ b/lib/apex27-portal.js
@@ -354,6 +354,56 @@ export function normalizePhone(input) {
   return cleaned;
 }
 
+function normalisePhoneWithCountry(phone, countryCode) {
+  const direct = normalizePhone(phone);
+  if (direct) {
+    return direct;
+  }
+
+  if (phone == null) {
+    return null;
+  }
+
+  const phoneString = String(phone).trim();
+  if (!phoneString) {
+    return null;
+  }
+
+  const phoneDigits = phoneString.replace(/\D+/g, '');
+  if (!phoneDigits) {
+    return null;
+  }
+
+  const stripped = phoneDigits.replace(/^0+/, '');
+
+  if (countryCode != null) {
+    const codeString = String(countryCode).trim();
+    if (codeString) {
+      const codeDigits = codeString.replace(/\D+/g, '');
+      if (codeDigits) {
+        const withPlus = `+${codeDigits}${stripped}`;
+        const normalisedWithPlus = normalizePhone(withPlus);
+        if (normalisedWithPlus) {
+          return normalisedWithPlus;
+        }
+
+        const withoutPlus = `${codeDigits}${stripped}`;
+        const normalisedWithoutPlus = normalizePhone(withoutPlus);
+        if (normalisedWithoutPlus) {
+          return normalisedWithoutPlus;
+        }
+      }
+    }
+  }
+
+  const withLocalPrefix = normalizePhone(stripped ? `0${stripped}` : phoneDigits);
+  if (withLocalPrefix) {
+    return withLocalPrefix;
+  }
+
+  return normalizePhone(phoneDigits);
+}
+
 function buildHeaders({ includeApiKey = true, token } = {}) {
   const headers = {
     accept: 'application/json',
@@ -623,12 +673,77 @@ async function fetchContactByPhone(phone) {
   return null;
 }
 
-export async function resolvePortalContact({ contact, contactId, token, email, phone } = {}) {
+async function lookupContactByPhoneInternal({ phone, countryCode } = {}) {
+  const normalisedPhone = normalisePhoneWithCountry(phone, countryCode);
+  if (!normalisedPhone) {
+    return null;
+  }
+
+  const lookup = await fetchContactByPhone(normalisedPhone);
+  if (!lookup) {
+    return null;
+  }
+
+  const resolved = await resolvePortalContact(
+    {
+      contact: lookup,
+      contactId: extractContactId(lookup) ?? null,
+      email: extractEmail(lookup) ?? null,
+      phone: normalisedPhone,
+      countryCode: countryCode ?? null,
+    },
+    { allowPhoneLookup: false }
+  );
+
+  const { contact, contactId, email, phone: resolvedPhone } = resolved || {};
+
+  if (contact) {
+    const result = { ...contact };
+
+    if (contactId != null && result.contactId == null) {
+      result.contactId = contactId;
+    }
+
+    if (resolvedPhone && !extractPhone(result)) {
+      result.phone = resolvedPhone;
+    }
+
+    if (email && !extractEmail(result)) {
+      result.email = email;
+    }
+
+    return result;
+  }
+
+  if (contactId != null) {
+    const fallback = { contactId };
+    if (resolvedPhone) {
+      fallback.phone = resolvedPhone;
+    }
+    if (email) {
+      fallback.email = email;
+    }
+    return fallback;
+  }
+
+  return null;
+}
+
+export { lookupContactByPhoneInternal as lookupContactByPhone };
+
+export async function resolvePortalContact(
+  { contact, contactId, token, email, phone, countryCode } = {},
+  { allowPhoneLookup = true } = {}
+) {
 
   let resolvedContact = contact ? normaliseContact(contact) : null;
   let resolvedContactId = extractContactId(resolvedContact) ?? contactId ?? null;
   let resolvedEmail = extractEmail(resolvedContact) ?? email ?? null;
-  let resolvedPhone = extractPhone(resolvedContact) ?? normalizePhone(phone) ?? null;
+  let resolvedPhone =
+    extractPhone(resolvedContact) ??
+    normalisePhoneWithCountry(phone, countryCode) ??
+    normalizePhone(phone) ??
+    null;
 
   if (
     resolvedContact &&
@@ -688,9 +803,17 @@ export async function resolvePortalContact({ contact, contactId, token, email, p
     }
   }
 
-  if (!resolvedContactId && !(resolvedEmail || email) && (resolvedPhone || phone)) {
+  if (
+    allowPhoneLookup &&
+    !resolvedContactId &&
+    !(resolvedEmail || email) &&
+    (resolvedPhone || phone)
+  ) {
     try {
-      const lookup = await fetchContactByPhone(resolvedPhone || phone || null);
+      const lookup = await lookupContactByPhoneInternal({
+        phone: resolvedPhone || phone || null,
+        countryCode: countryCode ?? null,
+      });
       if (lookup) {
         const id = extractContactId(lookup) ?? resolvedContactId ?? contactId ?? null;
         const contactEmail = extractEmail(lookup) ?? resolvedEmail ?? email ?? null;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,20 @@
 const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || '';
 const isProd = process.env.NODE_ENV === 'production';
 // Default to a serverful build so API routes like /api/register work.
-// Use NEXT_EXPORT=true if a static export is explicitly required.
-const shouldExport = process.env.NEXT_EXPORT === 'true';
+// Use NEXT_EXPORT=true if a static export is explicitly required and compatible.
+const requestedStaticExport = process.env.NEXT_EXPORT === 'true';
+
+const serverRuntimeOnlyRoutes = ['/integrations/3cx/contact-card'];
+const hasServerOnlyRoutes = serverRuntimeOnlyRoutes.length > 0;
+
+if (requestedStaticExport && hasServerOnlyRoutes) {
+  console.warn(
+    'NEXT_EXPORT requested but the following routes require server rendering and cannot be exported:',
+    serverRuntimeOnlyRoutes.join(', ')
+  );
+}
+
+const shouldExport = requestedStaticExport && !hasServerOnlyRoutes;
 
 /** @type {import('next').NextConfig} */
 function withNoSniff(headers) {

--- a/pages/api/integrations/3cx/contact.js
+++ b/pages/api/integrations/3cx/contact.js
@@ -88,7 +88,7 @@ export default async function handler(req, res) {
   const rawCountryCode = firstQueryValue(req.query.countryCode);
 
   const normalisedPhone = normalisePhoneDigits(rawPhone);
-  if (!normalisedPhone) {
+  if (!normalisedPhone && (!rawPhone || !String(rawPhone).trim())) {
     res.status(400).json({ error: 'Missing or invalid phone query parameter' });
     return;
   }
@@ -97,7 +97,10 @@ export default async function handler(req, res) {
 
   let contact = null;
   try {
-    contact = await lookupContactByPhone({ phone: normalisedPhone, countryCode: normalisedCountryCode });
+    contact = await lookupContactByPhone({
+      phone: normalisedPhone ?? rawPhone,
+      countryCode: normalisedCountryCode,
+    });
   } catch (err) {
     console.error('Failed to query Apex27 contact by phone', err);
     res.status(502).json({ error: 'Failed to lookup contact' });


### PR DESCRIPTION
## Summary
- add a shared Apex27 phone lookup helper that normalises phone and country codes before reusing existing resolvers
- update the portal contact resolver to leverage the helper and avoid redundant phone lookups
- adjust the 3CX contact integration to call the helper and gracefully handle missing results
- ensure the Apex27 phone lookup helper is explicitly exported for reuse and referenced internally without recursion
- fall back to a serverful build when static export is requested alongside server-rendered routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9fed2f668832e87893855236f7e1e