### PR TITLE
Add workflow validation for required Apex27 secrets

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -35,6 +35,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Validate required secrets
+        shell: bash
+        run: |
+          missing=()
+          for name in APEX27_API_KEY APEX27_BRANCH_ID; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            printf '::error::Missing required secrets: %s\n' "${missing[*]}"
+            echo "Required secrets are missing. Configure them in Settings → Secrets and variables → Actions."
+            exit 1
+          fi
       - name: Detect package manager
         id: detect-package-manager
         run: |


### PR DESCRIPTION
## Summary
- add a validation step to the deployment workflow to ensure Apex27 secrets are present before running the build

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da0c41de88832eae1caa135a108540