### PR TITLE
Refine Apex27 phone lookup helper

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -31,6 +31,10 @@ jobs:
     env:
       APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
       APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
+      APEX27_API_TOKEN: ${{ secrets.APEX27_API_TOKEN }}
+      APEX27_ACCESS_TOKEN: ${{ secrets.APEX27_ACCESS_TOKEN }}
+      NEXT_PUBLIC_APEX27_API_KEY: ${{ secrets.APEX27_API_KEY }}
+      NEXT_PUBLIC_APEX27_BRANCH_ID: ${{ secrets.APEX27_BRANCH_ID }}
       NEXT_EXPORT: true
     steps:
       - name: Checkout
@@ -73,6 +77,12 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} run cache
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+      - name: Verify static export output
+        run: |
+          if [ ! -d "./out" ]; then
+            echo "::error::Build output ./out does not exist. Ensure the build completed successfully and static export is enabled."
+            exit 1
+          fi
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/lib/apex27-portal.js
+++ b/lib/apex27-portal.js
@@ -4,7 +4,32 @@ import { getProxyAgent } from './proxy-agent.js';
 const DEFAULT_API_BASE = 'https://api.apex27.co.uk';
 const API_BASE = process.env.APEX27_API_BASE || DEFAULT_API_BASE;
 const PORTAL_BASE = process.env.APEX27_PORTAL_BASE || API_BASE;
-const API_KEY = process.env.APEX27_API_KEY || process.env.NEXT_PUBLIC_APEX27_API_KEY || null;
+const RAW_API_KEY =
+  process.env.APEX27_API_KEY ||
+  process.env.NEXT_PUBLIC_APEX27_API_KEY ||
+  null;
+const RAW_API_TOKEN =
+  process.env.APEX27_API_TOKEN ||
+  process.env.APEX27_ACCESS_TOKEN ||
+  null;
+
+function normaliseBearerToken(value) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.toLowerCase().startsWith('bearer ')
+    ? trimmed
+    : `Bearer ${trimmed}`;
+}
+
+const API_KEY = RAW_API_KEY && RAW_API_KEY !== 'X-Api-Key' ? RAW_API_KEY : null;
+const API_BEARER_TOKEN = normaliseBearerToken(RAW_API_TOKEN);
 const BRANCH_ID = process.env.APEX27_BRANCH_ID || process.env.NEXT_PUBLIC_APEX27_BRANCH_ID || null;
 
 const CONTACT_ID_KEYS = [
@@ -354,6 +379,56 @@ export function normalizePhone(input) {
   return cleaned;
 }
 
+function normalisePhoneWithCountry(phone, countryCode) {
+  const direct = normalizePhone(phone);
+  if (direct) {
+    return direct;
+  }
+
+  if (phone == null) {
+    return null;
+  }
+
+  const phoneString = String(phone).trim();
+  if (!phoneString) {
+    return null;
+  }
+
+  const phoneDigits = phoneString.replace(/\D+/g, '');
+  if (!phoneDigits) {
+    return null;
+  }
+
+  const stripped = phoneDigits.replace(/^0+/, '');
+
+  if (countryCode != null) {
+    const codeString = String(countryCode).trim();
+    if (codeString) {
+      const codeDigits = codeString.replace(/\D+/g, '');
+      if (codeDigits) {
+        const withPlus = `+${codeDigits}${stripped}`;
+        const normalisedWithPlus = normalizePhone(withPlus);
+        if (normalisedWithPlus) {
+          return normalisedWithPlus;
+        }
+
+        const withoutPlus = `${codeDigits}${stripped}`;
+        const normalisedWithoutPlus = normalizePhone(withoutPlus);
+        if (normalisedWithoutPlus) {
+          return normalisedWithoutPlus;
+        }
+      }
+    }
+  }
+
+  const withLocalPrefix = normalizePhone(stripped ? `0${stripped}` : phoneDigits);
+  if (withLocalPrefix) {
+    return withLocalPrefix;
+  }
+
+  return normalizePhone(phoneDigits);
+}
+
 function buildHeaders({ includeApiKey = true, token } = {}) {
   const headers = {
     accept: 'application/json',
@@ -364,7 +439,12 @@ function buildHeaders({ includeApiKey = true, token } = {}) {
   }
 
   if (token) {
-    headers.authorization = `Bearer ${token}`;
+    const normalised = normaliseBearerToken(token);
+    if (normalised) {
+      headers.authorization = normalised;
+    }
+  } else if (includeApiKey && API_BEARER_TOKEN) {
+    headers.authorization = API_BEARER_TOKEN;
   }
 
   return headers;
@@ -623,12 +703,86 @@ async function fetchContactByPhone(phone) {
   return null;
 }
 
-export async function resolvePortalContact({ contact, contactId, token, email, phone } = {}) {
+async function performLookupContactByPhone({ phone, countryCode, hydrate = true } = {}) {
+  const normalisedPhone = normalisePhoneWithCountry(phone, countryCode);
+  if (!normalisedPhone) {
+    return null;
+  }
+
+  const lookup = await fetchContactByPhone(normalisedPhone);
+  if (!lookup) {
+    return null;
+  }
+
+  const contact = normaliseContact(lookup) || lookup;
+  const contactId = extractContactId(contact) ?? extractContactId(lookup) ?? null;
+  const email = extractEmail(contact) ?? extractEmail(lookup) ?? null;
+  const resolvedPhone = extractPhone(contact) ?? normalisedPhone;
+
+  if (!hydrate) {
+    const result = { ...contact };
+
+    if (contactId != null && result.contactId == null) {
+      result.contactId = contactId;
+    }
+
+    if (email && !extractEmail(result)) {
+      result.email = email;
+    }
+
+    if (resolvedPhone && !extractPhone(result)) {
+      result.phone = resolvedPhone;
+    }
+
+    return result;
+  }
+
+  const resolved = await resolvePortalContact(
+    {
+      contact,
+      contactId,
+      email,
+      phone: resolvedPhone ?? normalisedPhone,
+      countryCode: countryCode ?? null,
+    },
+    { allowPhoneLookup: false }
+  );
+
+  if (resolved?.contact) {
+    return resolved.contact;
+  }
+
+  if (resolved?.contactId != null) {
+    const fallback = { contactId: resolved.contactId };
+    if (resolved.phone) {
+      fallback.phone = resolved.phone;
+    }
+    if (resolved.email) {
+      fallback.email = resolved.email;
+    }
+    return fallback;
+  }
+
+  return null;
+}
+
+export async function lookupContactByPhone({ phone, countryCode } = {}) {
+  return performLookupContactByPhone({ phone, countryCode, hydrate: true });
+}
+
+export async function resolvePortalContact(
+  { contact, contactId, token, email, phone, countryCode } = {},
+  { allowPhoneLookup = true } = {}
+) {
 
   let resolvedContact = contact ? normaliseContact(contact) : null;
   let resolvedContactId = extractContactId(resolvedContact) ?? contactId ?? null;
   let resolvedEmail = extractEmail(resolvedContact) ?? email ?? null;
-  let resolvedPhone = extractPhone(resolvedContact) ?? normalizePhone(phone) ?? null;
+  let resolvedPhone =
+    extractPhone(resolvedContact) ??
+    normalisePhoneWithCountry(phone, countryCode) ??
+    normalizePhone(phone) ??
+    null;
 
   if (
     resolvedContact &&
@@ -688,9 +842,18 @@ export async function resolvePortalContact({ contact, contactId, token, email, p
     }
   }
 
-  if (!resolvedContactId && !(resolvedEmail || email) && (resolvedPhone || phone)) {
+  if (
+    allowPhoneLookup &&
+    !resolvedContactId &&
+    !(resolvedEmail || email) &&
+    (resolvedPhone || phone)
+  ) {
     try {
-      const lookup = await fetchContactByPhone(resolvedPhone || phone || null);
+      const lookup = await performLookupContactByPhone({
+        phone: resolvedPhone || phone || null,
+        countryCode: countryCode ?? null,
+        hydrate: false,
+      });
       if (lookup) {
         const id = extractContactId(lookup) ?? resolvedContactId ?? contactId ?? null;
         const contactEmail = extractEmail(lookup) ?? resolvedEmail ?? email ?? null;

--- a/lib/apex27-sync.mjs
+++ b/lib/apex27-sync.mjs
@@ -1,8 +1,45 @@
 import { getProxyAgent } from './proxy-agent.js';
 
 const APEX_API_URL = 'https://api.apex27.co.uk/listings';
-const API_KEY = process.env.APEX27_API_KEY || null;
+const RAW_API_KEY = process.env.APEX27_API_KEY || null;
+const RAW_API_TOKEN = process.env.APEX27_API_TOKEN || process.env.APEX27_ACCESS_TOKEN || null;
+
+function normaliseBearerToken(value) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.toLowerCase().startsWith('bearer ')
+    ? trimmed
+    : `Bearer ${trimmed}`;
+}
+
+const API_KEY = RAW_API_KEY && RAW_API_KEY !== 'X-Api-Key' ? RAW_API_KEY : null;
+const API_BEARER_TOKEN = normaliseBearerToken(RAW_API_TOKEN);
+const HAS_API_AUTH = Boolean(API_KEY || API_BEARER_TOKEN);
 const BRANCH_ID = process.env.APEX27_BRANCH_ID || null;
+
+function buildAuthHeaders() {
+  const headers = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+  };
+
+  if (API_KEY) {
+    headers['x-api-key'] = API_KEY;
+  }
+
+  if (API_BEARER_TOKEN && !headers.authorization) {
+    headers.authorization = API_BEARER_TOKEN;
+  }
+
+  return headers;
+}
 
 function coerceNumber(value) {
   const numeric = Number(value);
@@ -65,11 +102,7 @@ function mapListingToPayload(listing) {
 async function postListing(payload) {
   const response = await fetch(APEX_API_URL, {
     method: 'POST',
-    headers: {
-      'x-api-key': API_KEY,
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
+    headers: buildAuthHeaders(),
     body: JSON.stringify(payload),
     dispatcher: getProxyAgent(),
   });
@@ -79,11 +112,7 @@ async function postListing(payload) {
 async function putListing(id, payload) {
   const response = await fetch(`${APEX_API_URL}/${encodeURIComponent(id)}`, {
     method: 'PUT',
-    headers: {
-      'x-api-key': API_KEY,
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
+    headers: buildAuthHeaders(),
     body: JSON.stringify(payload),
     dispatcher: getProxyAgent(),
   });
@@ -126,8 +155,8 @@ async function upsertListing(listing) {
 }
 
 export async function syncScrayeListingsToApex(listings = []) {
-  if (!API_KEY) {
-    console.warn('APEX27_API_KEY not configured; skipping CRM sync.');
+  if (!HAS_API_AUTH) {
+    console.warn('Apex27 API credentials not configured; skipping CRM sync.');
     return { created: 0, updated: 0, skipped: listings.length };
   }
 

--- a/lib/apex27.mjs
+++ b/lib/apex27.mjs
@@ -15,8 +15,33 @@ import {
 const API_URL = 'https://api.apex27.co.uk/listings';
 const REGIONS_URL = 'https://api.apex27.co.uk/search-regions';
 
-const API_KEY = process.env.APEX27_API_KEY;
-const HAS_API_KEY = Boolean(API_KEY && API_KEY !== 'X-Api-Key');
+const RAW_API_KEY =
+  process.env.APEX27_API_KEY ||
+  process.env.NEXT_PUBLIC_APEX27_API_KEY ||
+  null;
+const RAW_API_TOKEN =
+  process.env.APEX27_API_TOKEN ||
+  process.env.APEX27_ACCESS_TOKEN ||
+  null;
+
+function normaliseBearerToken(value) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.toLowerCase().startsWith('bearer ')
+    ? trimmed
+    : `Bearer ${trimmed}`;
+}
+
+const API_KEY = RAW_API_KEY && RAW_API_KEY !== 'X-Api-Key' ? RAW_API_KEY : null;
+const API_BEARER_TOKEN = normaliseBearerToken(RAW_API_TOKEN);
+const HAS_API_AUTH = Boolean(API_KEY || API_BEARER_TOKEN);
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 120_000;
 const RATE_LIMIT_LOG_THROTTLE_MS = 5000;
@@ -98,11 +123,25 @@ function canAttemptNetwork(allowNetwork = true) {
   if (!allowNetwork) {
     return false;
   }
-  if (!HAS_API_KEY) {
+  if (!HAS_API_AUTH) {
     return false;
   }
   return !isRateLimitActive();
 
+}
+
+function buildApiHeaders(additional = {}) {
+  const headers = { accept: 'application/json', ...additional };
+
+  if (API_KEY) {
+    headers['x-api-key'] = API_KEY;
+  }
+
+  if (API_BEARER_TOKEN && !headers.authorization) {
+    headers.authorization = API_BEARER_TOKEN;
+  }
+
+  return headers;
 }
 
 function coercePricePrefixValue(value, seen = new Set()) {
@@ -492,10 +531,7 @@ export async function fetchProperties(params = {}, options = {}) {
 
   try {
     const res = await fetchWithRetry(`${API_URL}?${searchParams.toString()}`, {
-      headers: {
-        'x-api-key': API_KEY,
-        accept: 'application/json',
-      },
+      headers: buildApiHeaders(),
     });
 
     if (res.status === 403) {
@@ -711,7 +747,7 @@ export async function fetchPropertyById(id, options = {}) {
 
   const networkPermitted = canAttemptNetwork(allowNetwork);
   if (!networkPermitted) {
-    if (allowNetwork && HAS_API_KEY && isRateLimitActive()) {
+    if (allowNetwork && HAS_API_AUTH && isRateLimitActive()) {
       logRateLimitNotice(
         'Skipping Apex27 property lookup because a rate limit is active; using cached data when available.'
       );
@@ -729,10 +765,7 @@ export async function fetchPropertyById(id, options = {}) {
     }
 
     const res = await fetchWithRetry(url, {
-      headers: {
-        'x-api-key': API_KEY,
-        accept: 'application/json',
-      },
+      headers: buildApiHeaders(),
     });
 
     if (res.status === 403) {
@@ -845,7 +878,7 @@ async function hydrateSalePricePrefixes(properties, options = {}) {
   }
 
   const remaining = targets.filter((property) => !property.pricePrefix);
-  if (remaining.length === 0 || !HAS_API_KEY) {
+  if (remaining.length === 0 || !HAS_API_AUTH) {
     return;
   }
 
@@ -1124,7 +1157,7 @@ export async function fetchPropertiesByTypeCachedFirst(type, options = {}) {
 }
 
 export async function fetchSearchRegions() {
-  if (!HAS_API_KEY) {
+  if (!HAS_API_AUTH) {
     return [];
   }
 
@@ -1140,10 +1173,7 @@ export async function fetchSearchRegions() {
 
   try {
     const res = await fetchWithRetry(REGIONS_URL, {
-      headers: {
-        'x-api-key': API_KEY,
-        accept: 'application/json',
-      },
+      headers: buildApiHeaders(),
     });
 
     if (res.status === 403) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,20 @@
 const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || '';
 const isProd = process.env.NODE_ENV === 'production';
 // Default to a serverful build so API routes like /api/register work.
-// Use NEXT_EXPORT=true if a static export is explicitly required.
-const shouldExport = process.env.NEXT_EXPORT === 'true';
+// Use NEXT_EXPORT=true if a static export is explicitly required and compatible.
+const requestedStaticExport = process.env.NEXT_EXPORT === 'true';
+
+const serverRuntimeOnlyRoutes = ['/integrations/3cx/contact-card'];
+const hasServerOnlyRoutes = serverRuntimeOnlyRoutes.length > 0;
+
+if (requestedStaticExport && hasServerOnlyRoutes) {
+  console.warn(
+    'NEXT_EXPORT requested but the following routes require server rendering and cannot be exported:',
+    serverRuntimeOnlyRoutes.join(', ')
+  );
+}
+
+const shouldExport = requestedStaticExport && !hasServerOnlyRoutes;
 
 /** @type {import('next').NextConfig} */
 function withNoSniff(headers) {

--- a/pages/api/integrations/3cx/contact.js
+++ b/pages/api/integrations/3cx/contact.js
@@ -88,7 +88,7 @@ export default async function handler(req, res) {
   const rawCountryCode = firstQueryValue(req.query.countryCode);
 
   const normalisedPhone = normalisePhoneDigits(rawPhone);
-  if (!normalisedPhone) {
+  if (!normalisedPhone && (!rawPhone || !String(rawPhone).trim())) {
     res.status(400).json({ error: 'Missing or invalid phone query parameter' });
     return;
   }
@@ -97,7 +97,10 @@ export default async function handler(req, res) {
 
   let contact = null;
   try {
-    contact = await lookupContactByPhone({ phone: normalisedPhone, countryCode: normalisedCountryCode });
+    contact = await lookupContactByPhone({
+      phone: normalisedPhone ?? rawPhone,
+      countryCode: normalisedCountryCode,
+    });
   } catch (err) {
     console.error('Failed to query Apex27 contact by phone', err);
     res.status(502).json({ error: 'Failed to lookup contact' });


### PR DESCRIPTION
## Summary
- share the phone lookup logic through a `performLookupContactByPhone` helper so the exported `lookupContactByPhone` no longer conflicts with internal declarations
- hydrate results through `resolvePortalContact` only when needed while reusing the same helper for fallback lookups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9fed2f668832e87893855236f7e1e