### PR TITLE
Ensure rental offer amounts use locale formatting

### DIFF
--- a/__tests__/admin-offers.test.js
+++ b/__tests__/admin-offers.test.js
@@ -101,7 +101,7 @@ describe('admin offers API', () => {
     expect(savedEntry).toBeDefined();
     expect(savedEntry).toEqual(
       expect.objectContaining({
-        amount: '£1800 Per month',
+        amount: '£1,800 Per month',
         date: savedOffer.createdAt,
         type: 'rent',
         price: savedOffer.price,

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -118,18 +118,21 @@ function getOfferType(offer) {
 
 export function formatOfferAmount(offer, type) {
   const price = offer?.price;
-  const formattedPrice =
-    price != null ? formatPriceGBP(price, { isSale: type === 'sale' }) : '';
-  if (!formattedPrice) {
-    return '';
-  }
-
   if (type === 'rent') {
+    const formattedPrice =
+      price != null ? formatPriceGBP(price, { isSale: true }) : '';
+    if (!formattedPrice) {
+      return '';
+    }
+
     const frequencyLabel = formatOfferFrequencyLabel(offer?.frequency);
     return frequencyLabel ? `${formattedPrice} ${frequencyLabel}` : formattedPrice;
   }
 
-  return formattedPrice;
+  const formattedPrice =
+    price != null ? formatPriceGBP(price, { isSale: type === 'sale' }) : '';
+
+  return formattedPrice || '';
 }
 
 function buildOfferPresentation(offer) {


### PR DESCRIPTION
## Summary
- ensure rental offer amounts format prices with GBP locale formatting before appending cadence labels
- update admin offers regression test to expect comma-formatted rent values

## Testing
- npm test -- admin-offers

------
https://chatgpt.com/codex/tasks/task_e_68da18d672c0832e8c29c644686f25d3