### PR TITLE
Format listing insight rent frequencies with helper

### DIFF
--- a/__tests__/listing-insights.test.js
+++ b/__tests__/listing-insights.test.js
@@ -27,16 +27,44 @@ jest.mock('../lib/format.mjs', () => {
   };
 });
 
+jest.mock('../lib/offer-frequency.mjs', () => {
+  const formatOfferFrequencyLabel = jest.fn((value) => {
+    if (!value) return '';
+    const normalized = String(value).trim().toLowerCase();
+    switch (normalized) {
+      case 'pcm':
+      case 'per month':
+      case 'per calendar month':
+        return 'Per month';
+      case 'pq':
+      case 'per quarter':
+        return 'Per quarter';
+      case 'pa':
+      case 'per annum':
+        return 'Per annum';
+      default:
+        return value;
+    }
+  });
+  return {
+    __esModule: true,
+    formatOfferFrequencyLabel,
+  };
+});
+
 describe('ListingInsights rent formatting', () => {
   it('shows comma separators for four-digit rent figures', async () => {
     const componentModule = await import('../components/ListingInsights.js');
     const ListingInsights =
       componentModule.default?.default ?? componentModule.default ?? componentModule;
     const { formatPriceGBP } = jest.requireMock('../lib/format.mjs');
+    const { formatOfferFrequencyLabel } = jest.requireMock('../lib/offer-frequency.mjs');
 
     const stats = {
       averagePrice: 2100,
       medianPrice: 2100,
+      averagePriceFrequency: 'pcm',
+      medianPriceFrequency: 'pcm',
       propertyTypes: [],
       topAreas: [],
       averageBedrooms: null,
@@ -46,10 +74,13 @@ describe('ListingInsights rent formatting', () => {
       <ListingInsights stats={stats} searchTerm="" variant="rent" />
     );
 
-    expect(markup).toContain('£2,100 pcm');
-    expect(markup).toContain('Median: £2,100 pcm');
+    expect(markup).toContain('£2,100 Per month');
+    expect(markup).toContain('Median: £2,100 Per month');
     expect(formatPriceGBP).toHaveBeenCalledTimes(2);
     expect(formatPriceGBP).toHaveBeenNthCalledWith(1, 2100, { isSale: true });
     expect(formatPriceGBP).toHaveBeenNthCalledWith(2, 2100, { isSale: true });
+    expect(formatOfferFrequencyLabel).toHaveBeenCalledTimes(2);
+    expect(formatOfferFrequencyLabel).toHaveBeenNthCalledWith(1, 'pcm');
+    expect(formatOfferFrequencyLabel).toHaveBeenNthCalledWith(2, 'pcm');
   });
 });

--- a/components/ListingInsights.js
+++ b/components/ListingInsights.js
@@ -1,5 +1,6 @@
 import styles from '../styles/ListingInsights.module.css';
 import { formatPriceGBP } from '../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../lib/offer-frequency.mjs';
 
 function formatLabel(value) {
   if (!value) return 'Other';
@@ -13,7 +14,15 @@ function formatLabel(value) {
 export default function ListingInsights({ stats, searchTerm, variant = 'sale' }) {
   if (!stats) return null;
 
-  const { averagePrice, medianPrice, propertyTypes, topAreas, averageBedrooms } = stats;
+  const {
+    averagePrice,
+    medianPrice,
+    propertyTypes,
+    topAreas,
+    averageBedrooms,
+    averagePriceFrequency,
+    medianPriceFrequency,
+  } = stats;
 
   const isRent = variant === 'rent';
 
@@ -25,9 +34,23 @@ export default function ListingInsights({ stats, searchTerm, variant = 'sale' })
     ? 'See how our rental homes perform across price brackets, property styles and the areas tenants ask for most.'
     : 'Understand how our listings compare across price points, property styles and the neighbourhoods buyers are looking at right now.';
 
+  const averageFrequencyLabel = isRent
+    ? formatOfferFrequencyLabel(
+        averagePriceFrequency ?? medianPriceFrequency ?? 'pcm'
+      )
+    : '';
+
+  const medianFrequencyLabel = isRent
+    ? formatOfferFrequencyLabel(
+        medianPriceFrequency ?? averagePriceFrequency ?? 'pcm'
+      )
+    : '';
+
   const averagePriceLabel = isRent
     ? averagePrice
-      ? `${formatPriceGBP(averagePrice, { isSale: true })} pcm`
+      ? `${formatPriceGBP(averagePrice, { isSale: true })}${
+          averageFrequencyLabel ? ` ${averageFrequencyLabel}` : ''
+        }`
       : '—'
     : averagePrice
     ? formatPriceGBP(averagePrice, { isSale: true })
@@ -35,7 +58,9 @@ export default function ListingInsights({ stats, searchTerm, variant = 'sale' })
 
   const medianPriceLabel = isRent
     ? medianPrice
-      ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })} pcm`
+      ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })}${
+          medianFrequencyLabel ? ` ${medianFrequencyLabel}` : ''
+        }`
       : 'Median rent unavailable'
     : medianPrice
     ? `Median: ${formatPriceGBP(medianPrice, { isSale: true })}`


### PR DESCRIPTION
## Summary
- import the offer frequency formatter so rent insights show readable cadences
- append the formatted cadence to average and median rent labels instead of hard-coded pcm
- extend the listing insights test to mock the formatter and assert the new label output

## Testing
- npm test -- listing-insights

------
https://chatgpt.com/codex/tasks/task_e_68e18a9b4004832e98b34b3ec4f643b8