### PR TITLE
Format rent frequency labels on to-rent page

### DIFF
--- a/__tests__/to-rent-page.test.js
+++ b/__tests__/to-rent-page.test.js
@@ -53,7 +53,12 @@ jest.mock('../lib/format.mjs', () => {
 
 jest.mock('../lib/offer-frequency.mjs', () => ({
   __esModule: true,
-  formatOfferFrequencyLabel: jest.fn((freq) => (freq ? freq : 'pcm')),
+  formatOfferFrequencyLabel: jest.fn((freq) => {
+    if (!freq) return '';
+    if (freq === 'pcm') return 'Per month';
+    if (typeof freq === 'string') return freq;
+    return '';
+  }),
 }));
 
 jest.mock('../lib/apex27.mjs', () => ({
@@ -137,7 +142,7 @@ describe('ToRent page hero stats', () => {
       <ToRent properties={properties} agents={[]} />
     );
 
-    expect(markup).toContain('£2,100 pcm');
+    expect(markup).toContain('£2,100 Per month');
     expect(formatPriceGBP).toHaveBeenCalledWith(2100, { isSale: true });
   });
 });


### PR DESCRIPTION
## Summary
- regenerate rent price filter option labels using the shared offer-frequency formatter
- reuse the resolved rent frequency label when displaying active filter chips and hero stats
- update the to-rent page unit test to expect the human-friendly rent cadence label

## Testing
- npm test -- to-rent-page

------
https://chatgpt.com/codex/tasks/task_e_68e18a9bf620832e90a88ea89d424b00