### PR TITLE
Format account dashboard rent filters with readable cadence

### DIFF
--- a/__tests__/account-dashboard.test.js
+++ b/__tests__/account-dashboard.test.js
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock('../components/account/AccountLayout', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="account-layout">{children}</div>,
+}));
+
+jest.mock('../lib/format.mjs', () => {
+  const formatPriceGBP = jest.fn((value) => {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return '';
+    return `£${amount.toLocaleString('en-GB')}`;
+  });
+  return {
+    __esModule: true,
+    formatPriceGBP,
+  };
+});
+
+jest.mock('../lib/offer-frequency.mjs', () => {
+  const formatOfferFrequencyLabel = jest.fn((value) => {
+    if (!value) return '';
+    const normalized = String(value).trim().toLowerCase();
+    if (['pcm', 'per month', 'per calendar month'].includes(normalized)) {
+      return 'Per month';
+    }
+    return value;
+  });
+  return {
+    __esModule: true,
+    formatOfferFrequencyLabel,
+  };
+});
+
+jest.mock(
+  '../styles/Account.module.css',
+  () => ({
+    pageSections: 'pageSections',
+    panel: 'panel',
+    panelHeader: 'panelHeader',
+    primaryCta: 'primaryCta',
+    registerGrid: 'registerGrid',
+    formGroup: 'formGroup',
+    groupLabel: 'groupLabel',
+    rangeControls: 'rangeControls',
+    selectWrap: 'selectWrap',
+    selectCaption: 'selectCaption',
+    select: 'select',
+    selectFull: 'selectFull',
+    groupHint: 'groupHint',
+    pillRow: 'pillRow',
+    pillOption: 'pillOption',
+    pillOptionActive: 'pillOptionActive',
+    chipRow: 'chipRow',
+    chipOption: 'chipOption',
+    chipOptionActive: 'chipOptionActive',
+    sectionHeader: 'sectionHeader',
+    ghostButton: 'ghostButton',
+    mapPanel: 'mapPanel',
+    mapShell: 'mapShell',
+    mapSurface: 'mapSurface',
+    mapToolbar: 'mapToolbar',
+    mapMode: 'mapMode',
+    mapModeActive: 'mapModeActive',
+    mapIllustration: 'mapIllustration',
+    mapFootnote: 'mapFootnote',
+    mapSearch: 'mapSearch',
+    searchInput: 'searchInput',
+    searchIcon: 'searchIcon',
+    searchField: 'searchField',
+    helperText: 'helperText',
+    areaChips: 'areaChips',
+    areaChip: 'areaChip',
+    areaChipActive: 'areaChipActive',
+    chipRemove: 'chipRemove',
+    flexOptions: 'flexOptions',
+    flexOption: 'flexOption',
+    flexOptionActive: 'flexOptionActive',
+    textArea: 'textArea',
+  }),
+  { virtual: true },
+);
+
+describe('Account dashboard price filters', () => {
+  it('renders readable rent frequency labels', async () => {
+    const pageModule = await import('../pages/account/index.js');
+    const AccountDashboard = pageModule.default?.default ?? pageModule.default ?? pageModule;
+
+    const markup = renderToStaticMarkup(<AccountDashboard />);
+
+    expect(markup).toContain('£1,500 Per month');
+    expect(markup).toContain('£3,200 Per month');
+    expect(markup).toContain('£3,500 Per month');
+    expect(markup).not.toContain('pcm');
+  });
+});

--- a/pages/account/index.js
+++ b/pages/account/index.js
@@ -2,9 +2,16 @@ import Link from 'next/link';
 
 import AccountLayout from '../../components/account/AccountLayout';
 import styles from '../../styles/Account.module.css';
+import { formatPriceGBP } from '../../lib/format.mjs';
+import { formatOfferFrequencyLabel } from '../../lib/offer-frequency.mjs';
 
-const PRICE_MIN_OPTIONS = ['£1,500 pcm', '£1,700 pcm', '£1,900 pcm', '£2,100 pcm'];
-const PRICE_MAX_OPTIONS = ['£2,600 pcm', '£2,900 pcm', '£3,200 pcm', '£3,500 pcm'];
+const DEFAULT_RENT_FREQUENCY = 'pcm';
+const DEFAULT_RENT_FREQUENCY_LABEL = formatOfferFrequencyLabel(DEFAULT_RENT_FREQUENCY);
+
+const formatRentPriceOption = (amount) => `${formatPriceGBP(amount)} ${DEFAULT_RENT_FREQUENCY_LABEL}`;
+
+const PRICE_MIN_OPTIONS = [1500, 1700, 1900, 2100].map(formatRentPriceOption);
+const PRICE_MAX_OPTIONS = [2600, 2900, 3200, 3500].map(formatRentPriceOption);
 const TENURE_OPTIONS = ['6 months', '12 months', '18 months', '24 months+'];
 
 const BEDROOM_OPTIONS = [
@@ -46,10 +53,10 @@ const AREA_TAGS = [
   { label: 'Canonbury' },
 ];
 
-const BUDGET_MIN_OPTIONS = ['£1,500 pcm', '£1,750 pcm', '£1,900 pcm', '£2,100 pcm'];
-const BUDGET_MAX_OPTIONS = ['£2,400 pcm', '£2,750 pcm', '£3,000 pcm', '£3,250 pcm', '£3,500 pcm'];
-const SELECTED_MIN = '£1,900 pcm';
-const SELECTED_MAX = '£3,000 pcm';
+const BUDGET_MIN_OPTIONS = [1500, 1750, 1900, 2100].map(formatRentPriceOption);
+const BUDGET_MAX_OPTIONS = [2400, 2750, 3000, 3250, 3500].map(formatRentPriceOption);
+const SELECTED_MIN = formatRentPriceOption(1900);
+const SELECTED_MAX = formatRentPriceOption(3200);
 
 export default function AccountDashboard() {
   return (
@@ -83,7 +90,7 @@ export default function AccountDashboard() {
               <div className={styles.rangeControls}>
                 <label className={styles.selectWrap}>
                   <span className={styles.selectCaption}>Min</span>
-                  <select className={styles.select} defaultValue="£1,900 pcm" aria-label="Minimum price per month">
+                  <select className={styles.select} defaultValue={SELECTED_MIN} aria-label="Minimum price per month">
                     {PRICE_MIN_OPTIONS.map((value) => (
                       <option key={value} value={value}>
                         {value}
@@ -93,7 +100,7 @@ export default function AccountDashboard() {
                 </label>
                 <label className={styles.selectWrap}>
                   <span className={styles.selectCaption}>Max</span>
-                  <select className={styles.select} defaultValue="£3,200 pcm" aria-label="Maximum price per month">
+                  <select className={styles.select} defaultValue={SELECTED_MAX} aria-label="Maximum price per month">
                     {PRICE_MAX_OPTIONS.map((value) => (
                       <option key={value} value={value}>
                         {value}


### PR DESCRIPTION
## Summary
- use shared price and frequency formatters to build account dashboard price options with readable cadence labels
- align the selected price defaults with the new formatted option strings
- add a component test that asserts the rendered dashboard shows "Per month" instead of raw frequency tokens

## Testing
- npm test -- --runTestsByPath __tests__/account-dashboard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e18ecb120c832e9eafcf4356030d6a