### PR TITLE
Replace Scraye data with live rental listings

### DIFF
--- a/data/scraye.json
+++ b/data/scraye.json
@@ -1,5207 +1,2775 @@
 {
-  "generatedAt": "2025-09-23T23:45:37Z",
+  "generatedAt": "2025-10-04T21:26:47Z",
   "rent": [
     {
-      "id": "scraye-950001",
-      "sourceId": "950001",
+      "id": "scraye-6808c4f0a58a7dca8de0b842",
+      "sourceId": "6808c4f0a58a7dca8de0b842",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Boutique Four Bedroom Maisonette, Fitzrovia W1T",
-      "description": "Boutique 4-bedroom maisonette in Fitzrovia offering pet friendly, roof terrace and private balcony.",
-      "price": "\u00a32275",
-      "priceValue": 2275,
+      "title": "New Horizons Court, Brentford End, Hounslow, London, TW8",
+      "description": "*PROMOTION: \n- Two weeks' rent free for move-ins by 21st September.\n\nPresenting this stunning studio flat in Vulcan House. The rent includes access to various convenient amenities like an on-site building manager, communal gardens and a covered bike garage. Parking is available at \u00a375/month, and pets for \u00a325/month.\n\nAvailable now. The flat benefits from fig windows, high ceilings and ample storage. It comes with a well-equipped kitchen and an ensuite bathroom.\n\nThe flat is under the Council Tax band B. \n\nNew Horizons Court is located minutes away from Syon Lane station.",
+      "price": "\u00a31,350",
+      "priceValue": 1350,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
+        "Parking",
         "Pet Friendly",
-        "Roof Terrace",
-        "Private Balcony"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "fitzrovia-950001-1",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "fitzrovia-950001-2",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "fitzrovia-950001-3",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5207,
-      "longitude": -0.1359,
-      "lat": 51.5207,
-      "lng": -0.1359,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Fitzrovia",
-        "W1T"
-      ],
-      "createdAt": "2025-02-15T11:00:00Z",
-      "updatedAt": "2025-03-07T16:00:00Z",
-      "availableAt": "2025-04-10T16:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 66,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "W1T",
-      "url": "https://www.scraye.com/listings/950001",
-      "externalUrl": "https://www.scraye.com/listings/950001",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "W1T",
-        "placeName": "Fitzrovia",
-        "slug": "london/fitzrovia",
-        "longitude": -0.1359,
-        "latitude": 51.5207,
-        "listTimestamp": "2025-02-15T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950002",
-      "sourceId": "950002",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Stylish Four Bedroom Apartment, Shoreditch E2",
-      "description": "Stylish 4-bedroom apartment in Shoreditch offering residents gym, smart home controls and city skyline views.",
-      "price": "\u00a31750",
-      "priceValue": 1750,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 4,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Residents Gym",
-        "Smart Home Controls",
-        "City Skyline Views"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "shoreditch-950002-1",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "shoreditch-950002-2",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "shoreditch-950002-3",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5246,
-      "longitude": -0.0755,
-      "lat": 51.5246,
-      "lng": -0.0755,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Shoreditch",
-        "E2"
-      ],
-      "createdAt": "2025-01-22T10:00:00Z",
-      "updatedAt": "2025-02-21T14:00:00Z",
-      "availableAt": "2025-03-23T14:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 124,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "E2",
-      "url": "https://www.scraye.com/listings/950002",
-      "externalUrl": "https://www.scraye.com/listings/950002",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E2",
-        "placeName": "Shoreditch",
-        "slug": "london/shoreditch",
-        "longitude": -0.0755,
-        "latitude": 51.5246,
-        "listTimestamp": "2025-01-22T10:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950003",
-      "sourceId": "950003",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant Three Bedroom Duplex, Highbury N5",
-      "description": "Elegant 3-bedroom duplex in Highbury offering private balcony, underfloor heating and roof terrace.",
-      "price": "\u00a31550",
-      "priceValue": 1550,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Private Balcony",
-        "Underfloor Heating",
-        "Roof Terrace"
+        "Modern",
+        "Open Plan Kitchen",
+        "Elevator",
+        "Ample Storage",
+        "Big Windows",
+        "High Ceilings",
+        "Dishwasher",
+        "Freezer",
+        "Dryer",
+        "Washer"
       ],
       "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
+      "image": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_d6a650141e0abb1ded934168ad0b7a1275d46161aee0bd1f85847212c8e6a068.jpg",
       "images": [
         {
-          "id": "highbury-950003-1",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
+          "id": "94e015b8-9cab-4bbc-b14b-629f9377ac3d",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_d6a650141e0abb1ded934168ad0b7a1275d46161aee0bd1f85847212c8e6a068.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "highbury-950003-2",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
+          "id": "7c8dfccf-2e91-4ba2-8a4d-8c55788b73d9",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_057d71452a62764ff3c8295dd274836ff2eb8bde2615eef0044342f05f09e828.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "highbury-950003-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
+          "id": "d5f57893-fa0e-45bb-b4c8-d8e9b09aa4a4",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_b451d6d515e99f6be6791f9b52e2d1bc2fa6d8e8f7d97986fbf162df1d7e8893.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "dfe625e5-726a-45b3-beab-e5cbf2fa2027",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_d6c9272260423ae9d64b6dcea4c4cba6b3768f63ddadce041fad33d39ce0f1f1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "3096e714-d440-465f-9bb7-37e756db304b",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_e74055acb66fdc0f2ab7494e01dedea827295958fdb69018a6c8e8d52b66fb44.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "3913b221-b49e-4128-bc9d-ee5594251620",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_eddd18f0ca9306c2b94919902118f37e64e4c9c8a652d265f5d6bd2bf451f2bf.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "687c640a-dfef-4731-813d-37c7773d188c",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_fd272207e7d34f94e2f26516f777447c7a8b56f024f158172ac4df5e651051d3.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "af5cb29f-d59d-4444-af49-2598edc11d27",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_cba7960ee41c23c49ed36e3019bb718de98ad1f326b8172fe6c40867b6c94909.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "468d440c-2dc5-4044-887c-0b1d4a793c4d",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_c368aa3ba59000aef3b979f0d5cdecc121582918f14cc05efd8092823947d59d.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "7ad01872-e092-4707-9492-f3693c01ab40",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_1312c847d3cbfb2464fbe8f4fe3d22c729f43d63dcea8127b86fa05a43359c8b.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "7a3d65f0-c6f9-453b-a831-6d66df1a9030",
+          "url": "https://assets.scraye.com/photos/original-1024/6808c4f0a58a7dca8de0b842_c905886f8a9ba9ddaa8d75b2a3dee1a09def72ce84060ae05d67cd381a43f5ff.jpg",
+          "altText": "Floor Plan"
         }
       ],
       "media": [],
-      "latitude": 51.552,
-      "longitude": -0.1026,
-      "lat": 51.552,
-      "lng": -0.1026,
+      "tenure": null,
+      "size": "329 sq ft",
+      "lat": 51.48393,
+      "lng": -0.32452,
       "city": "London",
-      "county": "Greater London",
+      "county": "Hounslow",
+      "outcode": "TW8",
       "matchingRegions": [
         "London",
-        "Highbury",
-        "N5"
+        "Hounslow",
+        "Brentford End"
       ],
-      "createdAt": "2025-02-05T15:00:00Z",
-      "updatedAt": "2025-02-28T21:00:00Z",
-      "availableAt": "2025-03-11T21:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 73,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "N5",
-      "url": "https://www.scraye.com/listings/950003",
-      "externalUrl": "https://www.scraye.com/listings/950003",
+      "url": "https://www.scraye.com/listings/6808c4f0a58a7dca8de0b842",
+      "externalUrl": "https://www.scraye.com/listings/6808c4f0a58a7dca8de0b842",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "N5",
-        "placeName": "Highbury",
-        "slug": "london/highbury",
-        "longitude": -0.1026,
-        "latitude": 51.552,
-        "listTimestamp": "2025-02-05T15:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-end",
+        "longitude": -0.32452,
+        "latitude": 51.48393,
+        "listTimestamp": "2025-04-23T10:46:08Z",
+        "reference": "24485#"
       }
     },
     {
-      "id": "scraye-950004",
-      "sourceId": "950004",
+      "id": "scraye-68480047578365e0b85b631d",
+      "sourceId": "68480047578365e0b85b631d",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Modern Four Bedroom Duplex, Farringdon EC1M",
-      "description": "Modern 4-bedroom duplex in Farringdon offering cycle storage, residents gym and on-site concierge.",
-      "price": "\u00a32000",
-      "priceValue": 2000,
+      "title": "New Horizons Court, Brentford End, Hounslow, London, TW8",
+      "description": "*PROMOTION: \n- Two weeks' rent free for move-ins by 21st September.\n\nPresenting this stunning studio flat in Folberth House. The rent includes access to various convenient amenities like an on-site building manager, a covered bike garage, parking at \u00a375/month, and pets for \u00a325/month. \n\nAvailable now, this flat benefits from big windows and high ceilings. It comes with a fully equipped kitchen, an ensuite bathroom and a private terrace.\n\nThis flat is under the Council tax band B. \n\nNew Horizons Court is located minutes away from Syon Lane station and near Boston Manor Park.",
+      "price": "\u00a31,425",
+      "priceValue": 1425,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 1,
-      "propertyType": "DUPLEX",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Cycle Storage",
-        "Residents Gym",
-        "On-site Concierge"
+        "Parking",
+        "Pet Friendly",
+        "Open Plan Kitchen",
+        "High Ceilings",
+        "Modern",
+        "Big Windows",
+        "Elevator",
+        "Dishwasher",
+        "Freezer",
+        "Washer",
+        "Terrace",
+        "Dryer"
       ],
       "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
+      "image": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_017adccc6aa1cc77838c6ea16636fe172fb5701842c9b525808a9c932826b379.jpg",
       "images": [
         {
-          "id": "farringdon-950004-1",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
+          "id": "a8bf7732-f804-43f7-bbf2-2b3fbf67fa08",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_017adccc6aa1cc77838c6ea16636fe172fb5701842c9b525808a9c932826b379.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "farringdon-950004-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
+          "id": "16b53460-87ca-4d51-a4f6-2b60f844ecbf",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_b7d3a4d8d5784ac41d57976ffce5d0a42c5fbd6793969dff00b75fd3d887e80a.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "farringdon-950004-3",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
+          "id": "536eb64f-6ee4-4540-8b61-48b5967b4013",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_9ca5d2be575bd6a4cbdd18aa1fe94a6b4b296cc3a014dba8d2ef0267b1a9c53b.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "3cb7f78a-d3bf-47d6-a6d5-9dfa8b9d790b",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_57ebb260025809e9343021eb2086dc5e66b7c35096f0f54a76da9894dd787f0f.jpg",
+          "altText": "Terrace"
+        },
+        {
+          "id": "d4f519e1-7a22-44ce-b58f-f1f448117cb0",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_99fa23452492d26484466a08e1bd7c3ac711dff1a798db9f334e542df21d3ae4.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "d3e5ca75-e607-4f34-adc9-1b7bcfadbc9b",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_64cc894f922cf2871d00d2dec07057e9047daf0daa9a8dcee780bc0e25deb9d9.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "64e19e1c-c8d6-4d18-820d-52624745eff2",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_43a5851a63897aee8cae45fce3baa0b8509eca34936e0579d684fa12c3eb238e.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "e1b3b7ca-6eb2-46c7-a75a-6049fc7dc1e4",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_7965a701b38e44afb23d1320469d1c980ee09700a6bb3f6ff2d9b233990b93e2.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "0df303f9-1810-4dee-b238-388b1bcc963d",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_9cfcefbefc398278733c8c1747f8acd6bc3d81a17633469030cdbdd862f6451e.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "2919796f-2392-4062-879f-5e9e24282554",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_c4c50efa10c687a4ef8fabf5572244086a5b852119888be58744fc5010bee7e1.jpg",
+          "altText": "Terrace"
+        },
+        {
+          "id": "3cfded18-3a83-4cf8-a5c7-c5d4972682a0",
+          "url": "https://assets.scraye.com/photos/original-1024/68480047578365e0b85b631d_ab698cf2464cef59bcb747c71a4db51fe2743aef7a7e7ee114e9cdd7761438c0.jpg",
+          "altText": "Floor Plan"
         }
       ],
       "media": [],
-      "latitude": 51.5201,
-      "longitude": -0.1041,
-      "lat": 51.5201,
-      "lng": -0.1041,
+      "tenure": null,
+      "size": "340 sq ft",
+      "lat": 51.48393,
+      "lng": -0.32452,
       "city": "London",
-      "county": "Greater London",
+      "county": "Hounslow",
+      "outcode": "TW8",
       "matchingRegions": [
         "London",
-        "Farringdon",
-        "EC1M"
+        "Hounslow",
+        "Brentford End"
       ],
-      "createdAt": "2025-01-10T09:00:00Z",
-      "updatedAt": "2025-02-01T13:00:00Z",
-      "availableAt": "2025-02-21T13:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 51,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "EC1M",
-      "url": "https://www.scraye.com/listings/950004",
-      "externalUrl": "https://www.scraye.com/listings/950004",
+      "url": "https://www.scraye.com/listings/68480047578365e0b85b631d",
+      "externalUrl": "https://www.scraye.com/listings/68480047578365e0b85b631d",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "EC1M",
-        "placeName": "Farringdon",
-        "slug": "london/farringdon",
-        "longitude": -0.1041,
-        "latitude": 51.5201,
-        "listTimestamp": "2025-01-10T09:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-end",
+        "longitude": -0.32452,
+        "latitude": 51.48393,
+        "listTimestamp": "2025-06-10T09:52:07Z",
+        "reference": "25796#"
       }
     },
     {
-      "id": "scraye-950005",
-      "sourceId": "950005",
+      "id": "scraye-67a9d6bbe82736c08a11bcb5",
+      "sourceId": "67a9d6bbe82736c08a11bcb5",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Elegant Four Bedroom Duplex, Tufnell Park N7",
-      "description": "Elegant 4-bedroom duplex in Tufnell Park offering underfloor heating, residents gym and secure parking.",
-      "price": "\u00a32750",
-      "priceValue": 2750,
+      "title": "Holloway Road, Holloway, Islington, London, N7",
+      "description": "Presenting a studio to rent in Holloway. The property is on Holloway Road and comprises a bed and 1 bathroom.\n\nAvailable from the 29th of November, this modern property comes with big windows. Residents can further enjoy a gym in the building, as well as a secure entry system & CCTV. \n\nFurther features and amenities include;\n- Fully fitted kitchenette\n- Concierge\n- Bike storage\n- Laundry facility\n- Fibre Internet\n\nPlease note:\n- Bills are charged at \u00a3150 per month\n- The photos used are of a different flat in the same building. The property advertised will be similar in style but may differ slightly in layout.\n- Open to young professionals who have recently graduated, interns, and student visa applicants\n\nRegular prices are based on the length of stay:\n43 - 52 weeks = \u00a3 440 / week\n29 - 42 weeks = \u00a3 450 / week\n4 - 28 weeks = \u00a3 460 / week\nSummer Stay - Valid for Stays between 15th May - 6th September = \u00a3 410 / week\n\nThe property is located only moments away from Holloway Road Underground.",
+      "price": "\u00a31,757",
+      "priceValue": 1757,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Underfloor Heating",
-        "Residents Gym",
-        "Secure Parking"
+        "Students Allowed",
+        "Gym",
+        "Fibre Internet",
+        "Modern",
+        "Security",
+        "Concierge",
+        "Big Windows",
+        "Open Plan Kitchen",
+        "Freezer"
       ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_b6651c32f7eb8b77b474b64e946eb89de4c030b2eb9a10d121706c76e4cd1054.jpg",
       "images": [
         {
-          "id": "tufnell-park-950005-1",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
+          "id": "079cfeb9-20da-4cdd-ac86-b6f54f5f8a08",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_b6651c32f7eb8b77b474b64e946eb89de4c030b2eb9a10d121706c76e4cd1054.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "tufnell-park-950005-2",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
+          "id": "db64026d-3004-4fcf-94d5-03a8bee3ba10",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_b452cf53a3160f01c957daa937a04218970395e4572addc0945d1302846bfd31.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "tufnell-park-950005-3",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
+          "id": "2371d577-80ee-4015-92e8-902b86730bce",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_5ededf058e15868de721fe118c22f6ac5a3e47897b03f1debcd702a0eb75504a.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "e3807672-b4ee-46c6-add7-7c8d336b5ed9",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_bef33ab8b368a46810d40dd9649e43a89872594e4ae1a79f71757dfed6dd6718.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "c2b8e1a9-bbea-4359-a127-64473a4c506e",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_0012f092b5c5debb223e4db781fc4cc5e4ffc08cb50ab9c4f5ae7399e56f28a3.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "db510f2f-fa7b-4775-b4e0-8a57f1c792cb",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_22122c4fe2b28b7fa06a2818b52a6b4843c83b42a4ec305836ae0a73de8fd338.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c035c7c8-fcde-42d6-9caf-8f235cb43bf2",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_eb13756c59bac375331563c2be45f55b4fdaf3d43296610164074d9b390c80d1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "f4345e4a-fd60-425d-83b1-ff067bf96760",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_e47ff1ebeaee081b2dbbeadfac59e957f3fc1298f252af08ea56346003433be5.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "6ef8296c-2358-45ca-8353-ca7f3176ff8e",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_607f22bef1f92db1479992c893f8b8bfbdb352ce7ec0a80bb01a1e34a487d723.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "56f7dd80-c8bd-4df2-9652-b62309c6950a",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_65882ff0456d26447e1bd08def4c687adfb1fd5bc965e0da3c003779ad47b6f9.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "304e25db-e5db-41e8-b2b1-fe6b67d65e0f",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_62b67498286077f69956369352a33ad39f2e7a90860713c7932aa0294972a525.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "8a49399d-9985-4b37-aecf-2fe550c5db03",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_b6c63890119dcb93d5a099ae74cbbf10679c7a2e041cfb043e5aceb75ff3655b.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "7136a675-368b-44f1-85a3-6fe304f4ce6e",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_c50c076caca0aab6f52bf386391d078e534482f3b3709beb835b559ff452a694.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ae7f92aa-ab9a-4d78-8800-e65bfab63245",
+          "url": "https://assets.scraye.com/photos/original-1024/67a9d6bbe82736c08a11bcb5_4e2503447466254342f5dc70583e6800e8811daa73c8b40bc994e8935dc3fcbe.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5573,
-      "longitude": -0.1409,
-      "lat": 51.5573,
-      "lng": -0.1409,
+      "tenure": null,
+      "size": "139 sq ft",
+      "lat": 51.55342,
+      "lng": -0.11364,
       "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Tufnell Park",
-        "N7"
-      ],
-      "createdAt": "2025-01-20T10:00:00Z",
-      "updatedAt": "2025-02-06T18:00:00Z",
-      "availableAt": "2025-03-12T18:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 49,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
+      "county": "Islington",
       "outcode": "N7",
-      "url": "https://www.scraye.com/listings/950005",
-      "externalUrl": "https://www.scraye.com/listings/950005",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "N7",
-        "placeName": "Tufnell Park",
-        "slug": "london/tufnell-park",
-        "longitude": -0.1409,
-        "latitude": 51.5573,
-        "listTimestamp": "2025-01-20T10:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950006",
-      "sourceId": "950006",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Modern Two Bedroom Apartment, Kew TW9",
-      "description": "Modern 2-bedroom apartment in Kew offering smart home controls, 24 hour security and secure parking.",
-      "price": "\u00a31675",
-      "priceValue": 1675,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Smart Home Controls",
-        "24 Hour Security",
-        "Secure Parking"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "kew-950006-1",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "kew-950006-2",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        },
-        {
-          "id": "kew-950006-3",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4788,
-      "longitude": -0.295,
-      "lat": 51.4788,
-      "lng": -0.295,
-      "city": "London",
-      "county": "Greater London",
       "matchingRegions": [
         "London",
-        "Kew",
-        "TW9"
+        "Islington",
+        "Holloway"
       ],
-      "createdAt": "2025-01-23T10:00:00Z",
-      "updatedAt": "2025-01-29T11:00:00Z",
-      "availableAt": "2025-03-06T11:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 115,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "TW9",
-      "url": "https://www.scraye.com/listings/950006",
-      "externalUrl": "https://www.scraye.com/listings/950006",
+      "url": "https://www.scraye.com/listings/67a9d6bbe82736c08a11bcb5",
+      "externalUrl": "https://www.scraye.com/listings/67a9d6bbe82736c08a11bcb5",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "TW9",
-        "placeName": "Kew",
-        "slug": "london/kew",
-        "longitude": -0.295,
-        "latitude": 51.4788,
-        "listTimestamp": "2025-01-23T10:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/holloway",
+        "longitude": -0.11364,
+        "latitude": 51.55342,
+        "listTimestamp": "2025-02-10T10:36:43Z",
+        "reference": "22619#"
       }
     },
     {
-      "id": "scraye-950007",
-      "sourceId": "950007",
+      "id": "scraye-67ed1f25989b5a74b4de42fd",
+      "sourceId": "67ed1f25989b5a74b4de42fd",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Spacious Two Bedroom Penthouse, Kilburn NW6",
-      "description": "Spacious 2-bedroom penthouse in Kilburn offering 24 hour security, underfloor heating and city skyline views.",
-      "price": "\u00a32475",
-      "priceValue": 2475,
+      "title": "First Way, Brent, London, HA9",
+      "description": "Presenting a studio to rent in Wembley. The property is on First Way and comprises a bed and 1 bathroom.\n\nAvailable now. Covering 217 sq ft in living space, this modern property comes with ample storage and high ceilings. The property also benefits from a communal terrace. Residents can further enjoy a gym in the building, as well as 24-hour security. \n\nFurther features and amenities include:\n- Air conditioning, a rare feature in London\n- Private fitted kitchen\n- Wi-Fi\n- On-site team 24/7\n- Co-working spaces\n- Laundry facilities (additional charges may apply)\n- Cinema room\n- Meeting room\n- Media room\n- Cleaning service\n- Bicycle storage\n- Parking is available at \u00a3150pcm\n\nPlease note:\n- The price shown is for a single occupant; there will be an uplift of \u00a3200pcm for dual occupancies.\n- The price shown is for 12-month tenancies only; shorter tenancies are available at the following rates:\n- 3-6 months at \u00a31,899pcm (including bills)\n- 6-8 months at \u00a31,799pcm (including bills)\n- 9-11 months at \u00a31,799pcm (including bills)\n- Pricing may vary slightly depending on the floor and layout.\n- These rates include all bills, access to amenities/ co-working spaces, bi-weekly cleaning services, and more.\n\nThe property is located only moments away from Wembley Stadium Station.",
+      "price": "\u00a31,599",
+      "priceValue": 1599,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "PENTHOUSE",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "24 Hour Security",
-        "Underfloor Heating",
-        "City Skyline Views"
+        "Fibre Internet",
+        "Gym",
+        "Modern",
+        "High Ceilings",
+        "Air Conditioning",
+        "Ample Storage",
+        "Security",
+        "Open Plan Kitchen",
+        "Short Lets Available",
+        "Students Allowed",
+        "Terrace",
+        "Refurbished",
+        "New Build",
+        "Great View",
+        "Quiet Street",
+        "Concierge",
+        "Dishwasher",
+        "Elevator",
+        "Freezer",
+        "Big Windows",
+        "All Bills Included",
+        "Parking"
       ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_0fa445218b72467f2faed5792d76e1528eed496ec76be493622550f06028b256.jpg",
       "images": [
         {
-          "id": "kilburn-950007-1",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
+          "id": "7f3a9c2c-d397-4f5d-a6c0-2b3649fffe52",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_0fa445218b72467f2faed5792d76e1528eed496ec76be493622550f06028b256.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "kilburn-950007-2",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
+          "id": "3b7ba155-cb2b-4102-a479-ca7482d91a55",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_8ae4407a3e809cd4326d67f8118d71051c698f2b704b42b32e01d1a39ce19532.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "kilburn-950007-3",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
+          "id": "fca60eb0-3540-4a68-a538-86bf06c6798e",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_1849804d7ae262ddc4357f978f0f26c5c6d7a1cd9a4154dbf8c76866287acf9c.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "e7a2f06c-1f3f-4e83-b103-73b1729f0770",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_0e1db449260ad2c70d68b81b16bd8c8d30a320876b7fec7c6d4956f6df72bf83.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "93f49215-8d8a-4f6f-800b-59eb20eae3b8",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_123eb93493a161b25f57df5913ac1e175a35a12affa8a8a64f0f8d97b9b60931.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "70edc186-3e91-48b6-986f-7dd6cf346c1c",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_5560099e072ae578500dfe322d09d536c87c8d77501bdae52bdd1721b9b15348.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "fac68309-e5a0-42f0-8e16-5a7d468885b2",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_546f3e1905cd788b4f3e5d90fa29f720bdc29b21f70a4cff8c63c8ed8e9c910c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "52a916bc-701b-4d1a-bad3-db62d2780912",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_6ecf2c2ff8a17f5e086a0050d02a1f28a3a0c7977dce3fbc9447e0f6cb27e0a0.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "42bba1d9-04f4-42c3-97e6-65a491391257",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_79e71a894d8cd206f066d96dbc3a62e862b4961f5576d3f83f2fd90d44e3aa3d.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "eda7372b-5992-4681-859d-91aed7bfe4f9",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_18400599a73fb0bd0aada0100495314250faa5f4f3acb1e5073b591383f3baa3.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "7616b2e0-c1ff-46ad-853f-5c792c9d243c",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_0a61fd254cf061a44d4eb0dd965c2d0eb313e74353e300bcb77a39750b5e11f7.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "09f14d46-a0ed-4a00-8242-d4b7f81330af",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_fc7ff112d290c270827665d882fc0dcbe8c5b75b674371952f316ee90c495451.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "f3a82808-a4c9-40e3-96f0-7b1fedf3f9d5",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_087429f8f4b4b6fc28f56c209351c85952530b12dff393596843625c576e481b.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "a894a71a-9b99-48cf-b8d6-faa83ede041b",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_25c5204099683a471fc4b182dbd1aa766348cad343e7a03840029d15635a749e.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "3cec5357-d12d-456f-bd1a-a191f841f922",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_f641ad759d72626a03383ba0f95b2d0b209d1f94d1c9028d3988daa6dde376a0.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "88302356-ba12-4eeb-a6d4-0578ba975780",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_afdbe7bcb3683d9f591885f346d6bb7ab2456fac358774ee484660a21192ef87.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "5a915c88-807c-4923-9a41-a79e8cebb47a",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_e794139fbfc7d33cca33ba6c558cb9cbe5f67f971523a396959118c6c87bfdb6.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "885fd025-c035-4fc2-96b8-ceab2aa333bd",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_5a01d674e606b6d7251a4deffd9f1cec62dbeb9c41f9baadfbb9c523b3e130b2.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "40161774-c869-4327-9fdd-a9df0553c1b0",
+          "url": "https://assets.scraye.com/photos/original-1024/67ed1f25989b5a74b4de42fd_a5d1ad753700b763588a080d3a8f6c290d8a612deb3995ba5cb8ae5cf8ec69a0.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5465,
-      "longitude": -0.1913,
-      "lat": 51.5465,
-      "lng": -0.1913,
+      "tenure": null,
+      "size": "217 sq ft",
+      "lat": 51.55784,
+      "lng": -0.27379,
       "city": "London",
-      "county": "Greater London",
+      "county": "Brent",
+      "outcode": "HA9",
       "matchingRegions": [
         "London",
-        "Kilburn",
-        "NW6"
+        "Brent"
       ],
-      "createdAt": "2025-02-09T09:00:00Z",
-      "updatedAt": "2025-02-15T13:00:00Z",
-      "availableAt": "2025-03-28T13:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 87,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "NW6",
-      "url": "https://www.scraye.com/listings/950007",
-      "externalUrl": "https://www.scraye.com/listings/950007",
+      "url": "https://www.scraye.com/listings/67ed1f25989b5a74b4de42fd",
+      "externalUrl": "https://www.scraye.com/listings/67ed1f25989b5a74b4de42fd",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "NW6",
-        "placeName": "Kilburn",
-        "slug": "london/kilburn",
-        "longitude": -0.1913,
-        "latitude": 51.5465,
-        "listTimestamp": "2025-02-09T09:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brent",
+        "longitude": -0.27379,
+        "latitude": 51.55784,
+        "listTimestamp": "2025-04-02T11:27:33Z",
+        "reference": "23967#"
       }
     },
     {
-      "id": "scraye-950008",
-      "sourceId": "950008",
+      "id": "scraye-680e782e9cb515ab4f018bb5",
+      "sourceId": "680e782e9cb515ab4f018bb5",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Spacious One Bedroom Apartment, Camden NW1",
-      "description": "Spacious 1-bedroom apartment in Camden offering roof terrace, secure parking and on-site concierge.",
-      "price": "\u00a31550",
-      "priceValue": 1550,
+      "title": "Market Road, Lower Holloway, Islington, London, N7",
+      "description": "Presenting a room to rent in Islington. The property is on Market Road and comprises a bed and 1 bathroom.\n\nAvailable from the 1st of November, this modern property comes with big windows and ample storage. Residents can further enjoy a gym in the building, as well as a secure entry system & CCTV. \n\nFeatures include:\n- Fully fitted shared kitchen\n- Concierge\n- Lift\n- Bike storage\n- Laundry facility\n- Dual-Band Wi-Fi\n- Social spaces\n\nPlease note:\n- Bills are charged at \u00a3150 per month\n- Open to young professionals who have recently graduated, interns, and student visa applicants\n- Regular prices are based on the length of stay:\n43 - 52 weeks = \u00a3 430 / week\n29 - 42 weeks = \u00a3 440 / week\n4 - 28 weeks = \u00a3 450 / week\n\nThe property is located only moments away from the Caledonian Road Underground.",
+      "price": "\u00a31,713",
+      "priceValue": 1713,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 1,
+      "bedrooms": -1,
       "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Roof Terrace",
-        "Secure Parking",
-        "On-site Concierge"
+        "Students Allowed",
+        "Gym",
+        "Fibre Internet",
+        "Modern",
+        "Security",
+        "Concierge",
+        "Big Windows",
+        "Ample Storage",
+        "Elevator"
       ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_e91ea54dcfee9055a18e90012273ddf28ee7e34e9e638e5d7b12f47ba34cd6a3.jpg",
       "images": [
         {
-          "id": "camden-950008-1",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
+          "id": "a8610a06-9632-4fec-b845-b504a1e14e65",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_e91ea54dcfee9055a18e90012273ddf28ee7e34e9e638e5d7b12f47ba34cd6a3.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "camden-950008-2",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
+          "id": "9e94c361-4e38-4f93-be41-798bc10ef6cf",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_5cdbdfed0a70a55a2ea029c08c81d4bbed47563a7d67f7720c364abeec8e8d2f.jpg",
+          "altText": "Bathroom"
         },
         {
-          "id": "camden-950008-3",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
+          "id": "c1baca37-dc20-4870-b642-22916d0af675",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_c3e07de8c23fc01bd2d98a3acc84d68a15f052ab56c633e7503add3769c0a060.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "27915a7f-e926-4cd3-9af4-badf5be7645c",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_abf4c5c1e54cd6358578d7b46c79adad7c5d17f2f7da81a8f857d0a0bf92745f.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "191bec0e-1eff-4c06-a668-b5ed5c7d8a88",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_0e326ba7042dfef8fbbaf338e5647ae2ff9e3572e61f40aa7561768957a01c90.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "419d4427-9dcb-4cc7-8f95-5b3186b6b7fa",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_f5444c33cd4b27471f3a51f32e22c73af94abf753617edda1e35c84c47c1eed1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "37973019-43ac-45d0-8994-50f908da1a6d",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_14e5ce8827b2bf3e65435a1f183da0d3911682b36d1627dca141a02259662763.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "2142c07e-6ab8-4bfa-9635-c4f3373bc9c0",
+          "url": "https://assets.scraye.com/photos/original-1024/680e782e9cb515ab4f018bb5_e63da9c329d273abcf84c798b612df9e26c9d74ae775ebaa6a92730a99560236.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5416,
-      "longitude": -0.1432,
-      "lat": 51.5416,
-      "lng": -0.1432,
+      "tenure": null,
+      "size": "0 sq ft",
+      "lat": 51.54683,
+      "lng": -0.12064,
       "city": "London",
-      "county": "Greater London",
+      "county": "Islington",
+      "outcode": "N7",
+      "matchingRegions": [
+        "London",
+        "Islington",
+        "Lower Holloway"
+      ],
+      "url": "https://www.scraye.com/listings/680e782e9cb515ab4f018bb5",
+      "externalUrl": "https://www.scraye.com/listings/680e782e9cb515ab4f018bb5",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/lower-holloway",
+        "longitude": -0.12064,
+        "latitude": 51.54683,
+        "listTimestamp": "2025-04-27T18:32:14Z",
+        "reference": "24619#"
+      }
+    },
+    {
+      "id": "scraye-68517cc29565ec6cc4207858",
+      "sourceId": "68517cc29565ec6cc4207858",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "First Way, Brent, London, HA9",
+      "description": "Presenting a studio to rent in Wembley. The property is on First Way and comprises a bed and 1 bathroom.\n\nAvailable now. Covering 217 sq ft in living space, this modern property comes with ample storage and high ceilings. The property also benefits from a communal terrace. Residents can further enjoy a gym in the building, as well as 24-hour security. \n\nFurther features and amenities include:\n- Air conditioning, a rare feature in London\n- Private fitted kitchen\n- Wi-Fi\n- On-site team 24/7\n- Co-working spaces\n- Laundry facilities (additional charges may apply)\n- Cinema room\n- Meeting room\n- Media room\n- Cleaning service\n- Bicycle storage\n- Parking is available at \u00a3150pcm\n\nPlease note:\n- The price shown is for a single occupant; there will be an uplift of \u00a3200pcm for dual occupancies.\n- The price shown is for 12-month tenancies only; shorter tenancies are available at the following rates:\n- 3-6 months at \u00a31,899pcm (including bills)\n- 6-8 months at \u00a31,799pcm (including bills)\n- 9-11 months at \u00a31,799pcm (including bills)\n- Pricing may vary slightly depending on the floor and layout.\n- These rates include all bills, access to amenities/ co-working spaces, bi-weekly cleaning services, and more.\n\nThe property is located only moments away from Wembley Stadium Station.",
+      "price": "\u00a31,599",
+      "priceValue": 1599,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Fibre Internet",
+        "Gym",
+        "Modern",
+        "High Ceilings",
+        "Air Conditioning",
+        "Ample Storage",
+        "Security",
+        "Open Plan Kitchen",
+        "Short Lets Available",
+        "Students Allowed",
+        "Terrace",
+        "Refurbished",
+        "New Build",
+        "Great View",
+        "Quiet Street",
+        "Concierge",
+        "Dishwasher",
+        "Elevator",
+        "Freezer",
+        "Big Windows",
+        "All Bills Included",
+        "Parking"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_840aafa97620635b8bbb44a2f3b97c6c4cd43899ee2078bc99b79df1301f2831.jpg",
+      "images": [
+        {
+          "id": "f74721c8-381d-41af-a4c7-a0992fef15fe",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_840aafa97620635b8bbb44a2f3b97c6c4cd43899ee2078bc99b79df1301f2831.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "b51df201-5567-4efd-8cdb-041f4df9706c",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_5d04495285b123e8212dd376937a049f243535e0cd061114af98add16b73d553.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "0bfbcad5-164a-4513-8d6b-8149c1e7d3e9",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_58153db5599e80f7cd2fc9bb0a62f53993bea690b2ab0a7b29af8fffbfc932f2.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "bd9d873c-79e7-4d44-8580-657d09834050",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_6905de65da2690bf194083957aa7ac6e5587b3fe36e1f90bb294e82361ef9008.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "ac001241-c3e5-4ae5-b094-4174d6e24e3c",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_ee864f60fd47d69ca5629ce058a1291a7bd83dea98a5fdaea2995dd82c6af10b.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "96c877ea-4bd5-436d-932d-5a42dcd948b3",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_9cf8f98ab2d40299a8ba7748edaeb51458bc3f151fb3b14605e2ea2a3b485c6a.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "76b614b9-8540-472e-992f-caa400b13d34",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_48b05b758492e866b68f012879a26f5efb914216cb0ba895ad0ad6ac47a5b62e.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "e67ac474-8554-4f99-b7be-b21c89d53e45",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_0de7b492ea1a8070e54113db9e482612a601a877077e75c6282e7a3e7d7781ab.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "323b5d0a-0c06-445b-bc66-c8c89e4541e6",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_507ffc661347924329e551452c2a8e782e5046f5fe790aa36e730d43cb2766fe.jpg",
+          "altText": "Terrace"
+        },
+        {
+          "id": "547f7f0d-1b7a-43f0-98df-7e38900a968d",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_e58a5e3660ae950f5d411996e6b7ea44cfb4e51b06f560d3dc698be2e88f778d.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "74db64af-926c-4455-a085-3ddac86770c8",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_8ba513f906383bba9436de54eaf3e21860abd8c3c4889e22baa190a196f1e100.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "8909c083-489c-43c6-aa27-24295a85cbdd",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_1913ab342857557d84e8e5caf137e5eea9bd052dcf2e9da4bc0ad2c40be46cb3.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "c0a1cb06-2d38-416f-8aba-555af7166587",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_58a0755bb5d3862a8e920711dabed79a7acba147bd6d2ebb72f2a9b2438e7bf4.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "5f1b3f2c-9e34-4890-bd3e-18e989b1f29f",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_5e7b424337f8e9ef89bd8698125e7448f991b40d5d7bd793ad2a1095a2d3c1e8.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "5ea45214-3e8b-4382-be99-73249e2d066d",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_2abb463e52f283bb13924fc4e3956f517c0a0dcb059bd28e0165a76605e6db74.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "da841544-adfe-47ef-b624-bcf9748906cd",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_ee246c106504a478d5d8e728894442a6adafad516e488369d8cf4edbfce8bb7d.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "278aab8f-f027-4ce9-a638-2e8c5eab8153",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_bd44a7bcacb6f5a8fadc5cc49f53a88df46646ac2a88c0d1be9afe296984ce67.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "ba7e94da-9eb3-4b2b-98f0-95808c7d4e31",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_aa74010736c938b65abb1982809204b1df3f8408d6e544ede8c727187ae01851.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "31e2cc5b-57f3-4074-a1de-00b3f94035b2",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_4e7bb7b7060e25219abd3c58ef1a7371a06ee2f701dcf982576a990876d9db90.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "5c83a43c-4314-4667-833a-273511569d86",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_4a9c6adcb80063929273a8c66834258c15e7fb16b7680d22d329c8c1717863d7.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "0a128a3c-f8a9-4f1c-9b7b-afced13a3472",
+          "url": "https://assets.scraye.com/photos/original-1024/68517cc29565ec6cc4207858_e299c6322f2daaa13d4ea38a69c9f671bb8eb9086a393e750be5082a5aa2645f.jpg",
+          "altText": "Other"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "217 sq ft",
+      "lat": 51.55784,
+      "lng": -0.27379,
+      "city": "London",
+      "county": "Brent",
+      "outcode": "HA9",
+      "matchingRegions": [
+        "London",
+        "Brent"
+      ],
+      "url": "https://www.scraye.com/listings/68517cc29565ec6cc4207858",
+      "externalUrl": "https://www.scraye.com/listings/68517cc29565ec6cc4207858",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brent",
+        "longitude": -0.27379,
+        "latitude": 51.55784,
+        "listTimestamp": "2025-06-17T14:33:38Z",
+        "reference": "26045#"
+      }
+    },
+    {
+      "id": "scraye-686bef89775965fef9bc4283",
+      "sourceId": "686bef89775965fef9bc4283",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Anson Road, Brondesbury, Brent, London, NW2",
+      "description": "A lovely and convenient studio flat to rent in Cricklewood, in Anson Road.\n\nAvailable from the 14th of December. This studio is offered furnished, and the kitchenette includes a fridge, hob, oven, microwave and storage.\n\n* Please note:\n- This studio has an ensuite bathroom with a shower \n- The studio is only suitable for single or double occupancy\n- In addition to the rent, the landlord charges a fixed monthly fee of \u00a3140 for bills (water, council tax, in-house maintenance), excluding electricity.\n- This property is pet-friendly, subject to the type of pet. Please enquire for more details.\n- Shortlet available (1-4 months at \u00a31,705pcm)\n\nAnson Road is conveniently located within a 10-minute walk to either the Willesden Green underground station or the Cricklewood train station.",
+      "price": "\u00a31,224",
+      "priceValue": 1224,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Students Allowed",
+        "Big Windows",
+        "Terrace",
+        "Pet Friendly"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_6c66afd954073e15e41944363fcc73ae9e411811009ccb3c9bacb7bdbffefa98.jpg",
+      "images": [
+        {
+          "id": "dc172486-fcf5-4434-9ece-226b6e55436a",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_6c66afd954073e15e41944363fcc73ae9e411811009ccb3c9bacb7bdbffefa98.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "3ce9d439-5bfb-4c1b-a0b7-3159d3ef05fc",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_ccb8179b78af84258fa42e431998568e3273bb114ce02b3ec73f6e962a0770b5.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "38b7ccca-34d4-430c-88c3-1829406fd90f",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_4d320ab45314247712959b808b21a2a248b37678cd16c0cd1cf93f56fe49b813.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "e6916e1d-7fc2-4248-9bc1-1af43ca8a081",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_9139ef72bb6b6dfa184011f58adcd5521a87e98ecbf4169e224e2da73ce35547.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "2b33d95e-3e8e-4802-a7ee-aae3b6853713",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_d7d047f8342ab372b73bf90ad2d0342dc310d2c83d2831c7c34888a5423e13c8.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "f07d3f52-9c41-4d35-b978-47af7236dfaa",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_f7888ef2cff3a466b3f9287e05d20a965017abad2ca7cd2c6cefba07fa218cd7.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "094c099a-cd1b-4927-bb57-79406eb7bcca",
+          "url": "https://assets.scraye.com/photos/original-1024/686bef89775965fef9bc4283_ad7ac9ac35f1621e8a29c149ecc6b5298c0254d8d1414669f4c8387726cd5445.jpg",
+          "altText": "Bathroom"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "0 sq ft",
+      "lat": 51.55393,
+      "lng": -0.21497,
+      "city": "London",
+      "county": "Brent",
+      "outcode": "NW2",
+      "matchingRegions": [
+        "London",
+        "Brent",
+        "Brondesbury"
+      ],
+      "url": "https://www.scraye.com/listings/686bef89775965fef9bc4283",
+      "externalUrl": "https://www.scraye.com/listings/686bef89775965fef9bc4283",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brondesbury",
+        "longitude": -0.21497,
+        "latitude": 51.55393,
+        "listTimestamp": "2025-07-07T16:02:17Z",
+        "reference": "26933#"
+      }
+    },
+    {
+      "id": "scraye-686fe1715176f8d903bcd5cf",
+      "sourceId": "686fe1715176f8d903bcd5cf",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Balmoral Road, Dudden Hill, Brent, London, NW2",
+      "description": "A lovely studio to rent in Willesden Green on Balmoral Road.\n\nAvailable from the 12th of November. This studio is offered furnished and the kitchenette includes a fridge, hob, oven, microwave and storage.\n\n* Please note:\n- This studio has an ensuite bathroom with a shower \n- There are shared laundry facilities available on site.\n- In addition to the rent, the landlord charges a fixed monthly fee of \u00a3140 for bills (water, council tax, in-house maintenance), excluding electricity.\n- This property is pet-friendly, subject to the type of pet. Please enquire for more details.\n- Shortlet available (1-4 months at \u00a31,705pcm including bills)\n\nBalmoral Road is conveniently located within a few minutes walk from both Queen's Park and Kilburn Park underground stations.",
+      "price": "\u00a31,251",
+      "priceValue": 1251,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Students Allowed",
+        "Big Windows",
+        "Pet Friendly",
+        "Short Lets Available"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_d85a0fb2c247fefe9d81c648aacd0aa7acde1cd122f92dfc3ee5b0224264078b.jpg",
+      "images": [
+        {
+          "id": "94291e46-f9ec-419a-846d-a56417bb05f7",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_d85a0fb2c247fefe9d81c648aacd0aa7acde1cd122f92dfc3ee5b0224264078b.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "1f1134be-153d-4339-b10b-33cac1f35516",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_0fe83b0fd79a5bbcb563a5b38253509fe45a8d8a8f44e2b700a7a4af5673ec66.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "e7091329-8aa4-43e1-bf4c-d0876776c4cd",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_91dcefa4c7e339f539e5b7924b061caee9ce6c988945c8f88323c37453809c43.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "68f766f3-14b1-4b3c-9dc3-c76a13a69370",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_2667e2fc439f88053f64fd58f8b0f18b6270eaa6f6324ccdb0eb61b9505d7e6f.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "0a2a06e3-56e3-481c-a1b3-67acf446eb21",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_5664dbbeb0adcbb21577f53d102e28ae5a237ef20067548059d60a5ecffdb0b7.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "a5d4be21-5080-4a2a-b154-ef84c71e4b67",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_284458ba371229199fa305a1f693efa1a408329ae57fa7fa5aeb7bcb44f5f4f1.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "d49a5db9-74c5-4ac6-8ebe-a189725855a4",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_d81dc2bdc158b893b82342a2e24e8188e274a78d54da0a89930cd333382109a6.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "d36028fc-b061-4914-90d0-3569d6ac3929",
+          "url": "https://assets.scraye.com/photos/original-1024/686fe1715176f8d903bcd5cf_729331af4c9b988662bc48f90618a901244145501c2a05ed713aa7679467c0f3.jpg",
+          "altText": "Bathroom"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "269 sq ft",
+      "lat": 51.5493,
+      "lng": -0.22877,
+      "city": "London",
+      "county": "Brent",
+      "outcode": "NW2",
+      "matchingRegions": [
+        "London",
+        "Brent",
+        "Dudden Hill"
+      ],
+      "url": "https://www.scraye.com/listings/686fe1715176f8d903bcd5cf",
+      "externalUrl": "https://www.scraye.com/listings/686fe1715176f8d903bcd5cf",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/dudden-hill",
+        "longitude": -0.22877,
+        "latitude": 51.5493,
+        "listTimestamp": "2025-07-10T15:51:13Z",
+        "reference": "27131#"
+      }
+    },
+    {
+      "id": "scraye-68c978cbc8f4c15af697ce23",
+      "sourceId": "68c978cbc8f4c15af697ce23",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Holloway Road, Holloway, Islington, London, N7",
+      "description": "Presenting a studio to rent in Holloway. The property is on Holloway Road and comprises a bed and 1 bathroom.\n\nAvailable from the 8th of November, this modern property comes with big windows. Residents can further enjoy a gym in the building, as well as a secure entry system & CCTV. \n\nFurther features and amenities include;\n- Fully fitted kitchenette\n- Concierge\n- Bike storage\n- Laundry facility\n- Fibre Internet\n- Short let available\n\nPlease note:\n- Bills are charged at \u00a3150 per month\n- The photos used are of a different flat in the same building. The property advertised will be similar in style but may differ slightly in layout.\n- Open to young professionals who have recently graduated, interns, and student visa applicants\n- Regular prices are based on the length of stay:\n43 - 52 weeks = \u00a3 415 / week\n29 - 42 weeks = \u00a3 425 / week\n4 - 28 weeks = \u00a3 435 / week\nSummer Stay - Valid for Stays between 31st May - 6th September = \u00a3 390 / week\n\nThe property is located only moments away from Holloway Road Underground.",
+      "price": "\u00a31,648",
+      "priceValue": 1648,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Students Allowed",
+        "Gym",
+        "Fibre Internet",
+        "Modern",
+        "Security",
+        "Concierge",
+        "Big Windows",
+        "Open Plan Kitchen",
+        "Freezer",
+        "Short Lets Available"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_0f9a8a85141e401b6de972d8271451a77e777b7020aa6a626a9fcc5ce7850abd.jpg",
+      "images": [
+        {
+          "id": "d0a21289-07f1-440c-b39a-a13e8937618d",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_0f9a8a85141e401b6de972d8271451a77e777b7020aa6a626a9fcc5ce7850abd.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "1b74b734-c14f-4ccd-9247-878515b89882",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_bb41951b580b868c1e3e9de18c1be2eb50c541930e46e64f47c76905e7633c24.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "b6372f19-e068-4a24-8c9d-b05ae8c68e74",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_73c6fe215abb549bd7d0718e3e2f0ecb55f29aa64b804828244bf316368c43ef.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "2a0a6cf6-73ee-4495-80a3-7902f580eec1",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_a327b24b4655fbec21f9b77cfb96c8f07617238719cd6727ef2844727fb1c61c.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "bb220606-de05-47f5-8ad9-34391dcfd377",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_c2def0daeb5b5c8da4bfa67d9a7cfa3ac399b0e747e89be6d46b2dd6a94accfb.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "6a3fced2-e263-4e7d-9756-92cd775272f7",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_8a8d3367adff35ba2256958cb8b5e7d993bd5d16901b251ffa56fc68d9b08abd.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "4c0017d4-72cf-4c8a-9734-86e0ee5bb3cd",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_e0f2042342ed8782f96b16a7c55b1d7c936589bb0a2cce548a6c2eb556ab77fa.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "42013e77-a7b2-4175-b3ca-905e0df6c09a",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_8d16c4cbd1b3b3199752454c4d2c3942f12c13fabcf123a572c1091b848da23f.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "4246057e-68db-4ff9-8dc4-7ddc31d3464a",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_7cf25e62836023955856daf1f69b995349ee006f128c7d2e1c1deee0aab4217b.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "5d22a3e5-498d-434b-bad9-abd1b09b4c5d",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_bc1233bc86fe232ddf69d282bfc2bb75abdc403ae4540e8c00d6fc7672da2e48.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "fe3ebf55-bb07-4474-9973-dcfb614806ee",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_2ec3cc06a67d02349f84fd62fb32647d24c29c25c3f244b1a42cbc4f0d8de006.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "b76b462a-61b5-43b6-91d8-dc9cc5e55926",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_109d0a9589e9ff093b13a9277d4def03b562d31226e751283e964648c8f60841.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "b829c21a-3103-4130-b6f8-749837fb8de5",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_092175173635691b1ff1c0e217cd5e5761e3e344d6346e70b0ab84827f73c503.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "14753f74-3e31-4a2c-9486-b9b1172e4c55",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_c53efe3309963b48bae2a8ec1606144ec89d5daf6b78cde5865cf4dc60c82db5.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "fab419f5-2034-4943-bcbd-1eb18c5c108d",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_9ddfb2eaaa59df2908573f7d012bfe39ea6647adf3e54a75e51157f002f39e89.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "98187a66-6301-4635-af0e-e1c108fe783c",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_285ade61b57d7ec184540779b7fbf15ef76de4f7b958ffebcc442df4180d82a1.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "382be192-e5e7-4e85-900a-3837337e55f2",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_6e720b2c23993236276a3a73ed0b53c3583d2acf7b85df051a249855d219f544.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "fb3028f3-3598-44d3-8564-5e3eef0ca989",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_56a14656a5f0aca0c55dbbb862d14c1abaa2da6c185c8d376311b049dbe9b131.jpg",
+          "altText": "Other"
+        },
+        {
+          "id": "f9d31239-98a8-4bd2-af08-632947805381",
+          "url": "https://assets.scraye.com/photos/original-1024/68c978cbc8f4c15af697ce23_8bf5a5a7c9c9f87f25cf655646e36139dd37934d55312d64a1a7756f0706e59e.jpg",
+          "altText": "Other"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "129 sq ft",
+      "lat": 51.55342,
+      "lng": -0.11364,
+      "city": "London",
+      "county": "Islington",
+      "outcode": "N7",
+      "matchingRegions": [
+        "London",
+        "Islington",
+        "Holloway"
+      ],
+      "url": "https://www.scraye.com/listings/68c978cbc8f4c15af697ce23",
+      "externalUrl": "https://www.scraye.com/listings/68c978cbc8f4c15af697ce23",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/holloway",
+        "longitude": -0.11364,
+        "latitude": 51.55342,
+        "listTimestamp": "2025-09-16T14:48:43Z",
+        "reference": "28490#"
+      }
+    },
+    {
+      "id": "scraye-67eeccef2b2e2e69f8863020",
+      "sourceId": "67eeccef2b2e2e69f8863020",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Cartwright Gardens, St Pancras, Camden, London, WC1H",
+      "description": "Presenting a refurbished studio to rent in Bloomsbury on Cartwright Gardens.\n\nAvailable now, covering 140 sq. ft. of living space and situated on the first floor, this modern property comes with high ceilings, big windows and ample storage. The property also benefits from great views and access to a communal garden. \n\nFurther features and amenities include:\n- Air conditioning, a rare feature in London (available in the summer months)\n- Fitted kitchenette\n- Wood floors\n- Fibre optic WIFI broadband\n- Digital TV/selected Sky channels\n- Shared laundry/ironing facilities (open 8 am-8 pm)\n- 24-hrs Concierge\n\nPlease note:\n- Bills are charged at \u00a3150 per month for water, electricity, heating, laundry services and high-speed WiFi.\n- The photos used are of a different flat in the same building. The property advertised will be similar in style but may differ slightly in layout.\n\nThe flat is under the Council Tax band A. The property is located only moments away from King's Cross St. Pancras Underground.",
+      "price": "\u00a32,017",
+      "priceValue": 2017,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Modern",
+        "Refurbished",
+        "Fibre Internet",
+        "Big Windows",
+        "High Ceilings",
+        "Ample Storage",
+        "Open Plan Kitchen",
+        "Great View",
+        "Freezer",
+        "Students Allowed",
+        "Concierge",
+        "Air Conditioning"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_d06806bb18b04e77e1ef85b99815441770d32ad0953c2e1a5839946dd4b0bb03.jpg",
+      "images": [
+        {
+          "id": "9bf1f5b0-39c8-4f9e-afc6-c8c1a7f02f9f",
+          "url": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_d06806bb18b04e77e1ef85b99815441770d32ad0953c2e1a5839946dd4b0bb03.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "4b77cf57-6acd-479e-a801-bb46e6ffe024",
+          "url": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_8181f1e623f74f459ac3d040499b4f63aa0eae29d6037da102fbd240a3e08111.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "367f9434-0f40-430b-a3cd-a1aabaeab3cd",
+          "url": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_74804739b690e1d32caf50ce2ef9b071e0f60369573f66c4f59a40be08f13f09.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "0b2adad6-cfe7-4d58-b129-4248babdbe8e",
+          "url": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_475e854a9299997e8dac9b95fe072b2845ee8f41a832242a8e609b7a01464f5f.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "cd3393c6-85f4-419b-a5a1-8899b3e06cc1",
+          "url": "https://assets.scraye.com/photos/original-1024/67eeccef2b2e2e69f8863020_fc04a2ff1bbf7c63e2b81adfc33a2512a63acd7ef26247ca407c6c0c3a3cfcf1.jpg",
+          "altText": "Building"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "140 sq ft",
+      "lat": 51.52749,
+      "lng": -0.1275,
+      "city": "London",
+      "county": "Camden",
+      "outcode": "WC1H",
       "matchingRegions": [
         "London",
         "Camden",
-        "NW1"
+        "St Pancras"
       ],
-      "createdAt": "2025-01-10T10:00:00Z",
-      "updatedAt": "2025-02-07T12:00:00Z",
-      "availableAt": "2025-02-18T12:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 78,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "NW1",
-      "url": "https://www.scraye.com/listings/950008",
-      "externalUrl": "https://www.scraye.com/listings/950008",
+      "url": "https://www.scraye.com/listings/67eeccef2b2e2e69f8863020",
+      "externalUrl": "https://www.scraye.com/listings/67eeccef2b2e2e69f8863020",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "NW1",
-        "placeName": "Camden",
-        "slug": "london/camden",
-        "longitude": -0.1432,
-        "latitude": 51.5416,
-        "listTimestamp": "2025-01-10T10:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/st-pancras",
+        "longitude": -0.1275,
+        "latitude": 51.52749,
+        "listTimestamp": "2025-04-03T18:01:19Z",
+        "reference": "24074#"
       }
     },
     {
-      "id": "scraye-950009",
-      "sourceId": "950009",
+      "id": "scraye-689a1f9057f012be21d58071",
+      "sourceId": "689a1f9057f012be21d58071",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Contemporary Two Bedroom Maisonette, Chiswick W4",
-      "description": "Contemporary 2-bedroom maisonette in Chiswick offering concierge service, secure parking and 24 hour security.",
-      "price": "\u00a32850",
-      "priceValue": 2850,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Concierge Service",
-        "Secure Parking",
-        "24 Hour Security"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "chiswick-950009-1",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        },
-        {
-          "id": "chiswick-950009-2",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        },
-        {
-          "id": "chiswick-950009-3",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        }
-      ],
-      "media": [],
-      "latitude": 51.494,
-      "longitude": -0.2673,
-      "lat": 51.494,
-      "lng": -0.2673,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Chiswick",
-        "W4"
-      ],
-      "createdAt": "2025-01-20T09:00:00Z",
-      "updatedAt": "2025-02-08T17:00:00Z",
-      "availableAt": "2025-03-15T17:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 56,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "W4",
-      "url": "https://www.scraye.com/listings/950009",
-      "externalUrl": "https://www.scraye.com/listings/950009",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "W4",
-        "placeName": "Chiswick",
-        "slug": "london/chiswick",
-        "longitude": -0.2673,
-        "latitude": 51.494,
-        "listTimestamp": "2025-01-20T09:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950010",
-      "sourceId": "950010",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant One Bedroom House, Clapham SW4",
-      "description": "Elegant 1-bedroom house in Clapham offering floor to ceiling windows, private balcony and city skyline views.",
-      "price": "\u00a31900",
-      "priceValue": 1900,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Floor to Ceiling Windows",
-        "Private Balcony",
-        "City Skyline Views"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "clapham-950010-1",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        },
-        {
-          "id": "clapham-950010-2",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        },
-        {
-          "id": "clapham-950010-3",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        }
-      ],
-      "media": [],
-      "latitude": 51.462,
-      "longitude": -0.138,
-      "lat": 51.462,
-      "lng": -0.138,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Clapham",
-        "SW4"
-      ],
-      "createdAt": "2025-01-07T16:00:00Z",
-      "updatedAt": "2025-01-17T18:00:00Z",
-      "availableAt": "2025-02-24T18:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 85,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW4",
-      "url": "https://www.scraye.com/listings/950010",
-      "externalUrl": "https://www.scraye.com/listings/950010",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW4",
-        "placeName": "Clapham",
-        "slug": "london/clapham",
-        "longitude": -0.138,
-        "latitude": 51.462,
-        "listTimestamp": "2025-01-07T16:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950011",
-      "sourceId": "950011",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Refurbished One Bedroom Penthouse, Wapping E1W",
-      "description": "Refurbished 1-bedroom penthouse in Wapping offering residents gym, secure parking and roof terrace.",
-      "price": "\u00a32250",
-      "priceValue": 2250,
+      "title": "Olympic Way, Wembley, Brent, London, HA9",
+      "description": "Presenting this stunning flat in Wembley. The rent includes access to a variety of convenient amenities like a reception/building manager, a co-working space, cinema, games room, gym/yoga studio, covered bike garage, playground, pet-friendly for an extra \u00a325pcm, and a stylish members' lounge on the 14th floor.\n\nAvailable from the 23rd of October, this flat is beautifully bright with big windows, high ceilings, and ample storage. It comes with ample storage, a well-equipped kitchen, a bathroom and a balcony.\n\nThis flat is under the Council tax band C.\n\nPlease note:\n- Internet & Wi-Fi will be charged at \u00a3 30.00 pcm\n- Utilities and council tax are excluded. \n\nFridman House sits in the up-and-coming, well-connected district of Wembley Park in Zone 4. The property is located right next to Wembley Park tube station.",
+      "price": "\u00a32,050",
+      "priceValue": 2050,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
       "bedrooms": 1,
       "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "PENTHOUSE",
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Residents Gym",
-        "Secure Parking",
-        "Roof Terrace"
+        "Gym",
+        "Fibre Internet",
+        "Modern",
+        "Terrace",
+        "Pet Friendly",
+        "Big Windows",
+        "Dishwasher",
+        "Freezer",
+        "High Ceilings",
+        "Open Plan Kitchen",
+        "Washer",
+        "Elevator",
+        "Ample Storage",
+        "Dryer",
+        "Concierge"
       ],
       "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
+      "image": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_aec8f4c0d3aeac96361c28b10cba4bf2362c62b4a63be55363f3bb798d9cc2e9.jpg",
       "images": [
         {
-          "id": "wapping-950011-1",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
+          "id": "0212f07c-ff75-4a91-a2d1-b9fb35ced6fc",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_aec8f4c0d3aeac96361c28b10cba4bf2362c62b4a63be55363f3bb798d9cc2e9.jpg",
+          "altText": "Living Room"
         },
         {
-          "id": "wapping-950011-2",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
+          "id": "e7c8eb35-5059-4191-8689-c87da6054b29",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_3f6aa1fd5729bcaba15ce2ee764d4e07c4da875afbe466d4b62b79aac8cc1e0d.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "wapping-950011-3",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
+          "id": "1fe45980-6d3c-4f73-af0e-2a7935a3ea5c",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_daec79a37a8cde5229e3c077803c7bfc2883602f220ce6f2846c735940e130eb.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "25348784-a250-4923-996b-473ffe63e711",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_80c465fc701bc7e86469e05d735a0ed58813585b56ecd1cc6024a71bd4f1a8c4.jpg",
+          "altText": "Balcony"
+        },
+        {
+          "id": "0d70923e-7726-4e67-9109-af777110b8c1",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_26078f7c0bf357bda0505d158903604ee2701fc564f81c0bacc2282440b6aa37.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "68d935ce-8912-4532-9223-d2d9960bc0a0",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_38ddb15626e6be111c6a049e3ea4375a4fc5b45e216eab15382a5400ce66314c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c4efb265-b2bb-4878-84f7-58759e3b97af",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_ec5d4dd9ab0cebbd11b63b8bca5f0217db19e4683af245aee602535595a2d5ea.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "9bed2208-845a-40da-b34b-ea8c6b2949fb",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_eae4e87176b2d713ab682d15af52f55d2122181a0f46b57ab25336c52173dc3b.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "b2173f83-f582-45ce-ad1e-fbaec5d3d3e6",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_cded4d9a91d99b1c8e4324af35484057ba664229173e21e4a443738eadcdc8d4.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "cd5c0c3b-bf74-4152-9114-cfeff3784d2b",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_1d95ecb444ffe1b5cbc04346f87c17c541339ae08f7239925076d984b299f6cb.jpg",
+          "altText": "Floor Plan"
+        },
+        {
+          "id": "692014a5-fabc-4eea-bd3e-2f4aa8ef9074",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_15a8a87be337f342e3701b31436ccd63aa466101596b0beb28605e387054a9c7.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "e8d7b059-c629-4e09-8fde-113fe6d2bfbb",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_a1ebc947e73abfa645cdb36f728ff3fbec0f5985b5fdc12d218ec9b2eeb5d556.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "47616041-8bda-4fb0-8da6-60de239fc0b3",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_a354473247a1e9c3f981b17c0396d711b97e032137924340e91ddf5d2d4651e1.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "93037010-7849-4344-bc52-fbcd7fafa529",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_b5f8ca97613d7d90deed467cfe6a9aa56e63f4bbebc79b65d510a85637190020.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "2f34b98d-02c5-4357-851e-1a390dac5c5a",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_b0f1d4c7cbcdec58d3ed2105f48cdbc2324123b7b291b81461023bb1b4509c38.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "bceb7dbd-8128-49ed-9287-207248c58e2a",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_ba3ace5cc8d95d953636f0003fe669a98419f4e51a3934f01c684285f8e2b84c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "a25570ea-7448-4ae0-9a22-8189d4cba672",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_56d5e4efd9b9b50df4f2c09b562a65155aec1e7032020ec76362f3c050214909.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "06917318-5f92-4b52-bb34-436abfadcd66",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_6fef9a3e0eff14a15c01f443b1c586293f174a4f6d5fd67a92e7ba5599921f96.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "bef84af9-a05c-4fee-b3a8-f2f08aab4d8c",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_95ea1a01344789b2690b69361fa218341e95ed5904702e5698f6ed5efdea7154.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "51791f7f-9b09-4ac7-8000-f4f5b54fe878",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_a18cac296fca392eb6aefaf8b6e8981ac0f7882df95c8ab4588bde6430a579e1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "d20f9194-d4f3-4126-b1ec-74627418343c",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_e85a520df41482abd82fc7cffb1c19e14083eb48d636859560cd90c05492b342.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "a8a02f5d-6812-41bc-8d9e-5d464073cc75",
+          "url": "https://assets.scraye.com/photos/original-1024/689a1f9057f012be21d58071_5525a9c43b56e16c191d2d768ba8b36482a370397b038a7b6135372d14285d96.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5059,
-      "longitude": -0.0557,
-      "lat": 51.5059,
-      "lng": -0.0557,
+      "tenure": null,
+      "size": "497 sq ft",
+      "lat": 51.56045,
+      "lng": -0.28021,
       "city": "London",
-      "county": "Greater London",
+      "county": "Brent",
+      "outcode": "HA9",
       "matchingRegions": [
         "London",
-        "Wapping",
-        "E1W"
+        "Brent",
+        "Wembley"
       ],
-      "createdAt": "2025-01-17T10:00:00Z",
-      "updatedAt": "2025-01-30T16:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 106,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "E1W",
-      "url": "https://www.scraye.com/listings/950011",
-      "externalUrl": "https://www.scraye.com/listings/950011",
+      "url": "https://www.scraye.com/listings/689a1f9057f012be21d58071",
+      "externalUrl": "https://www.scraye.com/listings/689a1f9057f012be21d58071",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "E1W",
-        "placeName": "Wapping",
-        "slug": "london/wapping",
-        "longitude": -0.0557,
-        "latitude": 51.5059,
-        "listTimestamp": "2025-01-17T10:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/wembley",
+        "longitude": -0.28021,
+        "latitude": 51.56045,
+        "listTimestamp": "2025-08-11T16:51:28Z",
+        "reference": "27786#"
       }
     },
     {
-      "id": "scraye-950012",
-      "sourceId": "950012",
+      "id": "scraye-68a36ce81d3c33471cfc9ef4",
+      "sourceId": "68a36ce81d3c33471cfc9ef4",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Contemporary Three Bedroom Apartment, Notting Hill W11",
-      "description": "Contemporary 3-bedroom apartment in Notting Hill offering 24 hour security, secure parking and floor to ceiling windows.",
-      "price": "\u00a32300",
-      "priceValue": 2300,
+      "title": "Olympic Way, Wembley, Brent, London, HA9",
+      "description": "Presenting this stunning flat on the 3rd floor of Merevale House in Wembley. The rent includes access to a variety of convenient amenities like a co-working space, gym, cinema, games room and a stylish members' lounge.\n\nAvailable now. The flat is beautifully bright with big windows and high ceilings, and comes with ample storage and a well-equipped open-plan kitchen. \n\nThis flat is under the Council tax band of C.\n\nPlease note:\n- Internet & Wi-Fi will be charged at \u00a330.00pcm\n- Utilities and council tax are excluded. \n- The photo is of a similar listing, but the video is of the property itself and was filmed recently.\n\nMerevale House sits in the up-and-coming, well-connected district of Wembley Park in Zone 4. The property is located right next to Wembley Park tube station.",
+      "price": "\u00a31,850",
+      "priceValue": 1850,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "24 Hour Security",
-        "Secure Parking",
-        "Floor to Ceiling Windows"
+        "Gym",
+        "Fibre Internet",
+        "Modern",
+        "Pet Friendly",
+        "Big Windows",
+        "Elevator",
+        "High Ceilings",
+        "Open Plan Kitchen",
+        "Ample Storage",
+        "Concierge",
+        "Washer"
       ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_7f5983a76d9ba5f002608fd3b40f26a4dc09141e91f26320baf3bdfabe3d4b98.jpg",
       "images": [
         {
-          "id": "notting-hill-950012-1",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
+          "id": "8fc0cd88-84c3-4769-98bc-be1554ae723b",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_7f5983a76d9ba5f002608fd3b40f26a4dc09141e91f26320baf3bdfabe3d4b98.jpg",
+          "altText": "Living Room"
         },
         {
-          "id": "notting-hill-950012-2",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
+          "id": "8c546af5-b8d2-46d9-a64d-72d3e3f3a570",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_efa28b2f8dacc0ded1ec20dee2ce911924561db18900f7a741d8ad32a8bdbaad.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "notting-hill-950012-3",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
+          "id": "85cddc81-a9b0-4a22-a5ba-2302be3ae96f",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_98d643325747da6cffccb6c222cf26ab0bc8e079ca6006880a0e9cfeb5e42208.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "20a36cdd-c5c9-457f-a799-19e098305e51",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_f20be2e66a311a0b24837441d6b7db03406c135252765a179cc0635f554d4380.jpg",
+          "altText": "Balcony"
+        },
+        {
+          "id": "882e5d7f-ac04-4e0e-a942-bd308b0719a9",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_29a4466230a056cb8ced6d56b73e216bede6a86a7233541f3c6a62f6e36942e9.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "81d76d7a-f78b-48c0-9cfa-15f5efb638bc",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_ac146e73c01e69ae62670af1594d49ce31a0446ae9e4b66440b14e47a561d04c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "d05a0791-149e-4bff-95fa-fc6f0423be4f",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_126e63835706ae763a09069fb929d0edae1ed30e619f36d19d58a484ca1c3882.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "ea3d2fa5-7aac-4e21-853b-499f36d117e4",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_7d974e33d43770694383822158411e67c21751f7a9ccc752507fd51f82815fb1.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "b7389bcd-b0fe-48fa-be9e-26bd70d91195",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_66f58eba30ccd9e69c7583c3234c59da7ebba64222e1bbd5794094c402ef8ce4.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "38088498-46d1-44f5-9bbf-9d0936185f61",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_455791997df70826959d5fc371310cb20ec132d0d8401b19130383bf9e2e45bc.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "7bb0fad5-c719-4b74-a32f-86338fb38b05",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_c2493d6868a62e0cc5b64b389703164771c83d9e842762ff4ac8e05fa2be6c1d.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "73749ded-439a-4f17-81cc-c6d2ff859167",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_ca3f5d91fbf3ddb76f225abc81fc41799567615ae06756fd275fb41333adb1e3.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "21b2f839-bcd9-4424-9ade-0898bf8075bc",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_fd24ee39a1bec8a8158b1e1bcb07efe75ef9320a62e7122a5ee6597082c6cc1d.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "b7e813b8-5717-437f-80fb-3dec7371d761",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_ba3ace5cc8d95d953636f0003fe669a98419f4e51a3934f01c684285f8e2b84c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "07cf5b12-1ad4-467a-82c6-fde89b31b832",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_6fef9a3e0eff14a15c01f443b1c586293f174a4f6d5fd67a92e7ba5599921f96.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "02c31062-2851-45b6-a509-0dc3876df8dc",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_95ea1a01344789b2690b69361fa218341e95ed5904702e5698f6ed5efdea7154.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "b1b6e13c-3382-4e33-89f2-a6e56732386c",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_a18cac296fca392eb6aefaf8b6e8981ac0f7882df95c8ab4588bde6430a579e1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "357d190a-6b2e-4fd4-be8d-c91a23956ca4",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_e85a520df41482abd82fc7cffb1c19e14083eb48d636859560cd90c05492b342.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "3987fef8-bd15-409d-9a52-c8ae21118466",
+          "url": "https://assets.scraye.com/photos/original-1024/68a36ce81d3c33471cfc9ef4_5525a9c43b56e16c191d2d768ba8b36482a370397b038a7b6135372d14285d96.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5094,
-      "longitude": -0.2059,
-      "lat": 51.5094,
-      "lng": -0.2059,
+      "tenure": null,
+      "size": "450 sq ft",
+      "lat": 51.56045,
+      "lng": -0.28021,
       "city": "London",
-      "county": "Greater London",
+      "county": "Brent",
+      "outcode": "HA9",
       "matchingRegions": [
         "London",
-        "Notting Hill",
-        "W11"
+        "Brent",
+        "Wembley"
       ],
-      "createdAt": "2025-02-09T13:00:00Z",
-      "updatedAt": "2025-02-17T21:00:00Z",
-      "availableAt": "2025-03-31T21:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 113,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "W11",
-      "url": "https://www.scraye.com/listings/950012",
-      "externalUrl": "https://www.scraye.com/listings/950012",
+      "url": "https://www.scraye.com/listings/68a36ce81d3c33471cfc9ef4",
+      "externalUrl": "https://www.scraye.com/listings/68a36ce81d3c33471cfc9ef4",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "W11",
-        "placeName": "Notting Hill",
-        "slug": "london/notting-hill",
-        "longitude": -0.2059,
-        "latitude": 51.5094,
-        "listTimestamp": "2025-02-09T13:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/wembley",
+        "longitude": -0.28021,
+        "latitude": 51.56045,
+        "listTimestamp": "2025-08-18T18:11:52Z",
+        "reference": "27929#"
       }
     },
     {
-      "id": "scraye-950013",
-      "sourceId": "950013",
+      "id": "scraye-68b1b265389999201d2385e0",
+      "sourceId": "68b1b265389999201d2385e0",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Boutique One Bedroom Apartment, Deptford SE8",
-      "description": "Boutique 1-bedroom apartment in Deptford offering concierge service, pet friendly and open-plan living.",
-      "price": "\u00a32100",
+      "title": "Cartwright Gardens, St Pancras, Camden, London, WC1H",
+      "description": "Presenting a newly-refurbished studio to rent in Bloomsbury on Cartwright Gardens.\n\nAvailable now, covering 151 sq. ft. of living space and situated on the second floor, this modern property comes with high ceilings, big windows and ample storage. The property also benefits from great views and access to a communal garden. \n\nFurther features and amenities include:\n- Air conditioning (available in summer months)\n- Fitted kitchenette\n- Wood floors\n- Fibre optic WIFI broadband\n- Digital TV/selected Sky channels\n- Shared laundry/ironing facilities (open 8 am-8 pm)\n- 24-hrs Concierge\n\n* Please note:\n- Bills are charged at \u00a3150 per month for electricity, water and heating\n- The photos used are of a different flat in the same building. The property advertised will be similar in style but may differ slightly in layout.\n\nThe flat is under the Council Tax band A. The property is located only moments away from King's Cross St. Pancras Underground.",
+      "price": "\u00a32,103",
+      "priceValue": 2103,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 0,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Modern",
+        "Refurbished",
+        "Fibre Internet",
+        "Big Windows",
+        "High Ceilings",
+        "Ample Storage",
+        "Open Plan Kitchen",
+        "Great View",
+        "Freezer",
+        "Air Conditioning",
+        "Students Allowed",
+        "Concierge"
+      ],
+      "furnishedState": "FURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_c97b748d88a4f50d2614241252291a98ca136d5df0a70c0466b69175e8354eea.jpg",
+      "images": [
+        {
+          "id": "58f18fee-ae37-481f-9d66-6284f3aff578",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_c97b748d88a4f50d2614241252291a98ca136d5df0a70c0466b69175e8354eea.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "2c713f71-0d1b-4444-9968-61529437849e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_e77be004317cf8d66efb1aa002d83a894c4be66d1a69de7cfbe05d875599e2e3.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "a38c2cf7-da62-44bd-ac5c-b030271b879b",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_f9d5710ff902c65c890845f43810d0aa179c9fa67c9f690625f9111ea23120b8.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "4c382e91-94c2-413a-ab60-4e1e1b257e48",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_5c97440b82dcd49598346528ff17ec28a054883fa0c5935ddfe687d3b79bac90.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "bef75c43-d6d8-4512-916f-efa166d28aa6",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_e05abc3f244e718f8883d5dd4c0e6b6dd4f47a3c37064fa6ee33c04d1270e2eb.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "10d0283a-b6c0-41d1-98ed-4cfcd02fa17d",
+          "url": "https://assets.scraye.com/photos/original-1024/68b1b265389999201d2385e0_fc04a2ff1bbf7c63e2b81adfc33a2512a63acd7ef26247ca407c6c0c3a3cfcf1.jpg",
+          "altText": "Building"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "151 sq ft",
+      "lat": 51.52739,
+      "lng": -0.12757,
+      "city": "London",
+      "county": "Camden",
+      "outcode": "WC1H",
+      "matchingRegions": [
+        "London",
+        "Camden",
+        "St Pancras"
+      ],
+      "url": "https://www.scraye.com/listings/68b1b265389999201d2385e0",
+      "externalUrl": "https://www.scraye.com/listings/68b1b265389999201d2385e0",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/st-pancras",
+        "longitude": -0.12757,
+        "latitude": 51.52739,
+        "listTimestamp": "2025-08-29T14:00:05Z",
+        "reference": "28161#"
+      }
+    },
+    {
+      "id": "scraye-68b692ea0d28d4aced6b7a7a",
+      "sourceId": "68b692ea0d28d4aced6b7a7a",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Great West Road, Brentford Dock, Hounslow, London, TW8",
+      "description": "Presenting a great flat to rent in Brentford. The property is on Great West Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable now, covering 402 sq. ft. in living space and situated on the fifth floor, this modern property comes with big windows, high ceilings, and ample storage. This property benefits from a bright living area and a private balcony. Residents can further enjoy co-working spaces, a gym, a yoga studio, a resident lounge, and a rooftop terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- High-speed Wi-Fi\n- Lift\n- Concierge/24-hour security\n- Parking is available at \u00a3100pcm (monitored by ANPR)\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Kew Bridge station and Gunnersbury Underground.",
+      "price": "\u00a31,800",
+      "priceValue": 1800,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Gym",
+        "Fibre Internet",
+        "Parking",
+        "Security",
+        "Concierge",
+        "Ample Storage",
+        "Big Windows",
+        "Dishwasher",
+        "High Ceilings",
+        "Open Plan Kitchen",
+        "Washer",
+        "Modern",
+        "Terrace",
+        "Elevator",
+        "Freezer",
+        "Dryer"
+      ],
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_aa89aba27f8b5f0ad7f8e2d92361a205dd0698aa4a08000f4576f5cd90e3a391.jpg",
+      "images": [
+        {
+          "id": "fddbd76d-b2e3-4bf6-bbb4-e22d573f4aea",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_aa89aba27f8b5f0ad7f8e2d92361a205dd0698aa4a08000f4576f5cd90e3a391.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "1c304c06-2433-45a1-af49-10a17678d649",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_eef9a67efca2e5a4f8f280ea57f10b283870c2232dab814a3af6f8fb6024c036.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "520cce25-8daf-4dbe-8c8f-efeb9375efaa",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_55e9c64e7e12a12a56ba483ecadec1a94ad12fc6bfaafefc27f9cabe7ae59adf.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "405fc246-7752-46c5-bc3c-1aa60c4bb1c8",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_3265bd3c89dfaa72562f7574f054409de6b545afdbef22e43b95c7ba6993f320.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "f8458cbd-3e9d-4c7d-a1f5-987599fbc9e4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_34d70215031682948c44f7a0488f940c079b25f74913a3850ad99cea532b1788.jpg",
+          "altText": "Balcony"
+        },
+        {
+          "id": "b330953f-52cf-4c46-9e8b-366b15d6c05b",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_738bf70a91d4f02985153ed315069f76367fd5717acda6a17102bc4dc7963155.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "b749f3bb-eec1-4e81-bd33-bb83032b6f93",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_90434efa51df2c6e2c109c0d968639be59851d2773769fe8f8de56830043d5b2.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "2018be66-a874-41e1-ba59-541d51b06a87",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_36e1b69ce8a001a45915b20b70d9e5655c917b02936419feb6ace31c6958f18b.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "e16d98ad-103a-483c-b7c8-18008121ce86",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_bce533c0878049ebf40a0c4b09d1613ec808b059a392fdbe93746a36e962fcf3.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "c7f9b11f-66aa-445d-98b4-5d8a7cad9e79",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_3733e95c066984a44ec599dc89cfd4e0c86fc9f6dbd46880e9dc7eb6b6413156.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "7fafe846-55c7-43f8-9768-b08f34708158",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_bc4e6d0291950e28200bcb3a97256b2ca9f0259d8d3ef7a0c4b8885260c2f294.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ea8bb4a4-a182-44ef-87bf-a77627342d15",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_d5deb3782d04d71c8fe3c11bb8bc43cda864b1e6ebe2f00ad73611e77a753706.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ec30266f-0858-4396-ae28-2421c842c06a",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_9277d2f2fa9a8646478582c02da97a3400ffae201651f24371e25c66b98b6a95.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "0bb0e555-731f-4cf9-b42b-540901a0d89e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_ba90b46a52966c0a9ebda5c0a88e7a7a9f7750a672b5aad137708864f2df00f8.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "c728e974-dfc1-4378-8627-d7e0fc61ebe5",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_b11ec8a8db97a357a879c66f8f6ab612027daedf74d712f4bd741a2ed413a2a6.jpg",
+          "altText": "Floor Plan"
+        },
+        {
+          "id": "120fdc59-54d9-4c56-b0b8-2e2d1df3dac4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_f737d8bfc1473bd814e79748267b5683a1f4aa6681b51048d1e40c46f8eb1b02.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "9a565c66-be74-4274-8f93-9b2bba4e5606",
+          "url": "https://assets.scraye.com/photos/original-1024/68b692ea0d28d4aced6b7a7a_3ac79f2f408c8cacd6a068293ebbddcb7b4438101feefb35ba40f23d001ef4a1.jpg",
+          "altText": "Building"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "402 sq ft",
+      "lat": 51.49183,
+      "lng": -0.29123,
+      "city": "London",
+      "county": "Hounslow",
+      "outcode": "TW8",
+      "matchingRegions": [
+        "London",
+        "Hounslow",
+        "Brentford Dock"
+      ],
+      "url": "https://www.scraye.com/listings/68b692ea0d28d4aced6b7a7a",
+      "externalUrl": "https://www.scraye.com/listings/68b692ea0d28d4aced6b7a7a",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-dock",
+        "longitude": -0.29123,
+        "latitude": 51.49183,
+        "listTimestamp": "2025-09-02T06:47:06Z",
+        "reference": "28218#"
+      }
+    },
+    {
+      "id": "scraye-68b698480d28d4aced6b7ba5",
+      "sourceId": "68b698480d28d4aced6b7ba5",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Great West Road, Brentford Dock, Hounslow, London, TW8",
+      "description": "Presenting a great flat to rent in Brentford. The property is on Great West Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable from the 6th of November, covering 420 sq. ft. in living space, this modern property comes with big windows, high ceilings, and ample storage. This property benefits from a bright living area. Residents can further enjoy co-working spaces, a gym, a yoga studio, a resident lounge, and a rooftop terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- High-speed Wi-Fi\n- Lift\n- Concierge/24-hour security\n- Pets are allowed at an additional \u00a350pcm\n- Parking is available at \u00a3100pcm (monitored by ANPR)\n\n*Please note that the photo is of a similar listing, but the video is of the property itself and was filmed recently.\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Kew Bridge station and Gunnersbury Underground.",
+      "price": "\u00a31,850",
+      "priceValue": 1850,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Ample Storage",
+        "Big Windows",
+        "Concierge",
+        "Dishwasher",
+        "Dryer",
+        "Elevator",
+        "Fibre Internet",
+        "Freezer",
+        "Great View",
+        "Gym",
+        "High Ceilings",
+        "Modern",
+        "Open Plan Kitchen",
+        "Parking",
+        "Security",
+        "Washer",
+        "Pet Friendly"
+      ],
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_90434efa51df2c6e2c109c0d968639be59851d2773769fe8f8de56830043d5b2.jpg",
+      "images": [
+        {
+          "id": "b749f3bb-eec1-4e81-bd33-bb83032b6f93",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_90434efa51df2c6e2c109c0d968639be59851d2773769fe8f8de56830043d5b2.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "1c304c06-2433-45a1-af49-10a17678d649",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_eef9a67efca2e5a4f8f280ea57f10b283870c2232dab814a3af6f8fb6024c036.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "520cce25-8daf-4dbe-8c8f-efeb9375efaa",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_55e9c64e7e12a12a56ba483ecadec1a94ad12fc6bfaafefc27f9cabe7ae59adf.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "405fc246-7752-46c5-bc3c-1aa60c4bb1c8",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_3265bd3c89dfaa72562f7574f054409de6b545afdbef22e43b95c7ba6993f320.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "f8458cbd-3e9d-4c7d-a1f5-987599fbc9e4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_34d70215031682948c44f7a0488f940c079b25f74913a3850ad99cea532b1788.jpg",
+          "altText": "Balcony"
+        },
+        {
+          "id": "b330953f-52cf-4c46-9e8b-366b15d6c05b",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_738bf70a91d4f02985153ed315069f76367fd5717acda6a17102bc4dc7963155.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "fddbd76d-b2e3-4bf6-bbb4-e22d573f4aea",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_aa89aba27f8b5f0ad7f8e2d92361a205dd0698aa4a08000f4576f5cd90e3a391.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "2018be66-a874-41e1-ba59-541d51b06a87",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_36e1b69ce8a001a45915b20b70d9e5655c917b02936419feb6ace31c6958f18b.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "e16d98ad-103a-483c-b7c8-18008121ce86",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_bce533c0878049ebf40a0c4b09d1613ec808b059a392fdbe93746a36e962fcf3.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "c7f9b11f-66aa-445d-98b4-5d8a7cad9e79",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_3733e95c066984a44ec599dc89cfd4e0c86fc9f6dbd46880e9dc7eb6b6413156.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "7fafe846-55c7-43f8-9768-b08f34708158",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_bc4e6d0291950e28200bcb3a97256b2ca9f0259d8d3ef7a0c4b8885260c2f294.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ea8bb4a4-a182-44ef-87bf-a77627342d15",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_d5deb3782d04d71c8fe3c11bb8bc43cda864b1e6ebe2f00ad73611e77a753706.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ec30266f-0858-4396-ae28-2421c842c06a",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_9277d2f2fa9a8646478582c02da97a3400ffae201651f24371e25c66b98b6a95.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "0bb0e555-731f-4cf9-b42b-540901a0d89e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_ba90b46a52966c0a9ebda5c0a88e7a7a9f7750a672b5aad137708864f2df00f8.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "120fdc59-54d9-4c56-b0b8-2e2d1df3dac4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_f737d8bfc1473bd814e79748267b5683a1f4aa6681b51048d1e40c46f8eb1b02.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "9a565c66-be74-4274-8f93-9b2bba4e5606",
+          "url": "https://assets.scraye.com/photos/original-1024/68b698480d28d4aced6b7ba5_3ac79f2f408c8cacd6a068293ebbddcb7b4438101feefb35ba40f23d001ef4a1.jpg",
+          "altText": "Building"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "420 sq ft",
+      "lat": 51.49183,
+      "lng": -0.29123,
+      "city": "London",
+      "county": "Hounslow",
+      "outcode": "TW8",
+      "matchingRegions": [
+        "London",
+        "Hounslow",
+        "Brentford Dock"
+      ],
+      "url": "https://www.scraye.com/listings/68b698480d28d4aced6b7ba5",
+      "externalUrl": "https://www.scraye.com/listings/68b698480d28d4aced6b7ba5",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-dock",
+        "longitude": -0.29123,
+        "latitude": 51.49183,
+        "listTimestamp": "2025-09-02T07:10:00Z",
+        "reference": "28221#"
+      }
+    },
+    {
+      "id": "scraye-68a81c3c75eff877b325c3bb",
+      "sourceId": "68a81c3c75eff877b325c3bb",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Great West Road, Brentford Dock, Hounslow, London, TW8",
+      "description": "Presenting a great flat to rent in Brentford. The property is on Great West Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable now, covering 465 sq. ft. in living space, this modern property comes with big windows, high ceilings, and ample storage. This property benefits from a bright living area. Residents can further enjoy co-working spaces, a gym, a yoga studio, a resident lounge, and a rooftop terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- High-speed Wi-Fi\n- Lift\n- Concierge/24-hour security\n- Pets are allowed at an additional \u00a350pcm\n- Parking is available at \u00a3100pcm (monitored by ANPR)\n\nPlease note:\n- The photos used are of a different flat in the same building. The property advertised will be similar in style but may differ slightly in layout.\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Kew Bridge station and Gunnersbury Underground.",
+      "price": "\u00a31,850",
+      "priceValue": 1850,
+      "priceCurrency": "GBP",
+      "priceQualifier": null,
+      "rentFrequency": "M",
+      "bedrooms": 1,
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
+      "status": "AVAILABLE",
+      "features": [
+        "Ample Storage",
+        "Big Windows",
+        "Concierge",
+        "Dishwasher",
+        "Dryer",
+        "Elevator",
+        "Fibre Internet",
+        "Freezer",
+        "Great View",
+        "Gym",
+        "High Ceilings",
+        "Modern",
+        "Open Plan Kitchen",
+        "Parking",
+        "Security",
+        "Washer",
+        "Pet Friendly"
+      ],
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_f66213f1e93af49efaf314974a78b3d58ee885127771ceffb7165b2d3b8e4d05.jpg",
+      "images": [
+        {
+          "id": "94248e04-ee18-4629-b89c-d42886816a20",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_f66213f1e93af49efaf314974a78b3d58ee885127771ceffb7165b2d3b8e4d05.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "2904f318-5262-45b9-a595-8c9b45066cd3",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_2ae9ee286a82ce5973699dfe190fef0ec684e6e55a057d9ce356c654fcf7efdc.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "a3812da5-2c2c-416c-9d5b-1c9f43cc81d5",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_b9c2b693d3716382ababfe83ead9e857435a78f65bbec55f5f65e2bdedb24b68.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "6b4b844f-3f5c-425b-9c7b-20d50561ada8",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_ce54581a7767efc9ede6c877ad68eb077dd7a4c8e138f46f530e6d0bf6676bc2.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "b6112296-60ba-497f-90af-3a2d892c55c5",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_c943020c3ee092e16ce4a2d897fea1628656d421470ea9b932b1f5aad139287c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "587cc07a-8670-4435-ad2c-9cc7ffb25ead",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_cf9308f2cfd18f43cc542e2f982082b1880805f8b887df675acf74558c55069e.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "99773bda-f4ab-40fd-8f85-a8988429311a",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_da3bc0db50b175e150e25e34187a3cabded26138fcda4fa0c9d345832ac028a2.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "4953b590-525d-4d5b-852b-46a1224752ea",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_060fe89f734d8727c955dff41bd6607cb00adf645e027d1529a81a0296cf0d7d.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "6aaaffe2-0bca-4905-b32e-6aea1c877838",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_9cb8840bbab8ed2d1a2b556b84f5bd2bd2d968d25b5d23fbeaf3bb30e8976eb4.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "3672cc42-1b32-4bbe-842b-e5f481977a04",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_f1a9f8b0839609992cf34cddcc3435fe1a5b7bf1d13015595ac8ed432a0195d2.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "1c8ed1a9-dbaa-485e-a780-46bc5e78d2ca",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_c1aba1eb6e7b84a14db656743a2f4020c0fb142677e317c555f3cc04b76fc810.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "1ace59a4-36ce-4228-b1f3-c780477d9a51",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_f1cb3b7f7d406fd5233413557795bccd7029fe2625ba41e481b92c32e0ec67d7.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "8888638d-365a-47c5-a672-fea4b1f2de26",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_a3c98d35fb5204877372121a04cfb94e222d2fcb0040e88dadf5ba19dc87b770.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "b6e129d6-dce3-4157-b145-0221b2228a3b",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_f10332ff36592433c54de180e0675fdada8e7ba063c8190efe0c42785a38dd2e.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "5f60d94f-3555-4038-b139-03323fa5eabe",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_6f1f0b812800ec77d870ff27cfa49d20d9918ea44cd72c4f678e55c77f2834b2.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "a05350af-03db-4000-8f84-e8c5655ef03e",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_e1135d18a81c05251c8426ee397629b212018b55982cbc6ebd88697dece3951f.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "3667e693-64ea-4933-b5c4-a573b3e5c930",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_c98670a56cc9820d05edb622a8802891624cc3c0291dc646670290824cfde098.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "07123fe0-f05c-4de4-97a0-e3086c026ef8",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_3b563cc57b47de92f99500cb9deda3f638be0d3cef5595b1eaac978301a8d450.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c17f7b28-df49-4950-8012-f16cb83076aa",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_1b4f473c220d7bf6f70deafc4896d22a0a0895ba71f8af9827783cd21862acdf.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "7d3aee8b-6de0-48d2-80d5-5e564bd98af4",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_7b7a31ebefde86e17369b54031a797a85e99cd37feda6713073245bd0672a044.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "452178f0-2066-48f0-9893-deaba08e7e9a",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_c6d1ea28147e8123bedb732f524557bb1edc52ff711e99f22a8ff4d8e06416c5.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "0115f9e2-921d-4871-bb9b-b0594fd5a5cf",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_a28d1008701aa7f4920051093f368a2b08bd323f0ffa9de531aa2da9da422f29.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "9f303b6e-5402-48bf-a623-70db97bf5bcb",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_c547b85806ef26f9e8ec72cb3de7b7666dc883914dde81459eba25bd534c8056.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "16782741-2eb9-4b1c-a901-ee75a0e45c14",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_48fc07af39cc5114e6d79bd276e88b8cb82acc7b39bc9890083af1f88850b20c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ea288a2f-bb43-464a-a9da-31d575d6d24f",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_07d97d6e46e1ccb31681e4765c232d2d879352f70c175fc77776007d55fe0cf1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c665a1b9-e5bb-4706-8f63-6fc68d404e4e",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_9de48b7dfe9b23c6cfc05a1f5687e8e2f7c4b75b2e9f8d4f9f2e7a2a4bdca501.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "05f1b852-d9d8-45cd-84d0-ebf10f195ecd",
+          "url": "https://assets.scraye.com/photos/original-1024/68a81c3c75eff877b325c3bb_61f0d49005276b6eb1570698694ce064eb6780866ea37e1b48b1a5ab9e128f76.jpg",
+          "altText": "Building"
+        }
+      ],
+      "media": [],
+      "tenure": null,
+      "size": "465 sq ft",
+      "lat": 51.49183,
+      "lng": -0.29123,
+      "city": "London",
+      "county": "Hounslow",
+      "outcode": "TW8",
+      "matchingRegions": [
+        "London",
+        "Hounslow",
+        "Brentford Dock"
+      ],
+      "url": "https://www.scraye.com/listings/68a81c3c75eff877b325c3bb",
+      "externalUrl": "https://www.scraye.com/listings/68a81c3c75eff877b325c3bb",
+      "provider": "Scraye",
+      "_scraye": {
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-dock",
+        "longitude": -0.29123,
+        "latitude": 51.49183,
+        "listTimestamp": "2025-08-22T07:29:00Z",
+        "reference": "27994#"
+      }
+    },
+    {
+      "id": "scraye-68b68f560d28d4aced6b7a3b",
+      "sourceId": "68b68f560d28d4aced6b7a3b",
+      "source": "scraye",
+      "transactionType": "rent",
+      "title": "Great West Road, Brentford Dock, Hounslow, London, TW8",
+      "description": "Presenting a great flat to rent in Brentford. The property is on Great West Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable now, covering 429 sq. ft. in living space and situated on the fourth floor, this modern property comes with big windows, high ceilings, and ample storage. This property also benefits from a private balcony and has a bright living area. Residents can further enjoy co-working spaces, a gym, a yoga studio, a resident lounge, and a rooftop terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- High-speed Wi-Fi\n- Lift\n- Concierge/24-hour security\n- Pets are allowed at an additional \u00a350pcm\n- Parking is available at \u00a3100pcm (monitored by ANPR)\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Kew Bridge station and Gunnersbury Underground.",
+      "price": "\u00a32,100",
       "priceValue": 2100,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
       "bedrooms": 1,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
+      "bathrooms": 1,
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Concierge Service",
+        "Ample Storage",
+        "Big Windows",
+        "Concierge",
+        "Dishwasher",
+        "Dryer",
+        "Elevator",
+        "Fibre Internet",
+        "Freezer",
+        "Great View",
+        "Gym",
+        "High Ceilings",
+        "Modern",
+        "Open Plan Kitchen",
+        "Parking",
+        "Security",
+        "Washer",
         "Pet Friendly",
-        "Open-Plan Living"
+        "Terrace"
       ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_fe5463c65ed698557cf6ae793cb618dd496334daaae0d72e7690a2c0246279ee.jpg",
       "images": [
         {
-          "id": "deptford-950013-1",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
+          "id": "ce4222e2-fec3-47bd-8761-177fa1e00e10",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_fe5463c65ed698557cf6ae793cb618dd496334daaae0d72e7690a2c0246279ee.jpg",
+          "altText": "Living Room"
         },
         {
-          "id": "deptford-950013-2",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
+          "id": "2d48fd4b-cb37-4861-9db9-16a9f742243a",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_10a6bace956b875940e234d00d2f40ef20c558c4fc3739ed4b04fa127e30d040.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "deptford-950013-3",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
+          "id": "d29c48ab-114f-46e7-9a8c-9213e888d4ed",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_509d779ff4db864c7ae7d6b19aba9add8ed40944faaf1d983486f379cf2aa804.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "135ccc72-b31a-4c5f-ada1-e610e3dad30e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_f85fc035232ea7839cf74b14992b9677f507580c793e36b7969d3a596f0c6b64.jpg",
+          "altText": "Balcony"
+        },
+        {
+          "id": "b71b5cc1-f8a6-41e7-bf95-8ba3fe109d04",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_33239c7f30fe60a980de14aa4762574875d7ab388e0b0f051ccd7c73015e6edd.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "5ca5f364-ceac-402f-afb0-6782d68b7079",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_c943020c3ee092e16ce4a2d897fea1628656d421470ea9b932b1f5aad139287c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "f0d4029a-d407-432c-a964-75a66e1d7141",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_6c9e4729d06e004e9353b6bbec03e1718012505d9e58d370530dd9f31277ca87.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "85a65b7c-ef26-441a-8f5b-0ee32b60782f",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_120ef8cf516a3acd4c5011a47b35bdc5228cea19bda103772c926042d94f4389.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "5481e173-4565-41bc-8b97-43c32c4f43ce",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_d161055908918b2c7a2ad7f1c941a3a320b5431b0e47e858fa6e4e819f47323a.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "d7d38403-2a8d-44e0-a8ff-015d84c4cd31",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_d8040700185ff12ebf44cd31d857257a47034850bff9809034f3de523db2a563.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "2c187830-c8ba-4158-922c-ace669d3deca",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_cf945b5cd958f6e0cc169c5cce226d9c546bd82173efa914552d534f4155494e.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "facefe8f-9a4e-47e7-b1a9-d2f0e6c0c286",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_251ea02ecbfcf8e983d577604521db7f23b506fc1427d54e2dfebd696d87f8c8.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "9896494d-9802-4a4c-87ee-3c8d52098c6a",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_c98670a56cc9820d05edb622a8802891624cc3c0291dc646670290824cfde098.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "05e63320-2552-47e6-9ae4-bc42b5143727",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_3b563cc57b47de92f99500cb9deda3f638be0d3cef5595b1eaac978301a8d450.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "bb3386fd-0a6e-42c7-880b-f112525412f4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_1b4f473c220d7bf6f70deafc4896d22a0a0895ba71f8af9827783cd21862acdf.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "144e0184-234b-47f6-81fa-530d4254ec69",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_7b7a31ebefde86e17369b54031a797a85e99cd37feda6713073245bd0672a044.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "3a14abce-435d-4c5b-81e5-be1a647718bc",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_c6d1ea28147e8123bedb732f524557bb1edc52ff711e99f22a8ff4d8e06416c5.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "6610b77c-bd89-4719-bdba-200a2f60c41e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_a28d1008701aa7f4920051093f368a2b08bd323f0ffa9de531aa2da9da422f29.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "cc147e93-e8d6-4342-be20-472a74f4d791",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_c547b85806ef26f9e8ec72cb3de7b7666dc883914dde81459eba25bd534c8056.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "91e03e8e-24a4-4169-95b7-afb766f0fff9",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_48fc07af39cc5114e6d79bd276e88b8cb82acc7b39bc9890083af1f88850b20c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c0f2d406-ab93-4e21-9158-7b121f8a05dd",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_07d97d6e46e1ccb31681e4765c232d2d879352f70c175fc77776007d55fe0cf1.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "1378bb22-a6ef-4cb2-92aa-799b4554862e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_9de48b7dfe9b23c6cfc05a1f5687e8e2f7c4b75b2e9f8d4f9f2e7a2a4bdca501.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "18c869ea-14bb-4653-80a1-bc9d91a1cd5e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_61f0d49005276b6eb1570698694ce064eb6780866ea37e1b48b1a5ab9e128f76.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "e282b653-88cd-4e57-bb5d-df355d8ce091",
+          "url": "https://assets.scraye.com/photos/original-1024/68b68f560d28d4aced6b7a3b_db6c53037d47981ee0e715583c829af5a0989f9f51e671f7ae49ad2654793fbc.jpg",
+          "altText": "Floor Plan"
         }
       ],
       "media": [],
-      "latitude": 51.4799,
-      "longitude": -0.0218,
-      "lat": 51.4799,
-      "lng": -0.0218,
+      "tenure": null,
+      "size": "429 sq ft",
+      "lat": 51.49183,
+      "lng": -0.29123,
       "city": "London",
-      "county": "Greater London",
+      "county": "Hounslow",
+      "outcode": "TW8",
       "matchingRegions": [
         "London",
-        "Deptford",
-        "SE8"
+        "Hounslow",
+        "Brentford Dock"
       ],
-      "createdAt": "2025-01-18T10:00:00Z",
-      "updatedAt": "2025-01-29T14:00:00Z",
-      "availableAt": "2025-02-16T14:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 93,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE8",
-      "url": "https://www.scraye.com/listings/950013",
-      "externalUrl": "https://www.scraye.com/listings/950013",
+      "url": "https://www.scraye.com/listings/68b68f560d28d4aced6b7a3b",
+      "externalUrl": "https://www.scraye.com/listings/68b68f560d28d4aced6b7a3b",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "SE8",
-        "placeName": "Deptford",
-        "slug": "london/deptford",
-        "longitude": -0.0218,
-        "latitude": 51.4799,
-        "listTimestamp": "2025-01-18T10:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/brentford-dock",
+        "longitude": -0.29123,
+        "latitude": 51.49183,
+        "listTimestamp": "2025-09-02T06:31:50Z",
+        "reference": "28216#"
       }
     },
     {
-      "id": "scraye-950014",
-      "sourceId": "950014",
+      "id": "scraye-68b69a870d28d4aced6b7bff",
+      "sourceId": "68b69a870d28d4aced6b7bff",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Modern One Bedroom Apartment, Greenwich SE10",
-      "description": "Modern 1-bedroom apartment in Greenwich offering cycle storage, pet friendly and floor to ceiling windows.",
-      "price": "\u00a32325",
-      "priceValue": 2325,
+      "title": "Headstone Road, Greenhill, Harrow, London, HA1",
+      "description": "Presenting a great flat to rent in Harrow. The property is on Headstone Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable from the 5th of November, covering 497 sq. ft. in living space and situated on the fifth floor, this modern property comes with big windows, high ceilings, and ample storage. This property benefits from a bright living area. Residents can further enjoy a fully equipped gym, games room, residents' lounge, residents' app, front desk and communal terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- Lift\n- Concierge/24-hour security\n- Pets are allowed at an additional \u00a350pcm\n- Parking is available at \u00a3100pcm\n\nPlease note:\n- The landlord is open to providing basic furniture.\n- The photo is of a similar listing, but the video is of the property itself and was filmed recently.\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Harrow on the Hill Underground.",
+      "price": "\u00a31,720",
+      "priceValue": 1720,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
       "bedrooms": 1,
       "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Cycle Storage",
+        "Gym",
+        "Washer",
+        "Dishwasher",
+        "Freezer",
         "Pet Friendly",
-        "Floor to Ceiling Windows"
+        "Concierge",
+        "Parking",
+        "Security",
+        "Big Windows",
+        "High Ceilings",
+        "Open Plan Kitchen",
+        "Ample Storage",
+        "Elevator",
+        "Modern",
+        "Dryer"
       ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_85e4211931f1a4a1ada4d62498ef16c018d0471088334039339184657be7f60e.jpg",
       "images": [
         {
-          "id": "greenwich-950014-1",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
+          "id": "6a7e5d30-f1f0-4df2-bbd1-8dcbce79d34f",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_85e4211931f1a4a1ada4d62498ef16c018d0471088334039339184657be7f60e.jpg",
+          "altText": "Living Room"
         },
         {
-          "id": "greenwich-950014-2",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
+          "id": "466b7730-f708-44fa-9ce6-6310bce66b67",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_43ecbb652e9e63620b9f995d3e6adfebabf7a25dcd054570e02117c507ec7063.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "greenwich-950014-3",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
+          "id": "4cdef599-84e2-4a88-92f7-a45a1bfc2b62",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_9d620c07eb29a27c16d189a9119d1fbb043fc1a91c968f1598b871fc33c64b73.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "45df2eb4-e7f8-4833-85c8-deb7cf6a8a3f",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_14aa90d902051283f9d4ce27b5bd28ccc13e13b6e27097f730a207237ba1e549.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "db854691-5310-4760-a4c7-b36e00c19b41",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_8c9507579d5827aae4dfa7cdbc13b57e97bc0a2efb3369580b84dbe1ec478b18.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "90f072c8-5772-4d02-ada1-de847056a0b4",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_03c5465d12ed27aa5c5034922765b91586a11b4ab711fc2de28dc8fd4a2ca7c6.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "30c02f27-cd82-411e-955d-cef1c888f64e",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_4b40c77f94917f163e9daddc56263059390360395e14bf07d1b932629979357b.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "03db7543-4840-4bf1-8b94-b7d2dd66dd5d",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_867c0ef837f1f74f121ab6b673490f9c6e848ab4406739aba87d2e6f7bfb3922.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "31e8e810-5301-4c2e-a163-ce8b5f655988",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_e6cce56fe6c1eb6f9ac97fdaf936d35bfe5eaaf0b08d815a1e7e3a0a1da723a1.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "d93fed42-22b3-4aa2-9f12-75b461b4a1cc",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_90f864bd75d59118d5b000f013f3f22464c0ec80ab31e0266dd10970f60a494b.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "187d5a8c-4b40-4c6b-8232-ea054a84cd77",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_f32aaadc11c3bf85268dd027bfd7bd21dea33d3cbeef34254108f10c35f534c8.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "c2a3d59c-4b1a-4dfe-bcc5-ea358a5b317f",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_6b6611dd1c54828dab3e8203c4afb0598af80867fa804af1be246954f70265ab.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "54b948b6-98b4-4b36-948f-ef1ce604580f",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_1cc44785a5cbba35823bef0288b3fa784000cafd9229b4becd9e5c326a27a943.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c1d1b115-121a-4cce-8ee3-1a4e5c8be092",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_1d7f65a32f04d79bc51805e4de66482c2180d4540be642431e4a4ffc3d666e6d.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "7e138e97-9fb2-4b13-bd44-ed096e9c78da",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_fd2837c397e68e4a1e684683ca15a4adb86ef8149708f1b6c1306e51105e4028.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "47900b85-4ff4-4c61-910b-1a75487a4e97",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_eebb3bdbbc7c84e2e8f5fc2e20f1a24ee67fbbf5b257b8ff21f021288ef10a60.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ca38f729-4e15-4432-ab80-33e00d66d791",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_f43a9e57a5ff6d8a523fe4e36a92bfa83c5afd8a9047f76198477c4beb5c0f3b.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "4754c5cc-0942-4a42-b3f1-9fb81bb59923",
+          "url": "https://assets.scraye.com/photos/original-1024/68b69a870d28d4aced6b7bff_010129b620278032482653b19fd28e0edd79a07088a72865951845b88231d563.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.4826,
-      "longitude": 0.0077,
-      "lat": 51.4826,
-      "lng": 0.0077,
+      "tenure": null,
+      "size": "497 sq ft",
+      "lat": 51.5806,
+      "lng": -0.34076,
       "city": "London",
-      "county": "Greater London",
+      "county": "Harrow",
+      "outcode": "HA1",
       "matchingRegions": [
         "London",
-        "Greenwich",
-        "SE10"
+        "Harrow",
+        "Greenhill"
       ],
-      "createdAt": "2025-03-04T13:00:00Z",
-      "updatedAt": "2025-03-19T20:00:00Z",
-      "availableAt": "2025-04-06T20:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 84,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE10",
-      "url": "https://www.scraye.com/listings/950014",
-      "externalUrl": "https://www.scraye.com/listings/950014",
+      "url": "https://www.scraye.com/listings/68b69a870d28d4aced6b7bff",
+      "externalUrl": "https://www.scraye.com/listings/68b69a870d28d4aced6b7bff",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "SE10",
-        "placeName": "Greenwich",
-        "slug": "london/greenwich",
-        "longitude": 0.0077,
-        "latitude": 51.4826,
-        "listTimestamp": "2025-03-04T13:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/greenhill",
+        "longitude": -0.34076,
+        "latitude": 51.5806,
+        "listTimestamp": "2025-09-02T07:19:35Z",
+        "reference": "28222#"
       }
     },
     {
-      "id": "scraye-950015",
-      "sourceId": "950015",
+      "id": "scraye-68ca6f72e0f0c6f9667f169c",
+      "sourceId": "68ca6f72e0f0c6f9667f169c",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Modern Two Bedroom House, Chelsea SW3",
-      "description": "Modern 2-bedroom house in Chelsea offering smart home controls, concierge service and roof terrace.",
-      "price": "\u00a32575",
-      "priceValue": 2575,
+      "title": "Headstone Road, Greenhill, Harrow, London, HA1",
+      "description": "Presenting a great flat to rent in Harrow. The property is on Headstone Road and comprises 1 bedroom and 1 bathroom. \n\nAvailable from the 21st of October, covering 505sq. ft. in living space and situated on the sixth floor, this modern property comes with big windows, high ceilings, and ample storage. This property benefits from a bright living area. Residents can further enjoy a fully equipped gym, games room, residents' lounge, residents' app, front desk and communal terrace.\n\nFurther features and amenities include: \n- Open-plan kitchen\n- Dishwasher\n- Freezer\n- Washer/Dryer\n- Lift\n- Concierge/24-hour security\n- Pets are allowed at an additional \u00a350pcm\n- Parking is available at \u00a3100pcm\n\nPlease note:\n- The landlord is open to providing basic furniture.\n- The photos used are the master images for rental flats in the building. The property in question is very similar but may differ slightly in layout.\n\nThe flat is under the Council Tax band C. Close to local amenities, the property is located only moments away from Harrow on the Hill Underground.",
+      "price": "\u00a31,720",
+      "priceValue": 1720,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 2,
+      "bedrooms": 1,
       "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "HOUSE",
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Smart Home Controls",
-        "Concierge Service",
-        "Roof Terrace"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "chelsea-950015-1",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        },
-        {
-          "id": "chelsea-950015-2",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "chelsea-950015-3",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4875,
-      "longitude": -0.1681,
-      "lat": 51.4875,
-      "lng": -0.1681,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Chelsea",
-        "SW3"
-      ],
-      "createdAt": "2025-03-04T14:00:00Z",
-      "updatedAt": "2025-04-01T20:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 117,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW3",
-      "url": "https://www.scraye.com/listings/950015",
-      "externalUrl": "https://www.scraye.com/listings/950015",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW3",
-        "placeName": "Chelsea",
-        "slug": "london/chelsea",
-        "longitude": -0.1681,
-        "latitude": 51.4875,
-        "listTimestamp": "2025-03-04T14:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950016",
-      "sourceId": "950016",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Boutique Three Bedroom House, Canary Wharf E14",
-      "description": "Boutique 3-bedroom house in Canary Wharf offering underfloor heating, floor to ceiling windows and communal gardens.",
-      "price": "\u00a32525",
-      "priceValue": 2525,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Underfloor Heating",
-        "Floor to Ceiling Windows",
-        "Communal Gardens"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "canary-wharf-950016-1",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "canary-wharf-950016-2",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "canary-wharf-950016-3",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5055,
-      "longitude": -0.0235,
-      "lat": 51.5055,
-      "lng": -0.0235,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Canary Wharf",
-        "E14"
-      ],
-      "createdAt": "2025-01-06T13:00:00Z",
-      "updatedAt": "2025-01-17T21:00:00Z",
-      "availableAt": "2025-02-13T21:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 70,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "E14",
-      "url": "https://www.scraye.com/listings/950016",
-      "externalUrl": "https://www.scraye.com/listings/950016",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E14",
-        "placeName": "Canary Wharf",
-        "slug": "london/canary-wharf",
-        "longitude": -0.0235,
-        "latitude": 51.5055,
-        "listTimestamp": "2025-01-06T13:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950017",
-      "sourceId": "950017",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Stylish Four Bedroom Duplex, Barnes SW13",
-      "description": "Stylish 4-bedroom duplex in Barnes offering concierge service, underfloor heating and secure parking.",
-      "price": "\u00a31800",
-      "priceValue": 1800,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Concierge Service",
-        "Underfloor Heating",
-        "Secure Parking"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "barnes-950017-1",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "barnes-950017-2",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "barnes-950017-3",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4723,
-      "longitude": -0.2391,
-      "lat": 51.4723,
-      "lng": -0.2391,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Barnes",
-        "SW13"
-      ],
-      "createdAt": "2025-01-26T14:00:00Z",
-      "updatedAt": "2025-02-24T22:00:00Z",
-      "availableAt": "2025-04-05T22:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 95,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW13",
-      "url": "https://www.scraye.com/listings/950017",
-      "externalUrl": "https://www.scraye.com/listings/950017",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW13",
-        "placeName": "Barnes",
-        "slug": "london/barnes",
-        "longitude": -0.2391,
-        "latitude": 51.4723,
-        "listTimestamp": "2025-01-26T14:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950018",
-      "sourceId": "950018",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Design-Led Four Bedroom Maisonette, Stratford E15",
-      "description": "Design-Led 4-bedroom maisonette in Stratford offering pet friendly, floor to ceiling windows and on-site concierge.",
-      "price": "\u00a31825",
-      "priceValue": 1825,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 4,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
+        "Gym",
+        "Washer",
+        "Dishwasher",
+        "Freezer",
         "Pet Friendly",
-        "Floor to Ceiling Windows",
-        "On-site Concierge"
+        "Concierge",
+        "Parking",
+        "Security",
+        "Big Windows",
+        "High Ceilings",
+        "Open Plan Kitchen",
+        "Ample Storage",
+        "Elevator",
+        "Modern",
+        "Dryer"
       ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
+      "furnishedState": "FURNISHED_UNFURNISHED",
+      "image": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_18fb1378f30b78dfdddbbc0b9a3508c1880c34d53a5e6bdb00bb81ad471f7562.jpg",
       "images": [
         {
-          "id": "stratford-950018-1",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
+          "id": "20285150-df9a-4bea-ac28-200ac55960c9",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_18fb1378f30b78dfdddbbc0b9a3508c1880c34d53a5e6bdb00bb81ad471f7562.jpg",
+          "altText": "Living Room"
         },
         {
-          "id": "stratford-950018-2",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
+          "id": "02f03f16-79bb-4943-94fe-7d6799ac8cfa",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_365df7ba20e005cc52d9b0bec39b92409ed65ee2f22c303773f3ae2872b9bb9f.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "stratford-950018-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
+          "id": "5a1dadec-11d3-40c7-bef4-c523e16f25c6",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_b8d6575bf124b9fdab550e112bb6b1cf519d5fca6add59d6ef73a48561b16299.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "9ba8bb81-40de-47dd-8467-a6e935104be0",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_358b366cd6dfbdcd30e0f2a00fd2fc686832943c84e813e05a60ca4d58648c24.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "34aca437-9e47-46ba-b9be-69f69682e89d",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_00b6f2fa671722efb9b9075aeabf34e95765af757162a422d9d84e0d30e6a2bd.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "b76038a1-0aae-4ff1-aed9-6f2354c6646f",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_bba42a6fd76504abaa6ef63ad2f04f53370fb1ae56785e344b62e7f85de2088e.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "1884f973-1668-4ab4-9d03-359b3e970629",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_4fc68df06d791c118d8b26a45df0470eb8ff13e021fb8dc436fc945900ad707b.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "37ae1156-3a6a-49e8-bf16-122951d3387f",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_d230e2195bc716f3828bc5cf85dff220e371e98ecab3f3a9507660688b193b7c.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "d5c0142e-90ec-4f58-b3d7-6e69e88d66ac",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_c0dad9f457d392367436947dc9cf10a410014039257e5a50809aad6ae3b41fc2.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "f3b0538b-62c2-4e0b-93d8-685154c4e7bf",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_2b6ffbfc327b4c75e1ad4495eed3f9265861f7204d12af3aa698df490725e15f.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "0974f499-8652-4aa0-9640-568749d51722",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_ed19f491a1d6b45bd1a6cda605b920084e1d7b4fa6053b2cfa414a6529f2bb04.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "8f164b5c-7065-4097-810a-b725a83ff874",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_c74c8b58a570ebad02ef5c8832248d59ca1be449012f3da6ba459a854ad243f9.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "3230f61e-2a36-4f4d-857c-42c1644c2b4a",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_5ec7cbdacaf144f097d25b91048e483ca3fcfe0fb42dc6d3fb3a79b942f0f563.jpg",
+          "altText": "Living Room"
+        },
+        {
+          "id": "cb787959-db17-4d46-8cca-8044760e0dba",
+          "url": "https://assets.scraye.com/photos/original-1024/68ca6f72e0f0c6f9667f169c_7fbf9295b431c095ef65c80463201871da8d055040a4a0fc7a118dce261508b5.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.5417,
-      "longitude": 0.0037,
-      "lat": 51.5417,
-      "lng": 0.0037,
+      "tenure": null,
+      "size": "505 sq ft",
+      "lat": 51.5806,
+      "lng": -0.34076,
       "city": "London",
-      "county": "Greater London",
+      "county": "Harrow",
+      "outcode": "HA1",
       "matchingRegions": [
         "London",
-        "Stratford",
-        "E15"
+        "Harrow",
+        "Greenhill"
       ],
-      "createdAt": "2025-02-17T17:00:00Z",
-      "updatedAt": "2025-03-05T21:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 76,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "E15",
-      "url": "https://www.scraye.com/listings/950018",
-      "externalUrl": "https://www.scraye.com/listings/950018",
+      "url": "https://www.scraye.com/listings/68ca6f72e0f0c6f9667f169c",
+      "externalUrl": "https://www.scraye.com/listings/68ca6f72e0f0c6f9667f169c",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "E15",
-        "placeName": "Stratford",
-        "slug": "london/stratford",
-        "longitude": 0.0037,
-        "latitude": 51.5417,
-        "listTimestamp": "2025-02-17T17:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/greenhill",
+        "longitude": -0.34076,
+        "latitude": 51.5806,
+        "listTimestamp": "2025-09-17T08:21:06Z",
+        "reference": "28495#"
       }
     },
     {
-      "id": "scraye-950019",
-      "sourceId": "950019",
+      "id": "scraye-68dd064ffb720e766c9cea3b",
+      "sourceId": "68dd064ffb720e766c9cea3b",
       "source": "scraye",
       "transactionType": "rent",
-      "title": "Spacious Three Bedroom Apartment, Westminster SW1A",
-      "description": "Spacious 3-bedroom apartment in Westminster offering underfloor heating, residents gym and smart home controls.",
-      "price": "\u00a32375",
-      "priceValue": 2375,
+      "title": "Popes Lane, Northfields, Hounslow, London, W5",
+      "description": "Presenting a lovely studio flat to rent in Ealing. The property is on Popes Lane and comprises a bedroom and an en-suite bathroom.\n\nAvailable now, covering 237 sq. ft. in living space. This modern property comes with a desk, a chair, and a wardrobe. The property also benefits from big windows and ample storage, as well as a 24-hour concierge/security.\n\nFurther features and amenities include:\n- Open-plan, fully equipped kitchenette\n- Mini Fridge\n- High Speed WiFi\n- Smart FOB Entry System\n- Smoke Detectors\n- Mechanical Ventilation System\n- Fire Alarm System\n- Common TV Lounge\n- On-Site Launderette\n- Blue Badge Car Park\n- Private Lockbox\n- Gaming Area\n\nPlease note:\n- Bills are charged at \u00a3150 pcm.\n- The price shown is for a 51-week tenancy only; a 44-46 week tenancy is available at \u00a31,492 pcm (excluding \u00a3150pcm for bills).\n\nThe property is located only moments away from South Ealing and Northfields tube stations, with convenient access to nearby universities and just a quick stroll from Gunnersbury Park.",
+      "price": "\u00a31,449",
+      "priceValue": 1449,
       "priceCurrency": "GBP",
       "priceQualifier": null,
       "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Underfloor Heating",
-        "Residents Gym",
-        "Smart Home Controls"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "westminster-950019-1",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        },
-        {
-          "id": "westminster-950019-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "westminster-950019-3",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4995,
-      "longitude": -0.1248,
-      "lat": 51.4995,
-      "lng": -0.1248,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Westminster",
-        "SW1A"
-      ],
-      "createdAt": "2025-02-11T09:00:00Z",
-      "updatedAt": "2025-02-16T15:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 82,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW1A",
-      "url": "https://www.scraye.com/listings/950019",
-      "externalUrl": "https://www.scraye.com/listings/950019",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW1A",
-        "placeName": "Westminster",
-        "slug": "london/westminster",
-        "longitude": -0.1248,
-        "latitude": 51.4995,
-        "listTimestamp": "2025-02-11T09:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950020",
-      "sourceId": "950020",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Design-Led One Bedroom Penthouse, Hoxton N1",
-      "description": "Design-Led 1-bedroom penthouse in Hoxton offering city skyline views, on-site concierge and residents gym.",
-      "price": "\u00a31825",
-      "priceValue": 1825,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "PENTHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "City Skyline Views",
-        "On-site Concierge",
-        "Residents Gym"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "hoxton-950020-1",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "hoxton-950020-2",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "hoxton-950020-3",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5316,
-      "longitude": -0.081,
-      "lat": 51.5316,
-      "lng": -0.081,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Hoxton",
-        "N1"
-      ],
-      "createdAt": "2025-02-15T16:00:00Z",
-      "updatedAt": "2025-03-04T22:00:00Z",
-      "availableAt": "2025-03-25T22:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 117,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "N1",
-      "url": "https://www.scraye.com/listings/950020",
-      "externalUrl": "https://www.scraye.com/listings/950020",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "N1",
-        "placeName": "Hoxton",
-        "slug": "london/hoxton",
-        "longitude": -0.081,
-        "latitude": 51.5316,
-        "listTimestamp": "2025-02-15T16:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950021",
-      "sourceId": "950021",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Refurbished Three Bedroom Duplex, Dulwich SE21",
-      "description": "Refurbished 3-bedroom duplex in Dulwich offering residents gym, open-plan living and cycle storage.",
-      "price": "\u00a31925",
-      "priceValue": 1925,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
+      "bedrooms": 0,
       "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "DUPLEX",
+      "receptions": null,
+      "propertyType": "FLAT",
       "status": "AVAILABLE",
       "features": [
-        "Residents Gym",
-        "Open-Plan Living",
-        "Cycle Storage"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "dulwich-950021-1",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "dulwich-950021-2",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        },
-        {
-          "id": "dulwich-950021-3",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4453,
-      "longitude": -0.0916,
-      "lat": 51.4453,
-      "lng": -0.0916,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Dulwich",
-        "SE21"
-      ],
-      "createdAt": "2025-01-26T12:00:00Z",
-      "updatedAt": "2025-02-08T19:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 114,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SE21",
-      "url": "https://www.scraye.com/listings/950021",
-      "externalUrl": "https://www.scraye.com/listings/950021",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SE21",
-        "placeName": "Dulwich",
-        "slug": "london/dulwich",
-        "longitude": -0.0916,
-        "latitude": 51.4453,
-        "listTimestamp": "2025-01-26T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950022",
-      "sourceId": "950022",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Stylish One Bedroom Penthouse, Earls Court SW5",
-      "description": "Stylish 1-bedroom penthouse in Earls Court offering city skyline views, roof terrace and secure parking.",
-      "price": "\u00a31775",
-      "priceValue": 1775,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "PENTHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "City Skyline Views",
-        "Roof Terrace",
-        "Secure Parking"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "earls-court-950022-1",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        },
-        {
-          "id": "earls-court-950022-2",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        },
-        {
-          "id": "earls-court-950022-3",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        }
-      ],
-      "media": [],
-      "latitude": 51.49,
-      "longitude": -0.1937,
-      "lat": 51.49,
-      "lng": -0.1937,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Earls Court",
-        "SW5"
-      ],
-      "createdAt": "2025-01-29T15:00:00Z",
-      "updatedAt": "2025-02-12T23:00:00Z",
-      "availableAt": "2025-02-28T23:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 115,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW5",
-      "url": "https://www.scraye.com/listings/950022",
-      "externalUrl": "https://www.scraye.com/listings/950022",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW5",
-        "placeName": "Earls Court",
-        "slug": "london/earls-court",
-        "longitude": -0.1937,
-        "latitude": 51.49,
-        "listTimestamp": "2025-01-29T15:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950023",
-      "sourceId": "950023",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Design-Led Two Bedroom Duplex, Woolwich SE18",
-      "description": "Design-Led 2-bedroom duplex in Woolwich offering cycle storage, smart home controls and on-site concierge.",
-      "price": "\u00a32900",
-      "priceValue": 2900,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Cycle Storage",
-        "Smart Home Controls",
-        "On-site Concierge"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "woolwich-950023-1",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        },
-        {
-          "id": "woolwich-950023-2",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        },
-        {
-          "id": "woolwich-950023-3",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4907,
-      "longitude": 0.0648,
-      "lat": 51.4907,
-      "lng": 0.0648,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Woolwich",
-        "SE18"
-      ],
-      "createdAt": "2025-01-18T11:00:00Z",
-      "updatedAt": "2025-01-30T14:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 77,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SE18",
-      "url": "https://www.scraye.com/listings/950023",
-      "externalUrl": "https://www.scraye.com/listings/950023",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SE18",
-        "placeName": "Woolwich",
-        "slug": "london/woolwich",
-        "longitude": 0.0648,
-        "latitude": 51.4907,
-        "listTimestamp": "2025-01-18T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950024",
-      "sourceId": "950024",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Two Bedroom Maisonette, Bethnal Green E2",
-      "description": "Spacious 2-bedroom maisonette in Bethnal Green offering concierge service, residents gym and open-plan living.",
-      "price": "\u00a32300",
-      "priceValue": 2300,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Concierge Service",
-        "Residents Gym",
-        "Open-Plan Living"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "bethnal-green-950024-1",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        },
-        {
-          "id": "bethnal-green-950024-2",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        },
-        {
-          "id": "bethnal-green-950024-3",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5273,
-      "longitude": -0.0605,
-      "lat": 51.5273,
-      "lng": -0.0605,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Bethnal Green",
-        "E2"
-      ],
-      "createdAt": "2025-01-07T17:00:00Z",
-      "updatedAt": "2025-01-17T00:00:00Z",
-      "availableAt": "2025-03-02T00:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 84,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "E2",
-      "url": "https://www.scraye.com/listings/950024",
-      "externalUrl": "https://www.scraye.com/listings/950024",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E2",
-        "placeName": "Bethnal Green",
-        "slug": "london/bethnal-green",
-        "longitude": -0.0605,
-        "latitude": 51.5273,
-        "listTimestamp": "2025-01-07T17:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950025",
-      "sourceId": "950025",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Stylish Three Bedroom Duplex, Herne Hill SE24",
-      "description": "Stylish 3-bedroom duplex in Herne Hill offering roof terrace, communal gardens and 24 hour security.",
-      "price": "\u00a32600",
-      "priceValue": 2600,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof Terrace",
-        "Communal Gardens",
-        "24 Hour Security"
+        "Open Plan Kitchen",
+        "Concierge",
+        "Security",
+        "Fibre Internet",
+        "Big Windows",
+        "Modern",
+        "Ample Storage",
+        "Elevator",
+        "Quiet Street"
       ],
       "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
+      "image": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_45d6fbb7e5fc731f6bdd1d7fa19cdca12d380bab4a5b4443b00f89e0abedf97a.jpg",
       "images": [
         {
-          "id": "herne-hill-950025-1",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
+          "id": "5696acb1-b243-4c07-9881-0a62ec147d57",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_45d6fbb7e5fc731f6bdd1d7fa19cdca12d380bab4a5b4443b00f89e0abedf97a.jpg",
+          "altText": "Bedroom"
         },
         {
-          "id": "herne-hill-950025-2",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
+          "id": "7286f310-0797-4d4d-ab65-572cc9093e2d",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_f2ece41a169b877c3654496d6331f6bef5644f6a8dbe8299fa70d795da327c05.jpg",
+          "altText": "Kitchen"
         },
         {
-          "id": "herne-hill-950025-3",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
+          "id": "e3891613-e7d7-4f06-b529-62cf16621f0b",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_c192bd3dd85aa0b9f59d0b3b43bc75da6bd48124d848da6d41d9d55a63a71abb.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "2add5174-9c76-464c-a769-3a9906e85fed",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_40e42773133868b81d9b1d84a66b46439d4e9b5fac27d49cf19cb5a802fdba1e.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "497927dc-67b7-41be-8bf8-7822a33841de",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_1a32945f3b33d4257c022541b8a2663142d0f9a404acec30afd88bc53e47b3c9.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "fe78c08f-1f8e-459c-beee-427d81e77672",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_fc3d0a11212852542637a68448b90a5479d9be7d79e318bf89999ba70f8c0c66.jpg",
+          "altText": "Kitchen"
+        },
+        {
+          "id": "b4fc6029-c129-4886-86c9-f77495bf0535",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_ea796e5806b878dcc2470edc4a5a74ea6df733bc11b046c2e547eff67f8bef16.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "981450f1-61f4-4788-a95c-054864a2fb42",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_14424e17cd0e80768ba141ed55d1c033c41fe77c9a30c7f00ed33f557578f7f8.jpg",
+          "altText": "Bedroom"
+        },
+        {
+          "id": "fff3d2a6-48fc-4447-958c-067d79a833b0",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_281f1777ca4d45318c37913ec0ef9eedf5a9202b6383e1704c17f1eb6745c965.jpg",
+          "altText": "Hallway"
+        },
+        {
+          "id": "6b87dbd1-e33b-4fb1-bdd1-33a1721a7209",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_bc86c1d91f7122d3bb6438eb872c7a6badb2175a6e047dba0eafcafebe30a83b.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "08d86d5f-ef5d-42a8-9859-dee60d0993f8",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_8e56ba61dd1ad37552bdf2fea9cf91288d2d717d71b9d6e0e4d5d27ed72c6a46.jpg",
+          "altText": "Bathroom"
+        },
+        {
+          "id": "e8d076ef-3b14-41ea-ba0a-686e83ed5ade",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_7f438fa2c8b6f468211d8aa7fb6f336cecec1d8b9cabf88840349df42b0a7419.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "490d0ff4-bdd0-4070-b72c-ac81a92f187f",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_13fb6650a9faeb778b7c81d9fa87f2f54526904a4a2bcbf75075cbdf03fccc52.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "254092e4-5d52-468e-b42d-f45179eb69cf",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_930885f1a33b5f0f0b199eaadf4cbd5317c7395d27d0b5691a43ddbc76d7fd8d.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "15f748d0-be25-4c1a-ab7b-e5f4d0d0ab68",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_d94cb4f41aaf2aecce066d0d2847b36c446508563604e9577c74480ccd7b7df3.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "ad37b48e-4c0d-416a-8db5-974914571edb",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_4687cd1ed072c94652e403af5d0190c5a7cb23304202fc642441acb9becf6a13.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "5254fc49-0754-4592-bad9-2b445f3a5cb5",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_388c98fb38ddc3695ae5bfab10a69b798d1e32fec9053bcd4c5be99825871356.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "c23b43e8-769d-45ee-979f-08e2fc91b66e",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_ae26c141118f192f023aecc82a57991bbd06103da3c1b1d6252436102bbe0b6c.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "302fddae-be81-438a-aa69-ea335769e359",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_ccf76171fca9e74881a8aac50d28e5b7a13fda413132b5a5b53e636b836e4a63.jpg",
+          "altText": "Building"
+        },
+        {
+          "id": "6a4e7fbe-6011-47df-aa35-3a6a7870939e",
+          "url": "https://assets.scraye.com/photos/original-1024/68dd064ffb720e766c9cea3b_0e995d3dbbeb46a731834b94aa0fc4a00cb3274930078c14d11d8f701c087af8.jpg",
+          "altText": "Building"
         }
       ],
       "media": [],
-      "latitude": 51.4529,
-      "longitude": -0.1024,
-      "lat": 51.4529,
-      "lng": -0.1024,
+      "tenure": null,
+      "size": "237 sq ft",
+      "lat": 51.49898,
+      "lng": -0.30049,
       "city": "London",
-      "county": "Greater London",
+      "county": "Hounslow",
+      "outcode": "W5",
       "matchingRegions": [
         "London",
-        "Herne Hill",
-        "SE24"
+        "Hounslow",
+        "Northfields"
       ],
-      "createdAt": "2025-01-30T13:00:00Z",
-      "updatedAt": "2025-02-13T15:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 66,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE24",
-      "url": "https://www.scraye.com/listings/950025",
-      "externalUrl": "https://www.scraye.com/listings/950025",
+      "url": "https://www.scraye.com/listings/68dd064ffb720e766c9cea3b",
+      "externalUrl": "https://www.scraye.com/listings/68dd064ffb720e766c9cea3b",
       "provider": "Scraye",
       "_scraye": {
-        "placeId": "SE24",
-        "placeName": "Herne Hill",
-        "slug": "london/herne-hill",
-        "longitude": -0.1024,
-        "latitude": 51.4529,
-        "listTimestamp": "2025-01-30T13:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950026",
-      "sourceId": "950026",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Design-Led Two Bedroom Apartment, Holborn WC1V",
-      "description": "Design-Led 2-bedroom apartment in Holborn offering on-site concierge, floor to ceiling windows and roof terrace.",
-      "price": "\u00a32750",
-      "priceValue": 2750,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "On-site Concierge",
-        "Floor to Ceiling Windows",
-        "Roof Terrace"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "holborn-950026-1",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        },
-        {
-          "id": "holborn-950026-2",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        },
-        {
-          "id": "holborn-950026-3",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5171,
-      "longitude": -0.1204,
-      "lat": 51.5171,
-      "lng": -0.1204,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Holborn",
-        "WC1V"
-      ],
-      "createdAt": "2025-03-04T16:00:00Z",
-      "updatedAt": "2025-04-03T23:00:00Z",
-      "availableAt": "2025-04-23T23:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 51,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "WC1V",
-      "url": "https://www.scraye.com/listings/950026",
-      "externalUrl": "https://www.scraye.com/listings/950026",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "WC1V",
-        "placeName": "Holborn",
-        "slug": "london/holborn",
-        "longitude": -0.1204,
-        "latitude": 51.5171,
-        "listTimestamp": "2025-03-04T16:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950027",
-      "sourceId": "950027",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Two Bedroom Penthouse, Hammersmith W6",
-      "description": "Spacious 2-bedroom penthouse in Hammersmith offering cycle storage, city skyline views and 24 hour security.",
-      "price": "\u00a31500",
-      "priceValue": 1500,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "PENTHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Cycle Storage",
-        "City Skyline Views",
-        "24 Hour Security"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "hammersmith-950027-1",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        },
-        {
-          "id": "hammersmith-950027-2",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        },
-        {
-          "id": "hammersmith-950027-3",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        }
-      ],
-      "media": [],
-      "latitude": 51.492,
-      "longitude": -0.2236,
-      "lat": 51.492,
-      "lng": -0.2236,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Hammersmith",
-        "W6"
-      ],
-      "createdAt": "2025-02-26T14:00:00Z",
-      "updatedAt": "2025-03-12T20:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 45,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "W6",
-      "url": "https://www.scraye.com/listings/950027",
-      "externalUrl": "https://www.scraye.com/listings/950027",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "W6",
-        "placeName": "Hammersmith",
-        "slug": "london/hammersmith",
-        "longitude": -0.2236,
-        "latitude": 51.492,
-        "listTimestamp": "2025-02-26T14:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950028",
-      "sourceId": "950028",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Contemporary Two Bedroom Apartment, Putney SW15",
-      "description": "Contemporary 2-bedroom apartment in Putney offering cycle storage, residents gym and roof terrace.",
-      "price": "\u00a32075",
-      "priceValue": 2075,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Cycle Storage",
-        "Residents Gym",
-        "Roof Terrace"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "putney-950028-1",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        },
-        {
-          "id": "putney-950028-2",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        },
-        {
-          "id": "putney-950028-3",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4613,
-      "longitude": -0.2155,
-      "lat": 51.4613,
-      "lng": -0.2155,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Putney",
-        "SW15"
-      ],
-      "createdAt": "2025-01-31T11:00:00Z",
-      "updatedAt": "2025-02-16T15:00:00Z",
-      "availableAt": "2025-03-18T15:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 105,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW15",
-      "url": "https://www.scraye.com/listings/950028",
-      "externalUrl": "https://www.scraye.com/listings/950028",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW15",
-        "placeName": "Putney",
-        "slug": "london/putney",
-        "longitude": -0.2155,
-        "latitude": 51.4613,
-        "listTimestamp": "2025-01-31T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950029",
-      "sourceId": "950029",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Characterful One Bedroom Apartment, Highgate N6",
-      "description": "Characterful 1-bedroom apartment in Highgate offering concierge service, on-site concierge and 24 hour security.",
-      "price": "\u00a32325",
-      "priceValue": 2325,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Concierge Service",
-        "On-site Concierge",
-        "24 Hour Security"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "highgate-950029-1",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        },
-        {
-          "id": "highgate-950029-2",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        },
-        {
-          "id": "highgate-950029-3",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        }
-      ],
-      "media": [],
-      "latitude": 51.572,
-      "longitude": -0.1462,
-      "lat": 51.572,
-      "lng": -0.1462,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Highgate",
-        "N6"
-      ],
-      "createdAt": "2025-01-21T13:00:00Z",
-      "updatedAt": "2025-01-30T17:00:00Z",
-      "availableAt": "2025-02-12T17:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 65,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "N6",
-      "url": "https://www.scraye.com/listings/950029",
-      "externalUrl": "https://www.scraye.com/listings/950029",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "N6",
-        "placeName": "Highgate",
-        "slug": "london/highgate",
-        "longitude": -0.1462,
-        "latitude": 51.572,
-        "listTimestamp": "2025-01-21T13:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950030",
-      "sourceId": "950030",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant Two Bedroom Apartment, Vauxhall SW8",
-      "description": "Elegant 2-bedroom apartment in Vauxhall offering floor to ceiling windows, smart home controls and 24 hour security.",
-      "price": "\u00a32000",
-      "priceValue": 2000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Floor to Ceiling Windows",
-        "Smart Home Controls",
-        "24 Hour Security"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "vauxhall-950030-1",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        },
-        {
-          "id": "vauxhall-950030-2",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "vauxhall-950030-3",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4861,
-      "longitude": -0.1255,
-      "lat": 51.4861,
-      "lng": -0.1255,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Vauxhall",
-        "SW8"
-      ],
-      "createdAt": "2025-01-30T12:00:00Z",
-      "updatedAt": "2025-02-10T14:00:00Z",
-      "availableAt": "2025-02-20T14:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 77,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW8",
-      "url": "https://www.scraye.com/listings/950030",
-      "externalUrl": "https://www.scraye.com/listings/950030",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW8",
-        "placeName": "Vauxhall",
-        "slug": "london/vauxhall",
-        "longitude": -0.1255,
-        "latitude": 51.4861,
-        "listTimestamp": "2025-01-30T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950031",
-      "sourceId": "950031",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Characterful One Bedroom House, Poplar E14",
-      "description": "Characterful 1-bedroom house in Poplar offering on-site concierge, floor to ceiling windows and 24 hour security.",
-      "price": "\u00a32750",
-      "priceValue": 2750,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "On-site Concierge",
-        "Floor to Ceiling Windows",
-        "24 Hour Security"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "poplar-950031-1",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "poplar-950031-2",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "poplar-950031-3",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.509,
-      "longitude": -0.017,
-      "lat": 51.509,
-      "lng": -0.017,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Poplar",
-        "E14"
-      ],
-      "createdAt": "2025-02-01T11:00:00Z",
-      "updatedAt": "2025-02-08T15:00:00Z",
-      "availableAt": "2025-03-08T15:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 56,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "E14",
-      "url": "https://www.scraye.com/listings/950031",
-      "externalUrl": "https://www.scraye.com/listings/950031",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E14",
-        "placeName": "Poplar",
-        "slug": "london/poplar",
-        "longitude": -0.017,
-        "latitude": 51.509,
-        "listTimestamp": "2025-02-01T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950032",
-      "sourceId": "950032",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Boutique Two Bedroom Penthouse, Victoria SW1E",
-      "description": "Boutique 2-bedroom penthouse in Victoria offering underfloor heating, private balcony and cycle storage.",
-      "price": "\u00a32175",
-      "priceValue": 2175,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "PENTHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Underfloor Heating",
-        "Private Balcony",
-        "Cycle Storage"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "victoria-950032-1",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "victoria-950032-2",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "victoria-950032-3",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4975,
-      "longitude": -0.1381,
-      "lat": 51.4975,
-      "lng": -0.1381,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Victoria",
-        "SW1E"
-      ],
-      "createdAt": "2025-02-06T09:00:00Z",
-      "updatedAt": "2025-02-17T13:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 92,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW1E",
-      "url": "https://www.scraye.com/listings/950032",
-      "externalUrl": "https://www.scraye.com/listings/950032",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW1E",
-        "placeName": "Victoria",
-        "slug": "london/victoria",
-        "longitude": -0.1381,
-        "latitude": 51.4975,
-        "listTimestamp": "2025-02-06T09:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950033",
-      "sourceId": "950033",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Contemporary Two Bedroom House, Balham SW12",
-      "description": "Contemporary 2-bedroom house in Balham offering communal gardens, on-site concierge and smart home controls.",
-      "price": "\u00a31825",
-      "priceValue": 1825,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Communal Gardens",
-        "On-site Concierge",
-        "Smart Home Controls"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "balham-950033-1",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "balham-950033-2",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        },
-        {
-          "id": "balham-950033-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4431,
-      "longitude": -0.1525,
-      "lat": 51.4431,
-      "lng": -0.1525,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Balham",
-        "SW12"
-      ],
-      "createdAt": "2025-01-18T09:00:00Z",
-      "updatedAt": "2025-02-16T11:00:00Z",
-      "availableAt": "2025-03-20T11:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 105,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW12",
-      "url": "https://www.scraye.com/listings/950033",
-      "externalUrl": "https://www.scraye.com/listings/950033",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW12",
-        "placeName": "Balham",
-        "slug": "london/balham",
-        "longitude": -0.1525,
-        "latitude": 51.4431,
-        "listTimestamp": "2025-01-18T09:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950034",
-      "sourceId": "950034",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Refurbished One Bedroom Apartment, Kentish Town NW5",
-      "description": "Refurbished 1-bedroom apartment in Kentish Town offering on-site concierge, floor to ceiling windows and pet friendly.",
-      "price": "\u00a32400",
-      "priceValue": 2400,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "On-site Concierge",
-        "Floor to Ceiling Windows",
-        "Pet Friendly"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "kentish-town-950034-1",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        },
-        {
-          "id": "kentish-town-950034-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "kentish-town-950034-3",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        }
-      ],
-      "media": [],
-      "latitude": 51.55,
-      "longitude": -0.14,
-      "lat": 51.55,
-      "lng": -0.14,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Kentish Town",
-        "NW5"
-      ],
-      "createdAt": "2025-02-11T14:00:00Z",
-      "updatedAt": "2025-02-16T20:00:00Z",
-      "availableAt": "2025-02-23T20:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 83,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "NW5",
-      "url": "https://www.scraye.com/listings/950034",
-      "externalUrl": "https://www.scraye.com/listings/950034",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "NW5",
-        "placeName": "Kentish Town",
-        "slug": "london/kentish-town",
-        "longitude": -0.14,
-        "latitude": 51.55,
-        "listTimestamp": "2025-02-11T14:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950035",
-      "sourceId": "950035",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious One Bedroom Maisonette, Elephant and Castle SE1",
-      "description": "Spacious 1-bedroom maisonette in Elephant and Castle offering on-site concierge, smart home controls and secure parking.",
-      "price": "\u00a32800",
-      "priceValue": 2800,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "On-site Concierge",
-        "Smart Home Controls",
-        "Secure Parking"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "elephant-and-castle-950035-1",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "elephant-and-castle-950035-2",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "elephant-and-castle-950035-3",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4945,
-      "longitude": -0.0991,
-      "lat": 51.4945,
-      "lng": -0.0991,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Elephant and Castle",
-        "SE1"
-      ],
-      "createdAt": "2025-01-13T15:00:00Z",
-      "updatedAt": "2025-01-29T17:00:00Z",
-      "availableAt": "2025-03-06T17:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 86,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE1",
-      "url": "https://www.scraye.com/listings/950035",
-      "externalUrl": "https://www.scraye.com/listings/950035",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SE1",
-        "placeName": "Elephant and Castle",
-        "slug": "london/elephant-and-castle",
-        "longitude": -0.0991,
-        "latitude": 51.4945,
-        "listTimestamp": "2025-01-13T15:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950036",
-      "sourceId": "950036",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant One Bedroom House, Angel N1",
-      "description": "Elegant 1-bedroom house in Angel offering communal gardens, on-site concierge and floor to ceiling windows.",
-      "price": "\u00a31925",
-      "priceValue": 1925,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Communal Gardens",
-        "On-site Concierge",
-        "Floor to Ceiling Windows"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "angel-950036-1",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "angel-950036-2",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        },
-        {
-          "id": "angel-950036-3",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5321,
-      "longitude": -0.1048,
-      "lat": 51.5321,
-      "lng": -0.1048,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Angel",
-        "N1"
-      ],
-      "createdAt": "2025-01-17T12:00:00Z",
-      "updatedAt": "2025-01-31T17:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 79,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "N1",
-      "url": "https://www.scraye.com/listings/950036",
-      "externalUrl": "https://www.scraye.com/listings/950036",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "N1",
-        "placeName": "Angel",
-        "slug": "london/angel",
-        "longitude": -0.1048,
-        "latitude": 51.5321,
-        "listTimestamp": "2025-01-17T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950037",
-      "sourceId": "950037",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant Four Bedroom House, Islington N1",
-      "description": "Elegant 4-bedroom house in Islington offering roof terrace, floor to ceiling windows and underfloor heating.",
-      "price": "\u00a31750",
-      "priceValue": 1750,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 4,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof Terrace",
-        "Floor to Ceiling Windows",
-        "Underfloor Heating"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "islington-950037-1",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        },
-        {
-          "id": "islington-950037-2",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        },
-        {
-          "id": "islington-950037-3",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5386,
-      "longitude": -0.1011,
-      "lat": 51.5386,
-      "lng": -0.1011,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Islington",
-        "N1"
-      ],
-      "createdAt": "2025-01-11T17:00:00Z",
-      "updatedAt": "2025-01-16T23:00:00Z",
-      "availableAt": "2025-02-12T23:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 126,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "N1",
-      "url": "https://www.scraye.com/listings/950037",
-      "externalUrl": "https://www.scraye.com/listings/950037",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "N1",
-        "placeName": "Islington",
-        "slug": "london/islington",
-        "longitude": -0.1011,
-        "latitude": 51.5386,
-        "listTimestamp": "2025-01-11T17:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950038",
-      "sourceId": "950038",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Light-Filled Three Bedroom Maisonette, Peckham SE15",
-      "description": "Light-Filled 3-bedroom maisonette in Peckham offering cycle storage, roof terrace and city skyline views.",
-      "price": "\u00a33000",
-      "priceValue": 3000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Cycle Storage",
-        "Roof Terrace",
-        "City Skyline Views"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "peckham-950038-1",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Elegant dining area"
-        },
-        {
-          "id": "peckham-950038-2",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        },
-        {
-          "id": "peckham-950038-3",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4746,
-      "longitude": -0.0694,
-      "lat": 51.4746,
-      "lng": -0.0694,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Peckham",
-        "SE15"
-      ],
-      "createdAt": "2025-02-13T17:00:00Z",
-      "updatedAt": "2025-03-02T21:00:00Z",
-      "availableAt": "2025-04-15T21:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 59,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE15",
-      "url": "https://www.scraye.com/listings/950038",
-      "externalUrl": "https://www.scraye.com/listings/950038",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SE15",
-        "placeName": "Peckham",
-        "slug": "london/peckham",
-        "longitude": -0.0694,
-        "latitude": 51.4746,
-        "listTimestamp": "2025-02-13T17:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950039",
-      "sourceId": "950039",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Four Bedroom Duplex, Nine Elms SW11",
-      "description": "Spacious 4-bedroom duplex in Nine Elms offering open-plan living, cycle storage and secure parking.",
-      "price": "\u00a31725",
-      "priceValue": 1725,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Open-Plan Living",
-        "Cycle Storage",
-        "Secure Parking"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "nine-elms-950039-1",
-          "url": "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Fully fitted kitchen"
-        },
-        {
-          "id": "nine-elms-950039-2",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        },
-        {
-          "id": "nine-elms-950039-3",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4807,
-      "longitude": -0.1404,
-      "lat": 51.4807,
-      "lng": -0.1404,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Nine Elms",
-        "SW11"
-      ],
-      "createdAt": "2025-01-08T10:00:00Z",
-      "updatedAt": "2025-01-27T14:00:00Z",
-      "availableAt": "2025-02-04T14:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 118,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW11",
-      "url": "https://www.scraye.com/listings/950039",
-      "externalUrl": "https://www.scraye.com/listings/950039",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW11",
-        "placeName": "Nine Elms",
-        "slug": "london/nine-elms",
-        "longitude": -0.1404,
-        "latitude": 51.4807,
-        "listTimestamp": "2025-01-08T10:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950040",
-      "sourceId": "950040",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Refurbished One Bedroom Duplex, Pimlico SW1V",
-      "description": "Refurbished 1-bedroom duplex in Pimlico offering floor to ceiling windows, secure parking and underfloor heating.",
-      "price": "\u00a32475",
-      "priceValue": 2475,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Floor to Ceiling Windows",
-        "Secure Parking",
-        "Underfloor Heating"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "pimlico-950040-1",
-          "url": "https://images.unsplash.com/photo-1507086184172-3e5e05b4b913?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace seating"
-        },
-        {
-          "id": "pimlico-950040-2",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        },
-        {
-          "id": "pimlico-950040-3",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4893,
-      "longitude": -0.133,
-      "lat": 51.4893,
-      "lng": -0.133,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Pimlico",
-        "SW1V"
-      ],
-      "createdAt": "2025-02-17T16:00:00Z",
-      "updatedAt": "2025-03-19T22:00:00Z",
-      "availableAt": "2025-03-26T22:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 110,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW1V",
-      "url": "https://www.scraye.com/listings/950040",
-      "externalUrl": "https://www.scraye.com/listings/950040",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW1V",
-        "placeName": "Pimlico",
-        "slug": "london/pimlico",
-        "longitude": -0.133,
-        "latitude": 51.4893,
-        "listTimestamp": "2025-02-17T16:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950041",
-      "sourceId": "950041",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Elegant Four Bedroom House, Stepney Green E1",
-      "description": "Elegant 4-bedroom house in Stepney Green offering roof terrace, concierge service and private balcony.",
-      "price": "\u00a32000",
-      "priceValue": 2000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof Terrace",
-        "Concierge Service",
-        "Private Balcony"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "stepney-green-950041-1",
-          "url": "https://images.unsplash.com/photo-1531973576160-7125cd663d86?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern bathroom suite"
-        },
-        {
-          "id": "stepney-green-950041-2",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        },
-        {
-          "id": "stepney-green-950041-3",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5204,
-      "longitude": -0.0461,
-      "lat": 51.5204,
-      "lng": -0.0461,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Stepney Green",
-        "E1"
-      ],
-      "createdAt": "2025-02-23T13:00:00Z",
-      "updatedAt": "2025-03-06T19:00:00Z",
-      "availableAt": "2025-04-01T19:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 96,
-      "allowedTenancyDurations": [
-        {
-          "min": 9,
-          "max": 36
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "E1",
-      "url": "https://www.scraye.com/listings/950041",
-      "externalUrl": "https://www.scraye.com/listings/950041",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E1",
-        "placeName": "Stepney Green",
-        "slug": "london/stepney-green",
-        "longitude": -0.0461,
-        "latitude": 51.5204,
-        "listTimestamp": "2025-02-23T13:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950042",
-      "sourceId": "950042",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Four Bedroom Apartment, Richmond TW9",
-      "description": "Spacious 4-bedroom apartment in Richmond offering cycle storage, underfloor heating and residents gym.",
-      "price": "\u00a32550",
-      "priceValue": 2550,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 4,
-      "receptions": 2,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Cycle Storage",
-        "Underfloor Heating",
-        "Residents Gym"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "richmond-950042-1",
-          "url": "https://images.unsplash.com/photo-1527030280862-64139fba04ca?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary lounge"
-        },
-        {
-          "id": "richmond-950042-2",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        },
-        {
-          "id": "richmond-950042-3",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4613,
-      "longitude": -0.3037,
-      "lat": 51.4613,
-      "lng": -0.3037,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Richmond",
-        "TW9"
-      ],
-      "createdAt": "2025-02-17T11:00:00Z",
-      "updatedAt": "2025-03-18T16:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 89,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 18
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "TW9",
-      "url": "https://www.scraye.com/listings/950042",
-      "externalUrl": "https://www.scraye.com/listings/950042",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "TW9",
-        "placeName": "Richmond",
-        "slug": "london/richmond",
-        "longitude": -0.3037,
-        "latitude": 51.4613,
-        "listTimestamp": "2025-02-17T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950043",
-      "sourceId": "950043",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Three Bedroom Maisonette, Limehouse E14",
-      "description": "Spacious 3-bedroom maisonette in Limehouse offering underfloor heating, private balcony and smart home controls.",
-      "price": "\u00a32225",
-      "priceValue": 2225,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 3,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Underfloor Heating",
-        "Private Balcony",
-        "Smart Home Controls"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "limehouse-950043-1",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Expansive riverside view"
-        },
-        {
-          "id": "limehouse-950043-2",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        },
-        {
-          "id": "limehouse-950043-3",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5123,
-      "longitude": -0.0398,
-      "lat": 51.5123,
-      "lng": -0.0398,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Limehouse",
-        "E14"
-      ],
-      "createdAt": "2025-01-05T12:00:00Z",
-      "updatedAt": "2025-01-21T16:00:00Z",
-      "availableAt": "2025-03-02T16:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 50,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "E14",
-      "url": "https://www.scraye.com/listings/950043",
-      "externalUrl": "https://www.scraye.com/listings/950043",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "E14",
-        "placeName": "Limehouse",
-        "slug": "london/limehouse",
-        "longitude": -0.0398,
-        "latitude": 51.5123,
-        "listTimestamp": "2025-01-05T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950044",
-      "sourceId": "950044",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Boutique Three Bedroom Maisonette, Wimbledon SW19",
-      "description": "Boutique 3-bedroom maisonette in Wimbledon offering smart home controls, floor to ceiling windows and on-site concierge.",
-      "price": "\u00a32900",
-      "priceValue": 2900,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Smart Home Controls",
-        "Floor to Ceiling Windows",
-        "On-site Concierge"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "wimbledon-950044-1",
-          "url": "https://images.unsplash.com/photo-1549187774-b4e9b0445b08?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Spacious family living room"
-        },
-        {
-          "id": "wimbledon-950044-2",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        },
-        {
-          "id": "wimbledon-950044-3",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4214,
-      "longitude": -0.2064,
-      "lat": 51.4214,
-      "lng": -0.2064,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Wimbledon",
-        "SW19"
-      ],
-      "createdAt": "2025-01-09T17:00:00Z",
-      "updatedAt": "2025-01-21T23:00:00Z",
-      "availableAt": "2025-03-01T23:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 127,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SW19",
-      "url": "https://www.scraye.com/listings/950044",
-      "externalUrl": "https://www.scraye.com/listings/950044",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW19",
-        "placeName": "Wimbledon",
-        "slug": "london/wimbledon",
-        "longitude": -0.2064,
-        "latitude": 51.4214,
-        "listTimestamp": "2025-01-09T17:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950045",
-      "sourceId": "950045",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Refurbished Three Bedroom Penthouse, Brixton SW9",
-      "description": "Refurbished 3-bedroom penthouse in Brixton offering communal gardens, smart home controls and underfloor heating.",
-      "price": "\u00a32575",
-      "priceValue": 2575,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "PENTHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Communal Gardens",
-        "Smart Home Controls",
-        "Underfloor Heating"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "brixton-950045-1",
-          "url": "https://images.unsplash.com/photo-1616594039964-3151a8e58f0c?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stylish home office"
-        },
-        {
-          "id": "brixton-950045-2",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "brixton-950045-3",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4616,
-      "longitude": -0.1157,
-      "lat": 51.4616,
-      "lng": -0.1157,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Brixton",
-        "SW9"
-      ],
-      "createdAt": "2025-01-27T11:00:00Z",
-      "updatedAt": "2025-02-20T19:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 102,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW9",
-      "url": "https://www.scraye.com/listings/950045",
-      "externalUrl": "https://www.scraye.com/listings/950045",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW9",
-        "placeName": "Brixton",
-        "slug": "london/brixton",
-        "longitude": -0.1157,
-        "latitude": 51.4616,
-        "listTimestamp": "2025-01-27T11:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950046",
-      "sourceId": "950046",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Modern One Bedroom Duplex, Bloomsbury WC1B",
-      "description": "Modern 1-bedroom duplex in Bloomsbury offering floor to ceiling windows, open-plan living and communal gardens.",
-      "price": "\u00a31800",
-      "priceValue": 1800,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Floor to Ceiling Windows",
-        "Open-Plan Living",
-        "Communal Gardens"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "bloomsbury-950046-1",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bright living room"
-        },
-        {
-          "id": "bloomsbury-950046-2",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "bloomsbury-950046-3",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5203,
-      "longitude": -0.1253,
-      "lat": 51.5203,
-      "lng": -0.1253,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Bloomsbury",
-        "WC1B"
-      ],
-      "createdAt": "2025-02-07T12:00:00Z",
-      "updatedAt": "2025-02-26T13:00:00Z",
-      "availableAt": "2025-04-07T13:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 47,
-      "allowedTenancyDurations": [
-        {
-          "min": 12,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "WC1B",
-      "url": "https://www.scraye.com/listings/950046",
-      "externalUrl": "https://www.scraye.com/listings/950046",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "WC1B",
-        "placeName": "Bloomsbury",
-        "slug": "london/bloomsbury",
-        "longitude": -0.1253,
-        "latitude": 51.5203,
-        "listTimestamp": "2025-02-07T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950047",
-      "sourceId": "950047",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Two Bedroom Maisonette, Aldgate EC3N",
-      "description": "Spacious 2-bedroom maisonette in Aldgate offering roof terrace, concierge service and open-plan living.",
-      "price": "\u00a31650",
-      "priceValue": 1650,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 2,
-      "bathrooms": 1,
-      "receptions": 2,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof Terrace",
-        "Concierge Service",
-        "Open-Plan Living"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "aldgate-950047-1",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Sleek contemporary kitchen"
-        },
-        {
-          "id": "aldgate-950047-2",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "aldgate-950047-3",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        }
-      ],
-      "media": [],
-      "latitude": 51.5143,
-      "longitude": -0.0754,
-      "lat": 51.5143,
-      "lng": -0.0754,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Aldgate",
-        "EC3N"
-      ],
-      "createdAt": "2025-02-26T12:00:00Z",
-      "updatedAt": "2025-03-28T17:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 84,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 24
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "EC3N",
-      "url": "https://www.scraye.com/listings/950047",
-      "externalUrl": "https://www.scraye.com/listings/950047",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "EC3N",
-        "placeName": "Aldgate",
-        "slug": "london/aldgate",
-        "longitude": -0.0754,
-        "latitude": 51.5143,
-        "listTimestamp": "2025-02-26T12:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950048",
-      "sourceId": "950048",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Boutique One Bedroom House, Tooting SW17",
-      "description": "Boutique 1-bedroom house in Tooting offering secure parking, on-site concierge and floor to ceiling windows.",
-      "price": "\u00a31725",
-      "priceValue": 1725,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Secure Parking",
-        "On-site Concierge",
-        "Floor to Ceiling Windows"
-      ],
-      "furnishedState": "UNFURNISHED",
-      "image": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "tooting-950048-1",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Serene double bedroom"
-        },
-        {
-          "id": "tooting-950048-2",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        },
-        {
-          "id": "tooting-950048-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4275,
-      "longitude": -0.168,
-      "lat": 51.4275,
-      "lng": -0.168,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Tooting",
-        "SW17"
-      ],
-      "createdAt": "2025-03-06T14:00:00Z",
-      "updatedAt": "2025-03-15T15:00:00Z",
-      "availableAt": "2025-04-11T15:00:00Z",
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 120,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": false,
-      "verified": true,
-      "outcode": "SW17",
-      "url": "https://www.scraye.com/listings/950048",
-      "externalUrl": "https://www.scraye.com/listings/950048",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SW17",
-        "placeName": "Tooting",
-        "slug": "london/tooting",
-        "longitude": -0.168,
-        "latitude": 51.4275,
-        "listTimestamp": "2025-03-06T14:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950049",
-      "sourceId": "950049",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Spacious Four Bedroom Duplex, Kensington W8",
-      "description": "Spacious 4-bedroom duplex in Kensington offering underfloor heating, residents gym and private balcony.",
-      "price": "\u00a31575",
-      "priceValue": 1575,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 4,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "DUPLEX",
-      "status": "AVAILABLE",
-      "features": [
-        "Underfloor Heating",
-        "Residents Gym",
-        "Private Balcony"
-      ],
-      "furnishedState": "PART_FURNISHED",
-      "image": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "kensington-950049-1",
-          "url": "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Designer bathroom with marble finishes"
-        },
-        {
-          "id": "kensington-950049-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "kensington-950049-3",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        }
-      ],
-      "media": [],
-      "latitude": 51.499,
-      "longitude": -0.1937,
-      "lat": 51.499,
-      "lng": -0.1937,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Kensington",
-        "W8"
-      ],
-      "createdAt": "2025-02-25T16:00:00Z",
-      "updatedAt": "2025-03-23T20:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 116,
-      "allowedTenancyDurations": [],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "W8",
-      "url": "https://www.scraye.com/listings/950049",
-      "externalUrl": "https://www.scraye.com/listings/950049",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "W8",
-        "placeName": "Kensington",
-        "slug": "london/kensington",
-        "longitude": -0.1937,
-        "latitude": 51.499,
-        "listTimestamp": "2025-02-25T16:00:00Z"
-      }
-    },
-    {
-      "id": "scraye-950050",
-      "sourceId": "950050",
-      "source": "scraye",
-      "transactionType": "rent",
-      "title": "Light-Filled Three Bedroom Apartment, Blackheath SE3",
-      "description": "Light-Filled 3-bedroom apartment in Blackheath offering communal gardens, cycle storage and on-site concierge.",
-      "price": "\u00a32325",
-      "priceValue": 2325,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": "M",
-      "bedrooms": 3,
-      "bathrooms": 3,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Communal Gardens",
-        "Cycle Storage",
-        "On-site Concierge"
-      ],
-      "furnishedState": "FURNISHED",
-      "image": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "blackheath-950050-1",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open-plan living space"
-        },
-        {
-          "id": "blackheath-950050-2",
-          "url": "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Private balcony with city views"
-        },
-        {
-          "id": "blackheath-950050-3",
-          "url": "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Inviting master bedroom"
-        }
-      ],
-      "media": [],
-      "latitude": 51.4676,
-      "longitude": 0.0086,
-      "lat": 51.4676,
-      "lng": 0.0086,
-      "city": "London",
-      "county": "Greater London",
-      "matchingRegions": [
-        "London",
-        "Blackheath",
-        "SE3"
-      ],
-      "createdAt": "2025-02-10T17:00:00Z",
-      "updatedAt": "2025-03-01T18:00:00Z",
-      "availableAt": null,
-      "depositType": "FIVE_WEEKS_RENT",
-      "size": 49,
-      "allowedTenancyDurations": [
-        {
-          "min": 6,
-          "max": 12
-        }
-      ],
-      "instantViewingsEnabled": true,
-      "verified": true,
-      "outcode": "SE3",
-      "url": "https://www.scraye.com/listings/950050",
-      "externalUrl": "https://www.scraye.com/listings/950050",
-      "provider": "Scraye",
-      "_scraye": {
-        "placeId": "SE3",
-        "placeName": "Blackheath",
-        "slug": "london/blackheath",
-        "longitude": 0.0086,
-        "latitude": 51.4676,
-        "listTimestamp": "2025-02-10T17:00:00Z"
+        "placeId": "MA",
+        "placeName": "London",
+        "slug": "london/northfields",
+        "longitude": -0.30049,
+        "latitude": 51.49898,
+        "listTimestamp": "2025-10-01T10:45:35Z",
+        "reference": "28675#"
       }
     }
   ],
-  "sale": [
-    {
-      "id": "scraye-960001",
-      "sourceId": "960001",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Warehouse Loft, Shoreditch E2",
-      "description": "Stylish 1-bedroom loft apartment with exposed brick, floor-to-ceiling windows and a private balcony moments from Shoreditch High Street.",
-      "price": "\u00a3625,000",
-      "priceValue": 625000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Open-plan living",
-        "Private balcony",
-        "Concierge"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "shoreditch-960001-1",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Loft living room"
-        },
-        {
-          "id": "shoreditch-960001-2",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Contemporary kitchen"
-        },
-        {
-          "id": "shoreditch-960001-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom with city views"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "562 sq ft",
-      "lat": 51.5268,
-      "lng": -0.0779,
-      "city": "Shoreditch",
-      "county": "London",
-      "outcode": "E2",
-      "matchingRegions": [
-        "London",
-        "Shoreditch"
-      ],
-      "url": "https://www.scraye.com/listings/960001",
-      "externalUrl": "https://www.scraye.com/listings/960001",
-      "_scraye": {
-        "placeId": "E2",
-        "placeName": "Shoreditch",
-        "slug": "london/shoreditch",
-        "longitude": -0.0779,
-        "latitude": 51.5268,
-        "listTimestamp": "2025-02-12T09:00:00Z",
-        "reference": "SCRAYE-960001"
-      }
-    },
-    {
-      "id": "scraye-960002",
-      "sourceId": "960002",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Riverside Apartment, Battersea SW11",
-      "description": "Bright 2-bedroom apartment overlooking the Thames with residents' gym and landscaped podium gardens.",
-      "price": "\u00a3805,000",
-      "priceValue": 805000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "River views",
-        "Residents' gym",
-        "24-hour concierge"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "battersea-960002-1",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Riverside living room"
-        },
-        {
-          "id": "battersea-960002-2",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Modern kitchen"
-        },
-        {
-          "id": "battersea-960002-3",
-          "url": "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "814 sq ft",
-      "lat": 51.4781,
-      "lng": -0.1505,
-      "city": "Battersea",
-      "county": "London",
-      "outcode": "SW11",
-      "matchingRegions": [
-        "London",
-        "Battersea"
-      ],
-      "url": "https://www.scraye.com/listings/960002",
-      "externalUrl": "https://www.scraye.com/listings/960002",
-      "_scraye": {
-        "placeId": "SW11",
-        "placeName": "Battersea",
-        "slug": "london/battersea",
-        "longitude": -0.1505,
-        "latitude": 51.4781,
-        "listTimestamp": "2025-02-10T08:30:00Z",
-        "reference": "SCRAYE-960002"
-      }
-    },
-    {
-      "id": "scraye-960003",
-      "sourceId": "960003",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Garden Duplex, Hampstead NW3",
-      "description": "Characterful 3-bedroom duplex arranged over two floors with private south-facing garden and study.",
-      "price": "\u00a3915,000",
-      "priceValue": 915000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Private garden",
-        "Period features",
-        "Home office"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1449844908441-8829872d2607?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "hampstead-960003-1",
-          "url": "https://images.unsplash.com/photo-1449844908441-8829872d2607?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Hampstead reception room"
-        },
-        {
-          "id": "hampstead-960003-2",
-          "url": "https://images.unsplash.com/photo-1502672023488-70e25813eb80?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        },
-        {
-          "id": "hampstead-960003-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Share of Freehold",
-      "size": "1,105 sq ft",
-      "lat": 51.5558,
-      "lng": -0.178,
-      "city": "Hampstead",
-      "county": "London",
-      "outcode": "NW3",
-      "matchingRegions": [
-        "London",
-        "Hampstead"
-      ],
-      "url": "https://www.scraye.com/listings/960003",
-      "externalUrl": "https://www.scraye.com/listings/960003",
-      "_scraye": {
-        "placeId": "NW3",
-        "placeName": "Hampstead",
-        "slug": "london/hampstead",
-        "longitude": -0.178,
-        "latitude": 51.5558,
-        "listTimestamp": "2025-02-14T12:15:00Z",
-        "reference": "SCRAYE-960003"
-      }
-    },
-    {
-      "id": "scraye-960004",
-      "sourceId": "960004",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Victorian Terrace, Clapham SW4",
-      "description": "Beautifully extended 4-bedroom Victorian family home with double reception, loft conversion and landscaped garden.",
-      "price": "\u00a31,450,000",
-      "priceValue": 1450000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "TERRACED_HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Double reception",
-        "Kitchen diner",
-        "Landscaped garden"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1600585154340-0ef3c08dcdb6?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "clapham-960004-1",
-          "url": "https://images.unsplash.com/photo-1600585154340-0ef3c08dcdb6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Exterior of terrace house"
-        },
-        {
-          "id": "clapham-960004-2",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Family kitchen"
-        },
-        {
-          "id": "clapham-960004-3",
-          "url": "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,842 sq ft",
-      "lat": 51.4633,
-      "lng": -0.1396,
-      "city": "Clapham",
-      "county": "London",
-      "outcode": "SW4",
-      "matchingRegions": [
-        "London",
-        "Clapham"
-      ],
-      "url": "https://www.scraye.com/listings/960004",
-      "externalUrl": "https://www.scraye.com/listings/960004",
-      "_scraye": {
-        "placeId": "SW4",
-        "placeName": "Clapham",
-        "slug": "london/clapham",
-        "longitude": -0.1396,
-        "latitude": 51.4633,
-        "listTimestamp": "2025-02-09T11:20:00Z",
-        "reference": "SCRAYE-960004"
-      }
-    },
-    {
-      "id": "scraye-960005",
-      "sourceId": "960005",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Period Conversion, Islington N1",
-      "description": "Elegant 1-bedroom conversion on a tree-lined street with high ceilings, sash windows and communal gardens.",
-      "price": "\u00a3595,000",
-      "priceValue": 595000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "High ceilings",
-        "Original fireplaces",
-        "Communal gardens"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1599423300746-b62533397364?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "islington-960005-1",
-          "url": "https://images.unsplash.com/photo-1599423300746-b62533397364?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Islington reception"
-        },
-        {
-          "id": "islington-960005-2",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "islington-960005-3",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Share of Freehold",
-      "size": "588 sq ft",
-      "lat": 51.5363,
-      "lng": -0.1049,
-      "city": "Islington",
-      "county": "London",
-      "outcode": "N1",
-      "matchingRegions": [
-        "London",
-        "Islington"
-      ],
-      "url": "https://www.scraye.com/listings/960005",
-      "externalUrl": "https://www.scraye.com/listings/960005",
-      "_scraye": {
-        "placeId": "N1",
-        "placeName": "Islington",
-        "slug": "london/islington",
-        "longitude": -0.1049,
-        "latitude": 51.5363,
-        "listTimestamp": "2025-02-11T10:10:00Z",
-        "reference": "SCRAYE-960005"
-      }
-    },
-    {
-      "id": "scraye-960006",
-      "sourceId": "960006",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Skyline Apartment, Canary Wharf E14",
-      "description": "Impressive 2-bedroom apartment on a high floor with panoramic docklands views and access to residents' club.",
-      "price": "\u00a3875,000",
-      "priceValue": 875000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Panoramic views",
-        "Residents' club",
-        "Secure parking"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "canarywharf-960006-1",
-          "url": "https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Skyline view"
-        },
-        {
-          "id": "canarywharf-960006-2",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Living area"
-        },
-        {
-          "id": "canarywharf-960006-3",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "901 sq ft",
-      "lat": 51.5037,
-      "lng": -0.0184,
-      "city": "Canary Wharf",
-      "county": "London",
-      "outcode": "E14",
-      "matchingRegions": [
-        "London",
-        "Canary Wharf"
-      ],
-      "url": "https://www.scraye.com/listings/960006",
-      "externalUrl": "https://www.scraye.com/listings/960006",
-      "_scraye": {
-        "placeId": "E14",
-        "placeName": "Canary Wharf",
-        "slug": "london/canary-wharf",
-        "longitude": -0.0184,
-        "latitude": 51.5037,
-        "listTimestamp": "2025-02-16T07:45:00Z",
-        "reference": "SCRAYE-960006"
-      }
-    },
-    {
-      "id": "scraye-960007",
-      "sourceId": "960007",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Edwardian Home, Wimbledon SW19",
-      "description": "Elegant 3-bedroom Edwardian house with bay-fronted reception, utility room and west-facing garden.",
-      "price": "\u00a3945,000",
-      "priceValue": 945000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 2,
-      "propertyType": "SEMI_DETACHED",
-      "status": "AVAILABLE",
-      "features": [
-        "Bay windows",
-        "Utility room",
-        "West-facing garden"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1568605114967-8130f3a36994?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "wimbledon-960007-1",
-          "url": "https://images.unsplash.com/photo-1568605114967-8130f3a36994?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Exterior"
-        },
-        {
-          "id": "wimbledon-960007-2",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Reception"
-        },
-        {
-          "id": "wimbledon-960007-3",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,362 sq ft",
-      "lat": 51.4199,
-      "lng": -0.2197,
-      "city": "Wimbledon",
-      "county": "London",
-      "outcode": "SW19",
-      "matchingRegions": [
-        "London",
-        "Wimbledon"
-      ],
-      "url": "https://www.scraye.com/listings/960007",
-      "externalUrl": "https://www.scraye.com/listings/960007",
-      "_scraye": {
-        "placeId": "SW19",
-        "placeName": "Wimbledon",
-        "slug": "london/wimbledon",
-        "longitude": -0.2197,
-        "latitude": 51.4199,
-        "listTimestamp": "2025-02-13T16:05:00Z",
-        "reference": "SCRAYE-960007"
-      }
-    },
-    {
-      "id": "scraye-960008",
-      "sourceId": "960008",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Riverside Townhouse, Chiswick W4",
-      "description": "Refurbished 4-bedroom townhouse with terrace, garage and access to Thames Path.",
-      "price": "\u00a31,295,000",
-      "priceValue": 1295000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "TOWNHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof terrace",
-        "Garage",
-        "River access"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1522156373667-4c7234bbd804?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "chiswick-960008-1",
-          "url": "https://images.unsplash.com/photo-1522156373667-4c7234bbd804?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Townhouse exterior"
-        },
-        {
-          "id": "chiswick-960008-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Terrace"
-        },
-        {
-          "id": "chiswick-960008-3",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Living room"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,728 sq ft",
-      "lat": 51.486,
-      "lng": -0.2686,
-      "city": "Chiswick",
-      "county": "London",
-      "outcode": "W4",
-      "matchingRegions": [
-        "London",
-        "Chiswick"
-      ],
-      "url": "https://www.scraye.com/listings/960008",
-      "externalUrl": "https://www.scraye.com/listings/960008",
-      "_scraye": {
-        "placeId": "W4",
-        "placeName": "Chiswick",
-        "slug": "london/chiswick",
-        "longitude": -0.2686,
-        "latitude": 51.486,
-        "listTimestamp": "2025-02-08T14:40:00Z",
-        "reference": "SCRAYE-960008"
-      }
-    },
-    {
-      "id": "scraye-960009",
-      "sourceId": "960009",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Period Apartment, Notting Hill W11",
-      "description": "Charming 1-bedroom apartment moments from Portobello Road with Juliette balcony and separate study nook.",
-      "price": "\u00a3620,000",
-      "priceValue": 620000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Juliette balcony",
-        "Separate study",
-        "Wooden floors"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1464890100898-a385f744067f?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "nottinghill-960009-1",
-          "url": "https://images.unsplash.com/photo-1464890100898-a385f744067f?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Notting Hill living room"
-        },
-        {
-          "id": "nottinghill-960009-2",
-          "url": "https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "nottinghill-960009-3",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "545 sq ft",
-      "lat": 51.5145,
-      "lng": -0.2059,
-      "city": "Notting Hill",
-      "county": "London",
-      "outcode": "W11",
-      "matchingRegions": [
-        "London",
-        "Notting Hill"
-      ],
-      "url": "https://www.scraye.com/listings/960009",
-      "externalUrl": "https://www.scraye.com/listings/960009",
-      "_scraye": {
-        "placeId": "W11",
-        "placeName": "Notting Hill",
-        "slug": "london/notting-hill",
-        "longitude": -0.2059,
-        "latitude": 51.5145,
-        "listTimestamp": "2025-02-17T09:25:00Z",
-        "reference": "SCRAYE-960009"
-      }
-    },
-    {
-      "id": "scraye-960010",
-      "sourceId": "960010",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Royal Park View, Greenwich SE10",
-      "description": "Immaculate 2-bedroom apartment with dual aspect reception, winter garden and views towards Greenwich Park.",
-      "price": "\u00a3765,000",
-      "priceValue": 765000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Winter garden",
-        "Park views",
-        "Concierge"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1484100356142-db6ab6244067?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "greenwich-960010-1",
-          "url": "https://images.unsplash.com/photo-1484100356142-db6ab6244067?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Greenwich apartment"
-        },
-        {
-          "id": "greenwich-960010-2",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Open plan living"
-        },
-        {
-          "id": "greenwich-960010-3",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "792 sq ft",
-      "lat": 51.4773,
-      "lng": -0.0134,
-      "city": "Greenwich",
-      "county": "London",
-      "outcode": "SE10",
-      "matchingRegions": [
-        "London",
-        "Greenwich"
-      ],
-      "url": "https://www.scraye.com/listings/960010",
-      "externalUrl": "https://www.scraye.com/listings/960010",
-      "_scraye": {
-        "placeId": "SE10",
-        "placeName": "Greenwich",
-        "slug": "london/greenwich",
-        "longitude": -0.0134,
-        "latitude": 51.4773,
-        "listTimestamp": "2025-02-18T13:55:00Z",
-        "reference": "SCRAYE-960010"
-      }
-    },
-    {
-      "id": "scraye-960011",
-      "sourceId": "960011",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "River Quarter House, Richmond TW9",
-      "description": "Spacious 3-bedroom townhouse close to Richmond Green with terrace, garage and flexible family room.",
-      "price": "\u00a3985,000",
-      "priceValue": 985000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 3,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "TOWNHOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Garage",
-        "Private terrace",
-        "Flexible family room"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "richmond-960011-1",
-          "url": "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Richmond townhouse"
-        },
-        {
-          "id": "richmond-960011-2",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Living room"
-        },
-        {
-          "id": "richmond-960011-3",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,524 sq ft",
-      "lat": 51.4572,
-      "lng": -0.3007,
-      "city": "Richmond",
-      "county": "London",
-      "outcode": "TW9",
-      "matchingRegions": [
-        "London",
-        "Richmond"
-      ],
-      "url": "https://www.scraye.com/listings/960011",
-      "externalUrl": "https://www.scraye.com/listings/960011",
-      "_scraye": {
-        "placeId": "TW9",
-        "placeName": "Richmond",
-        "slug": "london/richmond",
-        "longitude": -0.3007,
-        "latitude": 51.4572,
-        "listTimestamp": "2025-02-15T15:35:00Z",
-        "reference": "SCRAYE-960011"
-      }
-    },
-    {
-      "id": "scraye-960012",
-      "sourceId": "960012",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Edwardian Villa, Dulwich SE21",
-      "description": "Elegant 4-bedroom villa on Dulwich Village fringe offering generous rooms, cellar and 90ft garden.",
-      "price": "\u00a31,675,000",
-      "priceValue": 1675000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 3,
-      "propertyType": "DETACHED",
-      "status": "AVAILABLE",
-      "features": [
-        "90ft garden",
-        "Cellar",
-        "Period detailing"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "dulwich-960012-1",
-          "url": "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Dulwich home"
-        },
-        {
-          "id": "dulwich-960012-2",
-          "url": "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Reception"
-        },
-        {
-          "id": "dulwich-960012-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "2,105 sq ft",
-      "lat": 51.4416,
-      "lng": -0.0837,
-      "city": "Dulwich",
-      "county": "London",
-      "outcode": "SE21",
-      "matchingRegions": [
-        "London",
-        "Dulwich"
-      ],
-      "url": "https://www.scraye.com/listings/960012",
-      "externalUrl": "https://www.scraye.com/listings/960012",
-      "_scraye": {
-        "placeId": "SE21",
-        "placeName": "Dulwich",
-        "slug": "london/dulwich",
-        "longitude": -0.0837,
-        "latitude": 51.4416,
-        "listTimestamp": "2025-02-07T10:50:00Z",
-        "reference": "SCRAYE-960012"
-      }
-    },
-    {
-      "id": "scraye-960013",
-      "sourceId": "960013",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Stucco Apartment, Kensington W8",
-      "description": "Graceful 1-bedroom apartment in a white stucco building with ornate plasterwork and access to communal gardens.",
-      "price": "\u00a3910,000",
-      "priceValue": 910000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Communal gardens",
-        "Stucco facade",
-        "Period detailing"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1529429617124-aee318a79a6b?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "kensington-960013-1",
-          "url": "https://images.unsplash.com/photo-1529429617124-aee318a79a6b?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kensington facade"
-        },
-        {
-          "id": "kensington-960013-2",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Reception"
-        },
-        {
-          "id": "kensington-960013-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        }
-      ],
-      "media": [],
-      "tenure": "Share of Freehold",
-      "size": "602 sq ft",
-      "lat": 51.5014,
-      "lng": -0.1967,
-      "city": "Kensington",
-      "county": "London",
-      "outcode": "W8",
-      "matchingRegions": [
-        "London",
-        "Kensington"
-      ],
-      "url": "https://www.scraye.com/listings/960013",
-      "externalUrl": "https://www.scraye.com/listings/960013",
-      "_scraye": {
-        "placeId": "W8",
-        "placeName": "Kensington",
-        "slug": "london/kensington",
-        "longitude": -0.1967,
-        "latitude": 51.5014,
-        "listTimestamp": "2025-02-19T12:40:00Z",
-        "reference": "SCRAYE-960013"
-      }
-    },
-    {
-      "id": "scraye-960014",
-      "sourceId": "960014",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Canalside Loft, Camden NW1",
-      "description": "Cool 2-bedroom loft by Regent's Canal with mezzanine workspace and exposed steelwork.",
-      "price": "\u00a3870,000",
-      "priceValue": 870000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "LOFT",
-      "status": "AVAILABLE",
-      "features": [
-        "Mezzanine workspace",
-        "Exposed brick",
-        "Canal views"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1505692794403-5fd89976b6c5?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "camden-960014-1",
-          "url": "https://images.unsplash.com/photo-1505692794403-5fd89976b6c5?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Camden loft"
-        },
-        {
-          "id": "camden-960014-2",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "camden-960014-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "876 sq ft",
-      "lat": 51.5416,
-      "lng": -0.1433,
-      "city": "Camden",
-      "county": "London",
-      "outcode": "NW1",
-      "matchingRegions": [
-        "London",
-        "Camden"
-      ],
-      "url": "https://www.scraye.com/listings/960014",
-      "externalUrl": "https://www.scraye.com/listings/960014",
-      "_scraye": {
-        "placeId": "NW1",
-        "placeName": "Camden",
-        "slug": "london/camden",
-        "longitude": -0.1433,
-        "latitude": 51.5416,
-        "listTimestamp": "2025-02-20T07:20:00Z",
-        "reference": "SCRAYE-960014"
-      }
-    },
-    {
-      "id": "scraye-960015",
-      "sourceId": "960015",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Brixton Hill House, SW2",
-      "description": "Stylishly renovated 3-bedroom Victorian house with bifold doors opening to landscaped patio garden.",
-      "price": "\u00a3879,000",
-      "priceValue": 879000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "TERRACED_HOUSE",
-      "status": "AVAILABLE",
-      "features": [
-        "Bifold doors",
-        "Landscaped garden",
-        "Loft conversion"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1464316325666-63beaf639dbb?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "brixton-960015-1",
-          "url": "https://images.unsplash.com/photo-1464316325666-63beaf639dbb?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Brixton terrace"
-        },
-        {
-          "id": "brixton-960015-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen diner"
-        },
-        {
-          "id": "brixton-960015-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,218 sq ft",
-      "lat": 51.4459,
-      "lng": -0.1228,
-      "city": "Brixton",
-      "county": "London",
-      "outcode": "SW2",
-      "matchingRegions": [
-        "London",
-        "Brixton"
-      ],
-      "url": "https://www.scraye.com/listings/960015",
-      "externalUrl": "https://www.scraye.com/listings/960015",
-      "_scraye": {
-        "placeId": "SW2",
-        "placeName": "Brixton",
-        "slug": "london/brixton",
-        "longitude": -0.1228,
-        "latitude": 51.4459,
-        "listTimestamp": "2025-02-18T16:25:00Z",
-        "reference": "SCRAYE-960015"
-      }
-    },
-    {
-      "id": "scraye-960016",
-      "sourceId": "960016",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Highgate Heights, N6",
-      "description": "Handsome 4-bedroom detached home with sweeping driveway, south-facing garden and cinema room.",
-      "price": "\u00a32,150,000",
-      "priceValue": 2150000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 3,
-      "propertyType": "DETACHED",
-      "status": "AVAILABLE",
-      "features": [
-        "Cinema room",
-        "Sweeping driveway",
-        "South-facing garden"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1600585154526-990dced4db0d?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "highgate-960016-1",
-          "url": "https://images.unsplash.com/photo-1600585154526-990dced4db0d?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Highgate house"
-        },
-        {
-          "id": "highgate-960016-2",
-          "url": "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        },
-        {
-          "id": "highgate-960016-3",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "2,486 sq ft",
-      "lat": 51.5711,
-      "lng": -0.1527,
-      "city": "Highgate",
-      "county": "London",
-      "outcode": "N6",
-      "matchingRegions": [
-        "London",
-        "Highgate"
-      ],
-      "url": "https://www.scraye.com/listings/960016",
-      "externalUrl": "https://www.scraye.com/listings/960016",
-      "_scraye": {
-        "placeId": "N6",
-        "placeName": "Highgate",
-        "slug": "london/highgate",
-        "longitude": -0.1527,
-        "latitude": 51.5711,
-        "listTimestamp": "2025-02-06T09:15:00Z",
-        "reference": "SCRAYE-960016"
-      }
-    },
-    {
-      "id": "scraye-960017",
-      "sourceId": "960017",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Bankside Residence, Southwark SE1",
-      "description": "Sleek 2-bedroom apartment beside Tate Modern featuring winter garden, concierge and residents' lounge.",
-      "price": "\u00a3995,000",
-      "priceValue": 995000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 2,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "APARTMENT",
-      "status": "AVAILABLE",
-      "features": [
-        "Winter garden",
-        "Residents' lounge",
-        "Concierge"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "southwark-960017-1",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bankside reception"
-        },
-        {
-          "id": "southwark-960017-2",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "southwark-960017-3",
-          "url": "https://images.unsplash.com/photo-1505692794403-5fd89976b6c5?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "834 sq ft",
-      "lat": 51.5075,
-      "lng": -0.0994,
-      "city": "Southwark",
-      "county": "London",
-      "outcode": "SE1",
-      "matchingRegions": [
-        "London",
-        "Southwark"
-      ],
-      "url": "https://www.scraye.com/listings/960017",
-      "externalUrl": "https://www.scraye.com/listings/960017",
-      "_scraye": {
-        "placeId": "SE1",
-        "placeName": "Southwark",
-        "slug": "london/southwark",
-        "longitude": -0.0994,
-        "latitude": 51.5075,
-        "listTimestamp": "2025-02-05T08:05:00Z",
-        "reference": "SCRAYE-960017"
-      }
-    },
-    {
-      "id": "scraye-960018",
-      "sourceId": "960018",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Victorian Conversion, Stoke Newington N16",
-      "description": "Generous 3-bedroom conversion with bay windows, bespoke cabinetry and private roof terrace.",
-      "price": "\u00a3805,000",
-      "priceValue": 805000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 3,
-      "bathrooms": 2,
-      "receptions": 1,
-      "propertyType": "MAISONETTE",
-      "status": "AVAILABLE",
-      "features": [
-        "Roof terrace",
-        "Bespoke cabinetry",
-        "Bay windows"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1464890100898-a385f744067f?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "stokenewington-960018-1",
-          "url": "https://images.unsplash.com/photo-1464890100898-a385f744067f?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Stoke Newington living room"
-        },
-        {
-          "id": "stokenewington-960018-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "stokenewington-960018-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Roof terrace"
-        }
-      ],
-      "media": [],
-      "tenure": "Share of Freehold",
-      "size": "1,048 sq ft",
-      "lat": 51.5635,
-      "lng": -0.0765,
-      "city": "Stoke Newington",
-      "county": "London",
-      "outcode": "N16",
-      "matchingRegions": [
-        "London",
-        "Stoke Newington"
-      ],
-      "url": "https://www.scraye.com/listings/960018",
-      "externalUrl": "https://www.scraye.com/listings/960018",
-      "_scraye": {
-        "placeId": "N16",
-        "placeName": "Stoke Newington",
-        "slug": "london/stoke-newington",
-        "longitude": -0.0765,
-        "latitude": 51.5635,
-        "listTimestamp": "2025-02-04T09:35:00Z",
-        "reference": "SCRAYE-960018"
-      }
-    },
-    {
-      "id": "scraye-960019",
-      "sourceId": "960019",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Kings Cross Loft, N1C",
-      "description": "Light-filled 1-bedroom loft in converted warehouse with double-height ceilings and communal roof terrace.",
-      "price": "\u00a3675,000",
-      "priceValue": 675000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 1,
-      "bathrooms": 1,
-      "receptions": 1,
-      "propertyType": "LOFT",
-      "status": "AVAILABLE",
-      "features": [
-        "Double-height ceilings",
-        "Exposed brick",
-        "Communal roof terrace"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "kingscross-960019-1",
-          "url": "https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kings Cross loft"
-        },
-        {
-          "id": "kingscross-960019-2",
-          "url": "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Kitchen"
-        },
-        {
-          "id": "kingscross-960019-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Bedroom"
-        }
-      ],
-      "media": [],
-      "tenure": "Leasehold",
-      "size": "603 sq ft",
-      "lat": 51.5362,
-      "lng": -0.1269,
-      "city": "King's Cross",
-      "county": "London",
-      "outcode": "N1C",
-      "matchingRegions": [
-        "London",
-        "King's Cross"
-      ],
-      "url": "https://www.scraye.com/listings/960019",
-      "externalUrl": "https://www.scraye.com/listings/960019",
-      "_scraye": {
-        "placeId": "N1C",
-        "placeName": "King's Cross",
-        "slug": "london/kings-cross",
-        "longitude": -0.1269,
-        "latitude": 51.5362,
-        "listTimestamp": "2025-02-03T08:45:00Z",
-        "reference": "SCRAYE-960019"
-      }
-    },
-    {
-      "id": "scraye-960020",
-      "sourceId": "960020",
-      "source": "scraye",
-      "transactionType": "sale",
-      "title": "Heathside Residence, Blackheath SE3",
-      "description": "Grand 4-bedroom family home with orangery, home office and direct views over Blackheath.",
-      "price": "\u00a31,350,000",
-      "priceValue": 1350000,
-      "priceCurrency": "GBP",
-      "priceQualifier": null,
-      "rentFrequency": null,
-      "bedrooms": 4,
-      "bathrooms": 3,
-      "receptions": 2,
-      "propertyType": "DETACHED",
-      "status": "AVAILABLE",
-      "features": [
-        "Orangery",
-        "Home office",
-        "Heath views"
-      ],
-      "furnishedState": null,
-      "image": "https://images.unsplash.com/photo-1570129477492-45c003edd2be?auto=format&fit=crop&w=1200&q=80",
-      "images": [
-        {
-          "id": "blackheath-960020-1",
-          "url": "https://images.unsplash.com/photo-1570129477492-45c003edd2be?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Blackheath home"
-        },
-        {
-          "id": "blackheath-960020-2",
-          "url": "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Orangery"
-        },
-        {
-          "id": "blackheath-960020-3",
-          "url": "https://images.unsplash.com/photo-1521783593447-5702af1b3d4a?auto=format&fit=crop&w=1200&q=80",
-          "altText": "Garden"
-        }
-      ],
-      "media": [],
-      "tenure": "Freehold",
-      "size": "1,958 sq ft",
-      "lat": 51.4673,
-      "lng": 0.0014,
-      "city": "Blackheath",
-      "county": "London",
-      "outcode": "SE3",
-      "matchingRegions": [
-        "London",
-        "Blackheath"
-      ],
-      "url": "https://www.scraye.com/listings/960020",
-      "externalUrl": "https://www.scraye.com/listings/960020",
-      "_scraye": {
-        "placeId": "SE3",
-        "placeName": "Blackheath",
-        "slug": "london/blackheath",
-        "longitude": 0.0014,
-        "latitude": 51.4673,
-        "listTimestamp": "2025-02-02T11:30:00Z",
-        "reference": "SCRAYE-960020"
-      }
-    }
-  ]
+  "sale": []
 }


### PR DESCRIPTION
## Summary
- replace `data/scraye.json` with 20 live Scraye rental listings fetched from the public API, including real pricing, media and location metadata
- clear the obsolete sale fixtures so property detail pages no longer reference dummy Scraye entries

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e18d70507c832ea4d0b9fa824ac8f3