### PR TITLE
Stop using removed next export command in workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -57,11 +57,13 @@ jobs:
             echo "manager=yarn" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
             echo "build=yarn build" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
             echo "command=ci" >> $GITHUB_OUTPUT
             echo "build=npm run build" >> $GITHUB_OUTPUT
+            echo "runner=npx" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine package manager"
@@ -87,10 +89,8 @@ jobs:
       - name: Cache Apex27 listings
         if: steps.detect-secrets.outputs.has-apex-key == 'true'
         run: ${{ steps.detect-package-manager.outputs.manager }} run cache
-      - name: Build with Next.js
+      - name: Build static site with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Export static site
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Verify export directory
         run: |
           if [ ! -d "./out" ]; then


### PR DESCRIPTION
## Summary
- rename the build step to reflect the static export output
- drop the deprecated `next export` command so the workflow works with Next.js 15

## Testing
- npx next build

------
https://chatgpt.com/codex/tasks/task_e_68e197842e04832ebfc487b280ecbdc7