### PR TITLE
Add rental amenity filters and coverage tests

### DIFF
--- a/__tests__/listing-filters.test.js
+++ b/__tests__/listing-filters.test.js
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+jest.mock('../styles/ListingFilters.module.css', () => ({}), { virtual: true });
+
+import ListingFilters from '../components/ListingFilters.js';
+
+const previousActEnv = global.IS_REACT_ACT_ENVIRONMENT;
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('ListingFilters rental preferences', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  afterAll(() => {
+    if (typeof previousActEnv === 'undefined') {
+      delete global.IS_REACT_ACT_ENVIRONMENT;
+    } else {
+      global.IS_REACT_ACT_ENVIRONMENT = previousActEnv;
+    }
+  });
+
+  it('submits boolean flag selections as part of the form state', () => {
+    const onApply = jest.fn();
+
+    act(() => {
+      root.render(
+        <ListingFilters
+          totalResults={2}
+          initialFilters={{
+            search: '',
+            minPrice: '',
+            maxPrice: '',
+            bedrooms: '',
+            propertyType: '',
+            petsAllowed: true,
+            allBillsIncluded: false,
+            hasPorterSecurity: false,
+            hasAccessibilityFeatures: false,
+          }}
+          onApply={onApply}
+          onReset={jest.fn()}
+        />
+      );
+    });
+
+    const form = container.querySelector('form');
+    const petsCheckbox = container.querySelector('input[name="petsAllowed"]');
+    const billsCheckbox = container.querySelector('input[name="allBillsIncluded"]');
+
+    expect(petsCheckbox.checked).toBe(true);
+    expect(billsCheckbox.checked).toBe(false);
+
+    act(() => {
+      petsCheckbox.click();
+      billsCheckbox.click();
+    });
+
+    act(() => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0][0]).toMatchObject({
+      petsAllowed: false,
+      allBillsIncluded: true,
+      hasPorterSecurity: false,
+      hasAccessibilityFeatures: false,
+    });
+  });
+
+  it('clears the rental flag selections when reset is triggered', () => {
+    const onReset = jest.fn();
+
+    act(() => {
+      root.render(
+        <ListingFilters
+          totalResults={3}
+          initialFilters={{
+            petsAllowed: true,
+            allBillsIncluded: true,
+            hasPorterSecurity: true,
+            hasAccessibilityFeatures: true,
+          }}
+          onApply={jest.fn()}
+          onReset={onReset}
+        />
+      );
+    });
+
+    const resetButton = container.querySelector('button[type="button"]');
+    const checkboxes = Array.from(container.querySelectorAll('input[type="checkbox"]'));
+
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox.checked).toBe(true);
+    });
+
+    act(() => {
+      resetButton.click();
+    });
+
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox.checked).toBe(false);
+    });
+    expect(onReset).toHaveBeenCalled();
+  });
+});

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -126,7 +126,13 @@ export function formatOfferAmount(offer, type) {
     }
 
     const frequencyLabel = formatOfferFrequencyLabel(offer?.frequency);
-    return frequencyLabel ? `${formattedPrice} ${frequencyLabel}` : formattedPrice;
+    if (!frequencyLabel) {
+      return formattedPrice;
+    }
+
+    const displayPrice =
+      frequencyLabel === 'Per annum' ? formattedPrice.replace(/,/g, '') : formattedPrice;
+    return `${displayPrice} ${frequencyLabel}`;
   }
 
   const formattedPrice =

--- a/styles/ListingFilters.module.css
+++ b/styles/ListingFilters.module.css
@@ -41,6 +41,40 @@
   gap: var(--spacing-sm);
 }
 
+.flagGroup {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.flagGroup legend {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.flagOptions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-sm);
+}
+
+.flagOption {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.flagOption input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-primary);
+}
+
 .control {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add grouped rental preference toggles to the listing filters component with supporting styles
- propagate the new amenity filters through the to-rent page query logic, chips, and SSR data, and tweak rent offer formatting for annual values
- add unit and integration tests ensuring the new checkboxes submit correct state and filtered results hide non-matching listings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e194d66a8c832e80304a6d8cafe844