### PR TITLE
Improve admin console resilience to missing session data

### DIFF
--- a/components/AgentCard.js
+++ b/components/AgentCard.js
@@ -1,17 +1,38 @@
 import Link from 'next/link';
 
+const PLACEHOLDER_IMAGE = '/images/agent-placeholder.svg';
+
+function getAgentImage(agent) {
+  if (!agent || !agent.photo) {
+    return PLACEHOLDER_IMAGE;
+  }
+
+  return agent.photo;
+}
+
 export default function AgentCard({ agent }) {
   if (!agent) return null;
+  const imageSrc = getAgentImage(agent);
+
+  const handleImageError = (event) => {
+    const target = event.currentTarget;
+    if (target.dataset.fallbackApplied === 'true') {
+      return;
+    }
+    target.dataset.fallbackApplied = 'true';
+    target.src = PLACEHOLDER_IMAGE;
+  };
+
   return (
     <div className="agent-card">
-      {agent.photo && (
-        <img
-          src={agent.photo}
-          alt={agent.name}
-          className="agent-photo"
-          referrerPolicy="no-referrer"
-        />
-      )}
+      <img
+        src={imageSrc}
+        alt={agent.name}
+        className="agent-photo"
+        referrerPolicy="no-referrer"
+        onError={handleImageError}
+        data-fallback-applied="false"
+      />
       <h3>
         <Link href={`/agents/${agent.id}`}>{agent.name}</Link>
       </h3>

--- a/components/FavoriteButton.js
+++ b/components/FavoriteButton.js
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
+import { hasSessionCookie } from '../lib/client-session.js';
+
 const FETCH_OPTIONS = { credentials: 'include' };
 
 export default function FavoriteButton({ propertyId, iconOnly = false, className = '' }) {
@@ -18,6 +20,14 @@ export default function FavoriteButton({ propertyId, iconOnly = false, className
       if (!propertyId) {
         setFavourite(false);
         setLoading(false);
+        return;
+      }
+
+      if (!hasSessionCookie()) {
+        setFavourite(false);
+        setLoading(false);
+        setStatusMessage('Sign in to save favourites.');
+        setStatusTone('info');
         return;
       }
 
@@ -85,6 +95,12 @@ export default function FavoriteButton({ propertyId, iconOnly = false, className
 
   const toggleFavourite = async () => {
     if (!propertyId || updating || loading) {
+      return;
+    }
+
+    if (!hasSessionCookie()) {
+      setStatusTone('error');
+      setStatusMessage('Please sign in to manage favourites.');
       return;
     }
 

--- a/components/SessionProvider.js
+++ b/components/SessionProvider.js
@@ -1,5 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { hasSessionCookie } from '../lib/client-session.js';
+
 const SessionContext = createContext({
   user: null,
   loading: true,
@@ -12,6 +14,10 @@ const SessionContext = createContext({
 
 
 async function fetchSession() {
+  if (typeof window !== 'undefined' && !hasSessionCookie()) {
+    return { contact: null, email: null };
+  }
+
   const res = await fetch('/api/account/me', { credentials: 'include' });
 
   if (res.status === 401) {

--- a/data/agents.json
+++ b/data/agents.json
@@ -3,14 +3,14 @@
     "id": "1723",
     "name": "Shah Chowdhury",
     "phone": "02033898009",
-    "photo": "https://via.placeholder.com/150",
+    "photo": "/images/agent-placeholder.svg",
     "bio": "Specialist in London rentals and sales."
   },
   {
     "id": "1724",
     "name": "Jane Doe",
     "phone": "02033898010",
-    "photo": "https://via.placeholder.com/150",
+    "photo": "/images/agent-placeholder.svg",
     "bio": "Passionate about helping clients find their dream homes."
   }
 ]

--- a/lib/client-session.js
+++ b/lib/client-session.js
@@ -1,0 +1,14 @@
+const SESSION_COOKIE_NAME = 'aktonz_session';
+
+export function hasSessionCookie() {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  const cookies = document.cookie ? document.cookie.split(';') : [];
+  return cookies.some((cookie) => cookie.trim().startsWith(`${SESSION_COOKIE_NAME}=`));
+}
+
+export function getSessionCookieName() {
+  return SESSION_COOKIE_NAME;
+}

--- a/lib/offers-admin.mjs
+++ b/lib/offers-admin.mjs
@@ -148,13 +148,15 @@ function buildOfferPresentation(offer) {
 }
 
 export async function listOffersForAdmin() {
-  const listingMap = buildListingMap();
-  const contactMap = buildContactMap(listingMap);
-  const agentMap = buildAgentMap();
-  const offers = await readOffers();
+  try {
+    const listingMap = buildListingMap();
+    const contactMap = buildContactMap(listingMap);
+    const agentMap = buildAgentMap();
+    const rawOffers = await readOffers();
+    const offers = Array.isArray(rawOffers) ? rawOffers : [];
 
-  return offers
-    .map((offer) => {
+    return offers
+      .map((offer) => {
       const contactId = offer.contactId ? String(offer.contactId) : '';
       const propertyId = offer.propertyId ? String(offer.propertyId) : '';
       const agentId = offer.agentId ? String(offer.agentId) : '';
@@ -234,10 +236,14 @@ export async function listOffersForAdmin() {
         property,
         agent,
       };
-    })
-    .sort((a, b) => {
-      const right = normalizeDate(b.updatedAt || b.createdAt || b.date);
-      const left = normalizeDate(a.updatedAt || a.createdAt || a.date);
-      return right - left;
-    });
+      })
+      .sort((a, b) => {
+        const right = normalizeDate(b.updatedAt || b.createdAt || b.date);
+        const left = normalizeDate(a.updatedAt || a.createdAt || a.date);
+        return right - left;
+      });
+  } catch (error) {
+    console.error('Unable to compose offers for admin dashboard', error);
+    return [];
+  }
 }

--- a/pages/agents/[id].js
+++ b/pages/agents/[id].js
@@ -2,6 +2,16 @@ import PropertyList from '../../components/PropertyList';
 import agents from '../../data/agents.json';
 import { fetchProperties } from '../../lib/apex27.mjs';
 
+const PLACEHOLDER_IMAGE = '/images/agent-placeholder.svg';
+
+function resolveAgentImage(agent) {
+  if (!agent || !agent.photo) {
+    return PLACEHOLDER_IMAGE;
+  }
+
+  return agent.photo;
+}
+
 export default function AgentPage({ agent, listings }) {
   if (!agent) {
     return (
@@ -11,15 +21,26 @@ export default function AgentPage({ agent, listings }) {
     );
   }
 
+  const photoSrc = resolveAgentImage(agent);
+
+  const handleImageError = (event) => {
+    const target = event.currentTarget;
+    if (target.dataset.fallbackApplied === 'true') {
+      return;
+    }
+    target.dataset.fallbackApplied = 'true';
+    target.src = PLACEHOLDER_IMAGE;
+  };
+
   return (
     <main>
-      {agent.photo && (
-        <img
-          src={agent.photo}
-          alt={agent.name}
-          style={{ maxWidth: 'var(--size-avatar)' }}
-        />
-      )}
+      <img
+        src={photoSrc}
+        alt={agent.name}
+        style={{ maxWidth: 'var(--size-avatar)' }}
+        onError={handleImageError}
+        data-fallback-applied="false"
+      />
       <h1>{agent.name}</h1>
       {agent.bio && <p>{agent.bio}</p>}
       {agent.phone && (

--- a/public/images/agent-placeholder.svg
+++ b/public/images/agent-placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title">
+  <title>Agent placeholder</title>
+  <rect width="120" height="120" fill="#f3f4f6"/>
+  <circle cx="60" cy="42" r="22" fill="#d1d5db"/>
+  <path d="M18 110c0-23 19-42 42-42s42 19 42 42" fill="#d1d5db"/>
+</svg>


### PR DESCRIPTION
## Summary
- avoid unauthenticated fetches in the session provider and favourite button when there is no session cookie
- add a local placeholder asset and fallback handling for agent photos to eliminate broken image requests
- harden the admin offers list builder to fail gracefully if offers data cannot be read

## Testing
- npm test -- admin-offers
- npm test -- account-activity-api

------
https://chatgpt.com/codex/tasks/task_e_68e1e7f4d688832ebe746152a26cf653