### PR TITLE
Fix admin dashboard access with HttpOnly session cookies

### DIFF
--- a/__tests__/property-sustainability-panel.test.jsx
+++ b/__tests__/property-sustainability-panel.test.jsx
@@ -69,7 +69,7 @@ describe('PropertySustainabilityPanel', () => {
       includedUtilities: {},
     };
 
-    const markup = renderToStaticMarkup(
+    render(
       <PropertySustainabilityPanel property={property} />
     );
 

--- a/components/FavoriteButton.js
+++ b/components/FavoriteButton.js
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
-import { hasSessionCookie } from '../lib/client-session.js';
-
 const FETCH_OPTIONS = { credentials: 'include' };
 
 export default function FavoriteButton({ propertyId, iconOnly = false, className = '' }) {
@@ -23,14 +21,6 @@ export default function FavoriteButton({ propertyId, iconOnly = false, className
         return;
       }
 
-      if (!hasSessionCookie()) {
-        setFavourite(false);
-        setLoading(false);
-        setStatusMessage('Sign in to save favourites.');
-        setStatusTone('info');
-        return;
-      }
-
       try {
         const response = await fetch('/api/account/favourites', FETCH_OPTIONS);
         if (!active) return;
@@ -38,7 +28,7 @@ export default function FavoriteButton({ propertyId, iconOnly = false, className
         if (response.status === 401) {
           setFavourite(false);
           setStatusMessage('Sign in to save favourites.');
-          setStatusTone('error');
+          setStatusTone('info');
           return;
         }
 
@@ -95,12 +85,6 @@ export default function FavoriteButton({ propertyId, iconOnly = false, className
 
   const toggleFavourite = async () => {
     if (!propertyId || updating || loading) {
-      return;
-    }
-
-    if (!hasSessionCookie()) {
-      setStatusTone('error');
-      setStatusMessage('Please sign in to manage favourites.');
       return;
     }
 

--- a/components/SessionProvider.js
+++ b/components/SessionProvider.js
@@ -1,7 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { hasSessionCookie } from '../lib/client-session.js';
-
 const SessionContext = createContext({
   user: null,
   loading: true,
@@ -14,10 +12,6 @@ const SessionContext = createContext({
 
 
 async function fetchSession() {
-  if (typeof window !== 'undefined' && !hasSessionCookie()) {
-    return { contact: null, email: null };
-  }
-
   const res = await fetch('/api/account/me', { credentials: 'include' });
 
   if (res.status === 401) {


### PR DESCRIPTION
## Summary
- ensure the session provider always requests the current account instead of relying on detecting client-visible cookies
- update the favourites button to depend on API responses for authentication feedback rather than the session cookie heuristic
- fix the sustainability panel fallback test to render the component before running assertions

## Testing
- npm test -- --runTestsByPath __tests__/property-sustainability-panel.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e453490734832e9ab59fad6323df3a