### PR TITLE
feat: enable account offers and documents management

### DIFF
--- a/components/account/AccountLayout.js
+++ b/components/account/AccountLayout.js
@@ -48,11 +48,11 @@ export const DEFAULT_ACCOUNT_TABS = [
   },
   {
     label: 'Offers & viewings',
-    disabled: true,
+    href: '/account/offers',
   },
   {
     label: 'Documents',
-    disabled: true,
+    href: '/account/documents',
   },
 ];
 

--- a/lib/account-documents.js
+++ b/lib/account-documents.js
@@ -1,0 +1,144 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+
+const { readContactEntries, updateContactEntries } = require('./account-storage.js');
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const DOCUMENTS_DIR = path.join(DATA_DIR, 'documents');
+const STORE_NAME = 'documents.json';
+
+function sanitiseFileName(name) {
+  if (typeof name !== 'string') {
+    return 'document';
+  }
+  const base = name.replace(/\\/g, '/').split('/').pop() || 'document';
+  return base.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+async function ensureDocumentsDir() {
+  await fs.mkdir(DOCUMENTS_DIR, { recursive: true });
+}
+
+function formatDocumentEntry(entry) {
+  if (!entry) return null;
+  return {
+    id: entry.id,
+    fileName: entry.fileName,
+    storedName: entry.storedName,
+    mimeType: entry.mimeType,
+    size: entry.size,
+    uploadedAt: entry.uploadedAt,
+    category: entry.category || null,
+    note: entry.note || null,
+  };
+}
+
+async function listDocuments(contactId) {
+  const entries = await readContactEntries(STORE_NAME, contactId);
+  return entries.map(formatDocumentEntry).filter(Boolean);
+}
+
+async function saveDocument(contactId, { originalName, mimeType, buffer, category = null, note = null }) {
+  if (!contactId) {
+    throw new Error('Contact ID is required');
+  }
+  if (!buffer || !(buffer instanceof Buffer) || buffer.length === 0) {
+    throw new Error('File data is required');
+  }
+
+  await ensureDocumentsDir();
+
+  const id = randomUUID();
+  const safeName = sanitiseFileName(originalName);
+  const extension = path.extname(safeName);
+  const storedName = extension ? `${id}${extension}` : id;
+  const filePath = path.join(DOCUMENTS_DIR, storedName);
+  const uploadedAt = new Date().toISOString();
+
+  await fs.writeFile(filePath, buffer);
+
+  const entry = {
+    id,
+    fileName: safeName,
+    storedName,
+    mimeType: typeof mimeType === 'string' && mimeType ? mimeType : 'application/octet-stream',
+    size: buffer.length,
+    uploadedAt,
+    category,
+    note,
+  };
+
+  await updateContactEntries(STORE_NAME, contactId, (existing) => {
+    const next = Array.isArray(existing) ? [entry, ...existing.filter((item) => item?.id !== id)] : [entry];
+    return next;
+  });
+
+  return formatDocumentEntry(entry);
+}
+
+async function readDocumentFile(contactId, documentId) {
+  if (!contactId || !documentId) {
+    return null;
+  }
+  const entries = await readContactEntries(STORE_NAME, contactId);
+  const entry = entries.find((item) => item?.id === documentId);
+  if (!entry) {
+    return null;
+  }
+
+  const filePath = path.join(DOCUMENTS_DIR, entry.storedName);
+  try {
+    const buffer = await fs.readFile(filePath);
+    return { entry: formatDocumentEntry(entry), buffer };
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function deleteDocument(contactId, documentId) {
+  if (!contactId || !documentId) {
+    return false;
+  }
+
+  let removedEntry = null;
+  await updateContactEntries(STORE_NAME, contactId, (existing) => {
+    if (!Array.isArray(existing)) {
+      return [];
+    }
+    const next = [];
+    for (const item of existing) {
+      if (item?.id === documentId && !removedEntry) {
+        removedEntry = item;
+      } else if (item) {
+        next.push(item);
+      }
+    }
+    return next;
+  });
+
+  if (!removedEntry) {
+    return false;
+  }
+
+  const filePath = path.join(DOCUMENTS_DIR, removedEntry.storedName);
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    if (!(error && typeof error === 'object' && error.code === 'ENOENT')) {
+      throw error;
+    }
+  }
+
+  return true;
+}
+
+module.exports = {
+  listDocuments,
+  saveDocument,
+  readDocumentFile,
+  deleteDocument,
+};

--- a/pages/account/documents.js
+++ b/pages/account/documents.js
@@ -1,0 +1,307 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import AccountLayout from '../../components/account/AccountLayout';
+import { useSession } from '../../components/SessionProvider';
+import styles from '../../styles/AccountDocuments.module.css';
+
+const CATEGORY_OPTIONS = [
+  { value: '', label: 'Select a category' },
+  { value: 'tenancy', label: 'Tenancy' },
+  { value: 'sale', label: 'Sale' },
+  { value: 'compliance', label: 'Compliance' },
+  { value: 'other', label: 'Other' },
+];
+
+function formatFileSize(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return '—';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+async function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function AccountDocumentsPage() {
+  const { loading: sessionLoading } = useSession();
+  const [documents, setDocuments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [requiresAuth, setRequiresAuth] = useState(false);
+  const [file, setFile] = useState(null);
+  const [category, setCategory] = useState('');
+  const [note, setNote] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [deletingId, setDeletingId] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadDocuments() {
+      setLoading(true);
+      setError('');
+      try {
+        const response = await fetch('/api/account/documents', { credentials: 'include' });
+        if (cancelled) return;
+        if (response.status === 401) {
+          setRequiresAuth(true);
+          setDocuments([]);
+          setError('Sign in to manage your tenancy documents.');
+          return;
+        }
+        if (!response.ok) {
+          throw new Error('Failed to load documents');
+        }
+        const payload = await response.json();
+        if (cancelled) return;
+        const items = Array.isArray(payload?.documents) ? payload.documents : [];
+        setDocuments(items);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Failed to load documents', err);
+        setError('We could not load your documents. Please try again.');
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    loadDocuments();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasDocuments = documents.length > 0;
+  const sortedDocuments = useMemo(() => {
+    return [...documents].sort((a, b) => new Date(b?.uploadedAt || 0) - new Date(a?.uploadedAt || 0));
+  }, [documents]);
+
+  function handleFileChange(event) {
+    const selected = event.target.files?.[0] || null;
+    setFile(selected);
+    setFeedback('');
+  }
+
+  async function handleUpload(event) {
+    event.preventDefault();
+    if (requiresAuth) {
+      setFeedback('Please sign in to upload documents.');
+      return;
+    }
+    if (!file) {
+      setFeedback('Choose a file to upload.');
+      return;
+    }
+
+    setUploading(true);
+    setFeedback('');
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      const response = await fetch('/api/account/documents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          fileName: file.name,
+          fileType: file.type,
+          data: dataUrl,
+          category,
+          note,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to upload document');
+      }
+      if (payload?.document) {
+        setDocuments((prev) => [payload.document, ...prev.filter((doc) => doc.id !== payload.document.id)]);
+        setFeedback('Document uploaded successfully.');
+        setFile(null);
+        setCategory('');
+        setNote('');
+      }
+    } catch (err) {
+      console.error('Document upload failed', err);
+      setFeedback(err instanceof Error ? err.message : 'Unable to upload document.');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleDelete(id) {
+    if (!id) return;
+    setDeletingId(id);
+    setFeedback('');
+    try {
+      const response = await fetch(`/api/account/documents/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to delete document');
+      }
+      setDocuments((prev) => prev.filter((doc) => doc.id !== id));
+    } catch (err) {
+      console.error('Failed to delete document', err);
+      setFeedback(err instanceof Error ? err.message : 'Unable to delete document.');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <AccountLayout
+      heroSubtitle="My documents"
+      heroTitle="Tenancy & sale documents"
+      heroDescription="Securely share identity, compliance and contractual documents with the Aktonz team."
+    >
+      {requiresAuth ? (
+        <div className={styles.feedback} role="alert">
+          Please sign in to upload or download your documents.
+        </div>
+      ) : null}
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2>Upload documents</h2>
+            <p>Accepted formats include PDF, JPEG and PNG with a maximum size of 10MB.</p>
+          </div>
+        </div>
+        <form className={styles.uploadForm} onSubmit={handleUpload}>
+          <div className={styles.uploadRow}>
+            <div className={styles.fieldGroup}>
+              <label htmlFor="document-file">Select file</label>
+              <input
+                id="document-file"
+                type="file"
+                onChange={handleFileChange}
+                accept=".pdf,.jpg,.jpeg,.png,.doc,.docx"
+              />
+              {file ? (
+                <span className={styles.fileHint}>
+                  {file.name} • {formatFileSize(file.size)}
+                </span>
+              ) : null}
+            </div>
+            <div className={styles.fieldGroup}>
+              <label htmlFor="document-category">Category</label>
+              <select
+                id="document-category"
+                value={category}
+                onChange={(event) => setCategory(event.target.value)}
+              >
+                {CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className={styles.fieldGroup}>
+            <label htmlFor="document-note">Notes</label>
+            <textarea
+              id="document-note"
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              rows={3}
+              placeholder="Add any context for the team (optional)"
+            />
+          </div>
+          {feedback ? (
+            <p className={styles.feedback} role="alert">
+              {feedback}
+            </p>
+          ) : null}
+          <button type="submit" className={styles.submitButton} disabled={uploading}>
+            {uploading ? 'Uploading…' : 'Upload document'}
+          </button>
+        </form>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2>Stored documents</h2>
+            <p>Download or remove documents you no longer need.</p>
+          </div>
+        </div>
+        <div className={styles.listingCard}>
+          {loading && !hasDocuments ? (
+            <p className={styles.placeholder}>Loading your documents…</p>
+          ) : null}
+          {error ? <p className={styles.feedback}>{error}</p> : null}
+          {!loading && !hasDocuments && !error ? (
+            <p className={styles.placeholder}>No documents uploaded yet. Use the form above to add your first file.</p>
+          ) : null}
+          <ul className={styles.documentList}>
+            {sortedDocuments.map((doc) => (
+              <li key={doc.id} className={styles.documentCard}>
+                <div className={styles.documentHeader}>
+                  <div>
+                    <h3>{doc.fileName}</h3>
+                    <p className={styles.documentMeta}>
+                      {formatFileSize(doc.size)} · {doc.mimeType || 'Unknown type'}
+                    </p>
+                    <p className={styles.documentMeta}>Uploaded {formatDate(doc.uploadedAt) || '—'}</p>
+                    {doc.category ? <span className={styles.badge}>{doc.category}</span> : null}
+                    {doc.note ? <p className={styles.documentNote}>{doc.note}</p> : null}
+                  </div>
+                  <div className={styles.documentActions}>
+                    <a
+                      href={`/api/account/documents/${doc.id}`}
+                      className={styles.actionButton}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Download
+                    </a>
+                    <button
+                      type="button"
+                      className={styles.deleteButton}
+                      onClick={() => handleDelete(doc.id)}
+                      disabled={deletingId === doc.id}
+                    >
+                      {deletingId === doc.id ? 'Removing…' : 'Delete'}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {sessionLoading && !hasDocuments ? (
+        <p className={styles.placeholder}>Checking your account…</p>
+      ) : null}
+    </AccountLayout>
+  );
+}

--- a/pages/account/offers.js
+++ b/pages/account/offers.js
@@ -1,0 +1,537 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import AccountLayout from '../../components/account/AccountLayout';
+import { useSession } from '../../components/SessionProvider';
+import styles from '../../styles/AccountOffers.module.css';
+
+const FREQUENCY_OPTIONS = [
+  { value: 'pcm', label: 'Per calendar month' },
+  { value: 'pw', label: 'Per week' },
+  { value: 'pa', label: 'Per annum' },
+];
+
+function formatCurrency(value) {
+  if (value == null || Number.isNaN(Number(value))) {
+    return '—';
+  }
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: 'GBP',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(Number(value));
+  } catch (error) {
+    return `£${value}`;
+  }
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function sortByDate(a, b) {
+  return new Date(b?.createdAt || 0) - new Date(a?.createdAt || 0);
+}
+
+const defaultOfferForm = {
+  propertyId: '',
+  propertyTitle: '',
+  propertyAddress: '',
+  amount: '',
+  frequency: 'pcm',
+  message: '',
+  name: '',
+  email: '',
+  phone: '',
+};
+
+const defaultViewingForm = {
+  propertyId: '',
+  date: '',
+  time: '',
+  message: '',
+};
+
+export default function AccountOffersPage() {
+  const { user, email, loading: sessionLoading } = useSession();
+  const [offers, setOffers] = useState([]);
+  const [viewings, setViewings] = useState([]);
+  const [offersLoading, setOffersLoading] = useState(true);
+  const [viewingsLoading, setViewingsLoading] = useState(true);
+  const [offersError, setOffersError] = useState('');
+  const [viewingsError, setViewingsError] = useState('');
+  const [offerForm, setOfferForm] = useState(defaultOfferForm);
+  const [viewingForm, setViewingForm] = useState(defaultViewingForm);
+  const [offerSubmitting, setOfferSubmitting] = useState(false);
+  const [viewingSubmitting, setViewingSubmitting] = useState(false);
+  const [offerFeedback, setOfferFeedback] = useState('');
+  const [viewingFeedback, setViewingFeedback] = useState('');
+  const [requiresAuth, setRequiresAuth] = useState(false);
+
+  const defaultName = useMemo(() => {
+    if (!user) return '';
+    return [user.firstName, user.surname].filter(Boolean).join(' ').trim();
+  }, [user]);
+
+  const defaultPhone = useMemo(() => {
+    if (!user) return '';
+    return user.mobilePhone || user.phone || user.homePhone || '';
+  }, [user]);
+
+  useEffect(() => {
+    setOfferForm((prev) => ({
+      ...prev,
+      name: prev.name || defaultName,
+      email: prev.email || email || '',
+      phone: prev.phone || defaultPhone,
+    }));
+  }, [defaultName, defaultPhone, email]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadOffers() {
+      setOffersLoading(true);
+      setOffersError('');
+      try {
+        const response = await fetch('/api/account/offers', { credentials: 'include' });
+        if (cancelled) return;
+        if (response.status === 401) {
+          setRequiresAuth(true);
+          setOffers([]);
+          setOffersError('Sign in to review your offers.');
+          return;
+        }
+        if (!response.ok) {
+          throw new Error('Failed to load offers');
+        }
+        const payload = await response.json();
+        if (cancelled) return;
+        const items = Array.isArray(payload?.offers) ? payload.offers : [];
+        items.sort(sortByDate);
+        setOffers(items);
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Failed to load offers', error);
+        setOffersError('We could not load your offers. Please try again.');
+      } finally {
+        if (!cancelled) {
+          setOffersLoading(false);
+        }
+      }
+    }
+    loadOffers();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadViewings() {
+      setViewingsLoading(true);
+      setViewingsError('');
+      try {
+        const response = await fetch('/api/account/viewings', { credentials: 'include' });
+        if (cancelled) return;
+        if (response.status === 401) {
+          setRequiresAuth(true);
+          setViewings([]);
+          setViewingsError('Sign in to see your viewing requests.');
+          return;
+        }
+        if (!response.ok) {
+          throw new Error('Failed to load viewings');
+        }
+        const payload = await response.json();
+        if (cancelled) return;
+        const items = Array.isArray(payload?.viewings) ? payload.viewings : [];
+        items.sort(sortByDate);
+        setViewings(items);
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Failed to load viewings', error);
+        setViewingsError('We could not load your viewing activity. Please try again.');
+      } finally {
+        if (!cancelled) {
+          setViewingsLoading(false);
+        }
+      }
+    }
+    loadViewings();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function handleOfferInputChange(event) {
+    const { name, value } = event.target;
+    setOfferForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function handleViewingInputChange(event) {
+    const { name, value } = event.target;
+    setViewingForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  async function handleOfferSubmit(event) {
+    event.preventDefault();
+    if (requiresAuth) {
+      setOfferFeedback('Please sign in to submit an offer.');
+      return;
+    }
+    setOfferFeedback('');
+    setOfferSubmitting(true);
+    try {
+      const response = await fetch('/api/account/offers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(offerForm),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const detail = Array.isArray(payload?.details) ? payload.details.join(' ') : payload?.error;
+        throw new Error(detail || 'Unable to submit offer');
+      }
+      const entry = payload?.offer;
+      if (entry) {
+        setOffers((prev) => [entry, ...prev.filter((item) => item?.id !== entry.id)].sort(sortByDate));
+        setOfferForm((prev) => ({
+          ...defaultOfferForm,
+          name: prev.name || defaultName,
+          email: prev.email || email || '',
+          phone: prev.phone || defaultPhone,
+        }));
+        setOfferFeedback('Offer submitted successfully. Our team will be in touch.');
+      }
+    } catch (error) {
+      console.error('Offer submission failed', error);
+      setOfferFeedback(error instanceof Error ? error.message : 'Unable to submit offer.');
+    } finally {
+      setOfferSubmitting(false);
+    }
+  }
+
+  async function handleViewingSubmit(event) {
+    event.preventDefault();
+    if (requiresAuth) {
+      setViewingFeedback('Please sign in to request a viewing.');
+      return;
+    }
+    setViewingFeedback('');
+    setViewingSubmitting(true);
+    try {
+      const response = await fetch('/api/account/viewings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(viewingForm),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const detail = Array.isArray(payload?.details) ? payload.details.join(' ') : payload?.error;
+        throw new Error(detail || 'Unable to request viewing');
+      }
+      const entry = payload?.viewing;
+      if (entry) {
+        setViewings((prev) => [entry, ...prev.filter((item) => item?.id !== entry.id)].sort(sortByDate));
+        setViewingForm(defaultViewingForm);
+        setViewingFeedback('Viewing request sent. We will confirm the appointment shortly.');
+      }
+    } catch (error) {
+      console.error('Viewing request failed', error);
+      setViewingFeedback(error instanceof Error ? error.message : 'Unable to request viewing.');
+    } finally {
+      setViewingSubmitting(false);
+    }
+  }
+
+  const isLoading = sessionLoading || offersLoading || viewingsLoading;
+
+  return (
+    <AccountLayout
+      heroSubtitle="My activity"
+      heroTitle="Offers & viewings"
+      heroDescription="Track your negotiations and appointments in one place, and raise new requests whenever you are ready."
+    >
+      {requiresAuth ? (
+        <div className={styles.feedback} role="alert">
+          Please sign in to manage your offers and viewing requests.
+        </div>
+      ) : null}
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2>Offer history</h2>
+            <p>Review recent offers and raise a new one for any property on your shortlist.</p>
+          </div>
+        </div>
+        <div className={styles.sectionContent}>
+          <div className={styles.formCard}>
+            <h3>Create a new offer</h3>
+            <p>Submit the details below and our negotiators will follow up straight away.</p>
+            <form className={styles.form} onSubmit={handleOfferSubmit}>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="offer-propertyId">Property reference</label>
+                <input
+                  id="offer-propertyId"
+                  name="propertyId"
+                  value={offerForm.propertyId}
+                  onChange={handleOfferInputChange}
+                  required
+                  placeholder="e.g. AKT-12345"
+                />
+              </div>
+              <div className={styles.fieldRow}>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-propertyTitle">Property name</label>
+                  <input
+                    id="offer-propertyTitle"
+                    name="propertyTitle"
+                    value={offerForm.propertyTitle}
+                    onChange={handleOfferInputChange}
+                    placeholder="Optional"
+                  />
+                </div>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-propertyAddress">Address</label>
+                  <input
+                    id="offer-propertyAddress"
+                    name="propertyAddress"
+                    value={offerForm.propertyAddress}
+                    onChange={handleOfferInputChange}
+                    placeholder="Optional"
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldRow}>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-amount">Offer amount</label>
+                  <input
+                    id="offer-amount"
+                    name="amount"
+                    value={offerForm.amount}
+                    onChange={handleOfferInputChange}
+                    required
+                    inputMode="decimal"
+                    placeholder="£2,500"
+                  />
+                </div>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-frequency">Frequency</label>
+                  <select
+                    id="offer-frequency"
+                    name="frequency"
+                    value={offerForm.frequency}
+                    onChange={handleOfferInputChange}
+                  >
+                    {FREQUENCY_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className={styles.fieldRow}>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-name">Your name</label>
+                  <input
+                    id="offer-name"
+                    name="name"
+                    value={offerForm.name}
+                    onChange={handleOfferInputChange}
+                    required
+                  />
+                </div>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="offer-email">Email</label>
+                  <input
+                    id="offer-email"
+                    name="email"
+                    type="email"
+                    value={offerForm.email}
+                    onChange={handleOfferInputChange}
+                    required
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="offer-phone">Phone number</label>
+                <input
+                  id="offer-phone"
+                  name="phone"
+                  value={offerForm.phone}
+                  onChange={handleOfferInputChange}
+                  placeholder="Optional"
+                />
+              </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="offer-message">Supporting notes</label>
+                <textarea
+                  id="offer-message"
+                  name="message"
+                  value={offerForm.message}
+                  onChange={handleOfferInputChange}
+                  rows={4}
+                  placeholder="Add any conditions or context for your offer"
+                />
+              </div>
+              {offerFeedback ? (
+                <p className={styles.feedback} role="alert">
+                  {offerFeedback}
+                </p>
+              ) : null}
+              <button type="submit" className={styles.submitButton} disabled={offerSubmitting}>
+                {offerSubmitting ? 'Sending offer…' : 'Submit offer'}
+              </button>
+            </form>
+          </div>
+          <div className={styles.listingCard}>
+            <h3>Recent offers</h3>
+            {offersLoading && !offers.length ? (
+              <p className={styles.placeholder}>Loading your offers…</p>
+            ) : null}
+            {offersError ? <p className={styles.feedback}>{offersError}</p> : null}
+            {!offersLoading && !offers.length && !offersError ? (
+              <p className={styles.placeholder}>No offers yet. Submit one using the form to get started.</p>
+            ) : null}
+            <ul className={styles.offerList}>
+              {offers.map((offer) => (
+                <li key={offer.id} className={styles.offerCard}>
+                  <header className={styles.offerHeader}>
+                    <div>
+                      <h4>Property {offer.propertyId}</h4>
+                      {offer.propertyTitle ? <p>{offer.propertyTitle}</p> : null}
+                      {offer.propertyAddress ? <p className={styles.subtle}>{offer.propertyAddress}</p> : null}
+                    </div>
+                    <div className={styles.offerMeta}>
+                      <span className={styles.offerAmount}>{formatCurrency(offer.amount)}</span>
+                      {offer.frequency ? <span className={styles.badge}>{offer.frequency}</span> : null}
+                    </div>
+                  </header>
+                  {offer.message ? <p className={styles.offerMessage}>{offer.message}</p> : null}
+                  <footer className={styles.offerFooter}>
+                    <span>Status: {offer.status || 'submitted'}</span>
+                    <span>{formatDate(offer.createdAt) || 'Pending'}</span>
+                  </footer>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <h2>Viewing requests</h2>
+            <p>Manage upcoming appointments and request new tours with the team.</p>
+          </div>
+        </div>
+        <div className={styles.sectionContent}>
+          <div className={styles.formCard}>
+            <h3>Book a viewing</h3>
+            <p>Tell us which property you would like to see and when suits you best.</p>
+            <form className={styles.form} onSubmit={handleViewingSubmit}>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="viewing-propertyId">Property reference</label>
+                <input
+                  id="viewing-propertyId"
+                  name="propertyId"
+                  value={viewingForm.propertyId}
+                  onChange={handleViewingInputChange}
+                  required
+                  placeholder="e.g. AKT-12345"
+                />
+              </div>
+              <div className={styles.fieldRow}>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="viewing-date">Preferred date</label>
+                  <input
+                    id="viewing-date"
+                    name="date"
+                    type="date"
+                    value={viewingForm.date}
+                    onChange={handleViewingInputChange}
+                  />
+                </div>
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="viewing-time">Preferred time</label>
+                  <input
+                    id="viewing-time"
+                    name="time"
+                    type="time"
+                    value={viewingForm.time}
+                    onChange={handleViewingInputChange}
+                  />
+                </div>
+              </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="viewing-message">Notes</label>
+                <textarea
+                  id="viewing-message"
+                  name="message"
+                  value={viewingForm.message}
+                  onChange={handleViewingInputChange}
+                  rows={4}
+                  placeholder="Share your availability or key questions"
+                />
+              </div>
+              {viewingFeedback ? (
+                <p className={styles.feedback} role="alert">
+                  {viewingFeedback}
+                </p>
+              ) : null}
+              <button type="submit" className={styles.submitButton} disabled={viewingSubmitting}>
+                {viewingSubmitting ? 'Sending request…' : 'Request viewing'}
+              </button>
+            </form>
+          </div>
+          <div className={styles.listingCard}>
+            <h3>Upcoming & recent viewings</h3>
+            {viewingsLoading && !viewings.length ? (
+              <p className={styles.placeholder}>Loading your viewing requests…</p>
+            ) : null}
+            {viewingsError ? <p className={styles.feedback}>{viewingsError}</p> : null}
+            {!viewingsLoading && !viewings.length && !viewingsError ? (
+              <p className={styles.placeholder}>No viewing requests yet. Use the form to book your first appointment.</p>
+            ) : null}
+            <ul className={styles.viewingList}>
+              {viewings.map((viewing) => (
+                <li key={viewing.id} className={styles.viewingCard}>
+                  <header className={styles.viewingHeader}>
+                    <div>
+                      <h4>Property {viewing.propertyId}</h4>
+                      <span className={styles.badge}>{viewing.status || 'requested'}</span>
+                    </div>
+                    <div className={styles.viewingMeta}>
+                      {viewing.preferredDate ? <span>{viewing.preferredDate}</span> : null}
+                      {viewing.preferredTime ? <span>{viewing.preferredTime}</span> : null}
+                      <span className={styles.subtle}>{formatDate(viewing.createdAt) || 'Pending'}</span>
+                    </div>
+                  </header>
+                  {viewing.message ? <p className={styles.viewingMessage}>{viewing.message}</p> : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {isLoading && !offers.length && !viewings.length ? (
+        <p className={styles.placeholder}>Loading your activity…</p>
+      ) : null}
+    </AccountLayout>
+  );
+}

--- a/pages/api/account/documents/[id].js
+++ b/pages/api/account/documents/[id].js
@@ -1,0 +1,66 @@
+import { readSession } from '../../../../lib/session.js';
+const {
+  readDocumentFile,
+  deleteDocument,
+} = require('../../../../lib/account-documents.js');
+
+function requireContact(req, res) {
+  const session = readSession(req);
+  const contactId = session?.contactId;
+  if (!contactId) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
+  }
+  return { contactId };
+}
+
+export default async function handler(req, res) {
+  const contact = requireContact(req, res);
+  if (!contact) {
+    return;
+  }
+
+  const { id } = req.query || {};
+  if (typeof id !== 'string' || !id) {
+    res.status(400).json({ error: 'Document ID is required' });
+    return;
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const result = await readDocumentFile(contact.contactId, id);
+      if (!result) {
+        res.status(404).json({ error: 'Document not found' });
+        return;
+      }
+
+      res.setHeader('Content-Type', result.entry.mimeType || 'application/octet-stream');
+      res.setHeader('Content-Length', result.buffer.length);
+      const safeName = encodeURIComponent(result.entry.fileName || `document-${id}`);
+      res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${safeName}`);
+      res.status(200).send(result.buffer);
+    } catch (error) {
+      console.error('Failed to read document', error);
+      res.status(500).json({ error: 'Unable to download document.' });
+    }
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    try {
+      const removed = await deleteDocument(contact.contactId, id);
+      if (!removed) {
+        res.status(404).json({ error: 'Document not found' });
+        return;
+      }
+      res.status(200).json({ ok: true });
+    } catch (error) {
+      console.error('Failed to delete document', error);
+      res.status(500).json({ error: 'Unable to delete document.' });
+    }
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'DELETE']);
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/pages/api/account/documents/index.js
+++ b/pages/api/account/documents/index.js
@@ -1,0 +1,108 @@
+import { Buffer } from 'node:buffer';
+
+import { readSession } from '../../../../lib/session.js';
+const {
+  listDocuments,
+  saveDocument,
+} = require('../../../../lib/account-documents.js');
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+function requireContact(req, res) {
+  const session = readSession(req);
+  const contactId = session?.contactId;
+  if (!contactId) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
+  }
+  return { contactId };
+}
+
+function normaliseString(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : '';
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function parseBase64Data(data) {
+  if (typeof data !== 'string' || !data) {
+    return null;
+  }
+  const commaIndex = data.indexOf(',');
+  const raw = commaIndex >= 0 ? data.slice(commaIndex + 1) : data;
+  try {
+    return Buffer.from(raw, 'base64');
+  } catch (error) {
+    return null;
+  }
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '12mb',
+    },
+  },
+};
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const documents = await listDocuments(contact.contactId);
+    documents.sort((a, b) => new Date(b.uploadedAt || 0) - new Date(a.uploadedAt || 0));
+    res.status(200).json({ documents });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const body = req.body || {};
+    const fileName = normaliseString(body.fileName);
+    const fileType = normaliseString(body.fileType);
+    const note = normaliseString(body.note);
+    const category = normaliseString(body.category);
+    const buffer = parseBase64Data(body.data || body.base64 || body.fileData);
+
+    if (!fileName || !buffer) {
+      res.status(400).json({ error: 'File name and data are required.' });
+      return;
+    }
+
+    if (buffer.length > MAX_FILE_SIZE) {
+      res.status(413).json({ error: 'File is too large. Maximum size is 10MB.' });
+      return;
+    }
+
+    try {
+      const document = await saveDocument(contact.contactId, {
+        originalName: fileName,
+        mimeType: fileType || 'application/octet-stream',
+        buffer,
+        category: category || null,
+        note: note || null,
+      });
+
+      res.status(201).json({ document });
+    } catch (error) {
+      console.error('Failed to save document', error);
+      res.status(500).json({ error: 'Unable to save document.' });
+    }
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/pages/api/account/offers.js
+++ b/pages/api/account/offers.js
@@ -1,0 +1,178 @@
+import { randomUUID } from 'node:crypto';
+
+import { addOffer } from '../../../lib/offers.js';
+import { readSession } from '../../../lib/session.js';
+import { readContactEntries, updateContactEntries } from '../../../lib/account-storage.js';
+
+const STORE_NAME = 'account-offers.json';
+
+function requireContact(req, res) {
+  const session = readSession(req);
+  const contactId = session?.contactId;
+  if (!contactId) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
+  }
+
+  return {
+    contactId,
+    email: typeof session?.email === 'string' ? session.email : null,
+  };
+}
+
+function normaliseString(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : '';
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function normaliseAmount(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[,\s£]/g, '');
+    const parsed = Number.parseFloat(cleaned);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function buildOfferPayload(input, defaults) {
+  const propertyId = normaliseString(input?.propertyId);
+  const amount = normaliseAmount(input?.amount ?? input?.offerAmount);
+
+  const errors = [];
+  if (!propertyId) {
+    errors.push('Property reference is required.');
+  }
+  if (amount === null || amount <= 0) {
+    errors.push('Offer amount must be a positive number.');
+  }
+
+  const name = normaliseString(input?.name);
+  const email = normaliseString(input?.email || defaults?.email || '');
+
+  if (!email) {
+    errors.push('Email address is required.');
+  }
+
+  if (errors.length) {
+    return { errors };
+  }
+
+  const payload = {
+    propertyId,
+    propertyTitle: normaliseString(input?.propertyTitle),
+    propertyAddress: normaliseString(input?.propertyAddress || input?.address),
+    amount,
+    frequency: normaliseString(input?.frequency),
+    message: normaliseString(input?.message),
+    name: name || `Contact ${defaults?.contactId || ''}`.trim(),
+    email,
+    phone: normaliseString(input?.phone),
+  };
+
+  return { data: payload };
+}
+
+function formatOfferEntry(offer) {
+  if (!offer) return null;
+  return {
+    id: offer.id,
+    propertyId: offer.propertyId,
+    propertyTitle: offer.propertyTitle || '',
+    propertyAddress: offer.propertyAddress || '',
+    amount: offer.amount,
+    frequency: offer.frequency || '',
+    message: offer.message || '',
+    status: offer.status || 'submitted',
+    createdAt: offer.createdAt,
+    updatedAt: offer.updatedAt || offer.createdAt,
+  };
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const entries = await readContactEntries(STORE_NAME, contact.contactId);
+    const formatted = entries
+      .map(formatOfferEntry)
+      .filter(Boolean)
+      .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+
+    res.status(200).json({ offers: formatted });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const { data, errors } = buildOfferPayload(req.body || {}, contact);
+    if (!data) {
+      res.status(400).json({ error: 'Invalid request', details: errors });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    const entry = {
+      id,
+      propertyId: data.propertyId,
+      propertyTitle: data.propertyTitle,
+      propertyAddress: data.propertyAddress,
+      amount: data.amount,
+      frequency: data.frequency,
+      message: data.message,
+      status: 'submitted',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await updateContactEntries(STORE_NAME, contact.contactId, (existing) => {
+      const filtered = Array.isArray(existing) ? existing.filter((item) => item?.id !== id) : [];
+      return [entry, ...filtered];
+    });
+
+    try {
+      await addOffer({
+        propertyId: data.propertyId,
+        propertyTitle: data.propertyTitle,
+        propertyAddress: data.propertyAddress,
+        offerAmount: data.amount,
+        frequency: data.frequency,
+        name: data.name,
+        email: data.email,
+        phone: data.phone || undefined,
+        message: data.message || undefined,
+        depositAmount: undefined,
+        contactId: contact.contactId,
+        agentId: undefined,
+      });
+    } catch (error) {
+      console.warn('Failed to persist offer to shared store', error);
+    }
+
+    res.status(201).json({ offer: formatOfferEntry(entry) });
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/pages/api/account/viewings.js
+++ b/pages/api/account/viewings.js
@@ -1,0 +1,118 @@
+import { randomUUID } from 'node:crypto';
+
+import { readSession } from '../../../lib/session.js';
+import { readContactEntries, updateContactEntries } from '../../../lib/account-storage.js';
+
+const STORE_NAME = 'account-viewings.json';
+
+function requireContact(req, res) {
+  const session = readSession(req);
+  const contactId = session?.contactId;
+  if (!contactId) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return null;
+  }
+  return { contactId };
+}
+
+function normaliseString(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : '';
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function buildViewingPayload(input) {
+  const propertyId = normaliseString(input?.propertyId);
+  const preferredDate = normaliseString(input?.date || input?.preferredDate);
+  const preferredTime = normaliseString(input?.time || input?.preferredTime);
+  const message = normaliseString(input?.message);
+
+  const errors = [];
+  if (!propertyId) {
+    errors.push('Property reference is required.');
+  }
+
+  if (errors.length) {
+    return { errors };
+  }
+
+  return {
+    data: {
+      propertyId,
+      preferredDate,
+      preferredTime,
+      message,
+    },
+  };
+}
+
+function formatViewing(viewing) {
+  if (!viewing) return null;
+  return {
+    id: viewing.id,
+    propertyId: viewing.propertyId || '',
+    preferredDate: viewing.preferredDate || '',
+    preferredTime: viewing.preferredTime || '',
+    message: viewing.message || '',
+    status: viewing.status || 'requested',
+    createdAt: viewing.createdAt,
+  };
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const entries = await readContactEntries(STORE_NAME, contact.contactId);
+    const formatted = entries
+      .map(formatViewing)
+      .filter(Boolean)
+      .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+
+    res.status(200).json({ viewings: formatted });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const contact = requireContact(req, res);
+    if (!contact) {
+      return;
+    }
+
+    const { data, errors } = buildViewingPayload(req.body || {});
+    if (!data) {
+      res.status(400).json({ error: 'Invalid request', details: errors });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const entry = {
+      id: randomUUID(),
+      propertyId: data.propertyId,
+      preferredDate: data.preferredDate,
+      preferredTime: data.preferredTime,
+      message: data.message,
+      status: 'requested',
+      createdAt: now,
+    };
+
+    await updateContactEntries(STORE_NAME, contact.contactId, (existing) => {
+      const next = Array.isArray(existing) ? [entry, ...existing] : [entry];
+      return next;
+    });
+
+    res.status(201).json({ viewing: formatViewing(entry) });
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).json({ error: 'Method Not Allowed' });
+}

--- a/styles/AccountDocuments.module.css
+++ b/styles/AccountDocuments.module.css
@@ -1,0 +1,224 @@
+.section {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #ececec;
+  margin-bottom: 2.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
+}
+
+.sectionHeader {
+  padding: 1.75rem 2rem 0;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.3;
+}
+
+.sectionHeader p {
+  margin: 0.5rem 0 0;
+  color: #555;
+}
+
+.uploadForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+.uploadRow {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .uploadRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fieldGroup label {
+  font-weight: 600;
+  color: #333;
+}
+
+.fieldGroup input,
+.fieldGroup select,
+.fieldGroup textarea {
+  border: 1px solid #d5d5d5;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fieldGroup input:focus,
+.fieldGroup select:focus,
+.fieldGroup textarea:focus {
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.15);
+  outline: none;
+}
+
+.fieldGroup textarea {
+  resize: vertical;
+}
+
+.fileHint {
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.submitButton {
+  align-self: flex-start;
+  background: #1f6feb;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: #174fb3;
+  transform: translateY(-1px);
+}
+
+.submitButton:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.feedback {
+  background: #f9f0c3;
+  border: 1px solid #f1d97a;
+  color: #6f5d1f;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.placeholder {
+  color: #666;
+  font-style: italic;
+}
+
+.listingCard {
+  padding: 2rem;
+}
+
+.documentList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.documentCard {
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #fafafa;
+}
+
+.documentHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .documentHeader {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.documentHeader h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.documentMeta {
+  margin: 0.25rem 0 0;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.documentNote {
+  margin: 0.5rem 0 0;
+  color: #444;
+}
+
+.documentActions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid #1f6feb;
+  background: #fff;
+  color: #1f6feb;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.actionButton:hover {
+  background: #1f6feb;
+  color: #fff;
+}
+
+.deleteButton {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid #d9534f;
+  background: #fff5f5;
+  color: #a12d2a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.deleteButton:hover:not(:disabled) {
+  background: #d9534f;
+  color: #fff;
+}
+
+.deleteButton:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3b4cca;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.5rem;
+  display: inline-block;
+}

--- a/styles/AccountOffers.module.css
+++ b/styles/AccountOffers.module.css
@@ -1,0 +1,223 @@
+.section {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #ececec;
+  margin-bottom: 2.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
+}
+
+.sectionHeader {
+  padding: 1.75rem 2rem 0;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.3;
+}
+
+.sectionHeader p {
+  margin: 0.5rem 0 0;
+  color: #555;
+}
+
+.sectionContent {
+  display: grid;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+@media (min-width: 960px) {
+  .sectionContent {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.formCard,
+.listingCard {
+  background: #fafafa;
+  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formCard h3,
+.listingCard h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.formCard p,
+.listingCard p {
+  margin: 0;
+  color: #555;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.fieldRow {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .fieldRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fieldGroup label {
+  font-weight: 600;
+  color: #333;
+}
+
+.fieldGroup input,
+.fieldGroup select,
+.fieldGroup textarea {
+  border: 1px solid #d5d5d5;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fieldGroup input:focus,
+.fieldGroup select:focus,
+.fieldGroup textarea:focus {
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.15);
+  outline: none;
+}
+
+.fieldGroup textarea {
+  resize: vertical;
+}
+
+.submitButton {
+  align-self: flex-start;
+  background: #1f6feb;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: #174fb3;
+  transform: translateY(-1px);
+}
+
+.submitButton:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.feedback {
+  background: #f9f0c3;
+  border: 1px solid #f1d97a;
+  color: #6f5d1f;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.placeholder {
+  color: #666;
+  font-style: italic;
+}
+
+.offerList,
+.viewingList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.offerCard,
+.viewingCard {
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.offerHeader,
+.viewingHeader {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.offerHeader h4,
+.viewingHeader h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.offerMeta,
+.viewingMeta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.offerAmount {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3b4cca;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.offerMessage,
+.viewingMessage {
+  margin: 0;
+  color: #444;
+}
+
+.offerFooter {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #666;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.subtle {
+  color: #888;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- enable navigation to new Offers & viewings and Documents areas in the account portal
- add account-specific offers and viewings pages with inline forms and activity listings
- implement APIs and storage helpers for viewing requests, offer submissions, and secure document upload/download

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e467c64274832e88867bd3698c628f