### PR TITLE
Refine Purplebricks-style messaging across Aktonz

### DIFF
--- a/components/Features.js
+++ b/components/Features.js
@@ -3,30 +3,30 @@ import styles from '../styles/Home.module.css';
 export default function Features() {
   const items = [
     {
-      icon: '🏠',
-      title: 'Let your property hassle free',
-      text: 'Our team handles everything from tenant search to management.'
+      icon: '💜',
+      title: 'Transparent fixed fees',
+      text: 'Instruct Aktonz from £799 including VAT and know exactly what you will pay from day one.'
     },
     {
-      icon: '💰',
-      title: "What's your home worth?",
-      text: 'Get an instant online valuation today.'
+      icon: '🧭',
+      title: 'Dedicated local expertise',
+      text: 'Work with an experienced agent who lives and negotiates in your neighbourhood.'
     },
     {
-      icon: '🔍',
-      title: 'Find the right property for you',
-      text: 'Browse thousands of homes across London.'
+      icon: '🕒',
+      title: '24/7 online control',
+      text: 'Track viewings, feedback and offers in real time with our digital seller portal.'
     },
     {
       icon: '🤝',
-      title: 'Need help? Ask our experts',
-      text: 'Our local agents are here to support you.'
+      title: 'Support when you need it',
+      text: 'Add hosted viewings, sales progression or mortgage advice to tailor your move.'
     }
   ];
 
   return (
     <section className={styles.featuresSection}>
-      <h2>When you need experts</h2>
+      <h2>Everything you need to move forward</h2>
       <div className={styles.featuresGrid}>
         {items.map((item) => (
           <div className={styles.featureCard} key={item.title}>

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -5,8 +5,11 @@ export default function Hero() {
   return (
     <section className={styles.hero}>
       <div className={styles.heroContent}>
-        <h2>London&apos;s Estate Agent</h2>
-        <p className={styles.subtitle}>Get it done with London&apos;s number one</p>
+        <h1>Sell with Aktonz fixed-fee estate agents</h1>
+        <p className={styles.subtitle}>
+          List your property from £799 including VAT, stay in control with our 24/7 online portal and lean on a
+          dedicated Aktonz expert who knows your street.
+        </p>
         <SearchBar />
       </div>
     </section>

--- a/components/Stats.js
+++ b/components/Stats.js
@@ -2,9 +2,9 @@ import styles from '../styles/Home.module.css';
 
 export default function Stats() {
   const items = [
-    { number: '200+', text: 'buyers registered each week' },
-    { number: '98%', text: 'customer satisfaction' },
-    { number: '30+', text: 'local experts across London' }
+    { number: '£799', text: 'Fixed selling fee including VAT' },
+    { number: 'Free', text: 'No-obligation valuations from local Aktonz experts' },
+    { number: '24/7', text: 'Online control of viewings, offers and updates' }
   ];
 
   return (

--- a/docs/purplebricks-business-concept.md
+++ b/docs/purplebricks-business-concept.md
@@ -1,0 +1,18 @@
+# Purplebricks Business Concept
+
+## Overview
+Purplebricks operates as a UK estate agency that helps homeowners sell their properties while saving on fees. The platform promotes free valuations, access to mortgage deals, and property search services through its digital experience.【2167b7†L20-L23】
+
+## Value Proposition
+* **Customer control with expert support:** The service emphasises that sellers can manage key steps such as valuations and payment options while staying backed by an expert estate agent throughout the sale.【1395b7†L3-L12】
+* **Local market expertise:** Purplebricks highlights access to local knowledge, positioning its agents as real people who understand neighbourhood markets and provide guidance from valuation through negotiations.【1395b7†L13-L22】
+* **Fixed-fee pricing:** Instead of percentage-based commissions, Purplebricks advertises a fixed selling fee starting at £799 including VAT, framing this as a fairer way to sell compared with traditional high-street agents.【1395b7†L23-L31】
+
+## Supporting Services
+* **Free property valuations:** Homeowners are encouraged to book free valuations with local agents who understand the area’s market dynamics.【1395b7†L32-L36】
+* **End-to-end selling resources:** The company bundles tools and guides covering everything from marketing and viewings to closing, reinforcing an all-in-one selling journey.【1395b7†L37-L46】
+* **Mortgage and financial guidance:** Purplebricks flags access to mortgage deals, noting that mortgage advice may carry a fee of up to 1% (typically £299), which suggests an ancillary financial services offering alongside property sales.【2167b7†L20-L23】【1395b7†L47-L48】
+* **Lettings support:** Beyond sales, the platform also mentions services for landlords through its letting agents, expanding its proposition into property management.【1395b7†L49-L50】
+
+## Geographic Reach
+Purplebricks markets coverage across numerous UK cities and towns, underscoring availability of local estate agents nationwide to support sellers wherever they are located.【1395b7†L51-L78】

--- a/pages/index.js
+++ b/pages/index.js
@@ -117,7 +117,11 @@ export default function Home({ sales, lettings, archiveSales }) {
   return (
     <>
       <Head>
-        <title>Property Portal</title>
+        <title>Aktonz | Fixed-Fee Estate Agents with Local Experts</title>
+        <meta
+          name="description"
+          content="Sell or let with Aktonz from £799 including VAT. Stay in control online 24/7 while our local experts handle valuations, viewings and negotiations."
+        />
       </Head>
       <main className={styles.main}>
         <Hero />

--- a/pages/valuation.js
+++ b/pages/valuation.js
@@ -133,20 +133,20 @@ export default function Valuation() {
   return (
     <>
       <Head>
-        <title>Book a Property Valuation in London | Aktonz</title>
+        <title>Book a Fixed-Fee Property Valuation | Aktonz</title>
         <meta
           name="description"
-          content="Arrange a free Aktonz property valuation with a local expert and discover the best strategy to sell or let your home."
+          content="Arrange a free Aktonz property valuation with a local expert, discover our fixed-fee selling plans and manage your move online."
         />
       </Head>
       <main className={styles.main}>
       <section className={styles.hero}>
         <div className={styles.heroContent}>
-          <h1>Book a Property Valuation in London</h1>
+          <h1>Book a free valuation with a local Aktonz expert</h1>
           <ul>
-            <li>Free, no obligation appointment with a local expert</li>
-            <li>Clear marketing strategy for your property</li>
-            <li>14,000 buyers and tenants registered last month</li>
+            <li>Free, no-obligation visit from an agent who knows your neighbourhood</li>
+            <li>Agree your fixed fee upfront and map out the best marketing and negotiation plan</li>
+            <li>Get set up with 24/7 access to the Aktonz online portal for instant updates</li>
           </ul>
         </div>
         <form className={styles.form} onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- update the homepage hero copy to emphasise Aktonz's fixed-fee, local expert proposition
- refresh homepage metadata, features, and stats to reinforce the digital-first, fixed-fee narrative
- refine valuation page bullets to highlight upfront fee transparency and 24/7 portal access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5db96ed60832eb712ac7f55678531