### PR TITLE
Adjust homepage featured listings layout

### DIFF
--- a/components/PropertyList.js
+++ b/components/PropertyList.js
@@ -1,11 +1,53 @@
 import Link from 'next/link';
+import { useRef } from 'react';
 import PropertyCard from './PropertyCard';
 import { resolvePropertyIdentifier } from '../lib/property-id.mjs';
 
 
-export default function PropertyList({ properties }) {
-  return (
-    <div className="property-list">
+export default function PropertyList({
+  properties = [],
+  layout = 'default',
+  enableSlider = false,
+}) {
+  const listRef = useRef(null);
+
+  const handleScroll = (direction) => {
+    const list = listRef.current;
+    if (!list) {
+      return;
+    }
+
+    const firstCard = list.querySelector('.property-card-wrapper');
+    if (!firstCard) {
+      return;
+    }
+
+    const { width: cardWidth } = firstCard.getBoundingClientRect();
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const computedStyles = window.getComputedStyle(list);
+    const gapValue = computedStyles.columnGap || computedStyles.gap || '0';
+    const gap = Number.parseFloat(gapValue) || 0;
+    const scrollAmount = (cardWidth + gap) * direction;
+
+    list.scrollBy({
+      left: scrollAmount,
+      behavior: 'smooth',
+    });
+  };
+
+  const listClassName = [
+    'property-list',
+    layout === 'five-per-row' ? 'property-list--five-per-row' : '',
+    enableSlider ? 'property-list--scrollable' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const listContent = (
+    <div ref={listRef} className={listClassName}>
       {properties.map((property, index) => {
         if (!property) {
           return null;
@@ -58,6 +100,31 @@ export default function PropertyList({ properties }) {
           </Link>
         );
       })}
+    </div>
+  );
+  if (!enableSlider) {
+    return listContent;
+  }
+
+  return (
+    <div className="property-list-slider">
+      <button
+        type="button"
+        className="property-list-slider__control property-list-slider__control--prev"
+        aria-label="Scroll properties left"
+        onClick={() => handleScroll(-1)}
+      >
+        &#8249;
+      </button>
+      {listContent}
+      <button
+        type="button"
+        className="property-list-slider__control property-list-slider__control--next"
+        aria-label="Scroll properties right"
+        onClick={() => handleScroll(1)}
+      >
+        &#8250;
+      </button>
     </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -125,11 +125,15 @@ export default function Home({ sales, lettings, archiveSales }) {
         <Stats />
         <section className={styles.listings} id="listings">
           <h2>Featured Sales</h2>
-          <PropertyList properties={sales} />
+          <PropertyList properties={sales} layout="five-per-row" />
         </section>
         <section className={styles.listings}>
           <h2>Featured Lettings</h2>
-          <PropertyList properties={lettings} />
+          <PropertyList
+            properties={lettings}
+            layout="five-per-row"
+            enableSlider
+          />
         </section>
         {archiveSales.length > 0 && (
           <section className={styles.listings}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,6 +17,53 @@ body {
   grid-auto-rows: 1fr;
 }
 
+.property-list--five-per-row {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.property-list--scrollable {
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, calc(100% / 5));
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+}
+
+.property-list--scrollable::-webkit-scrollbar {
+  display: none;
+}
+
+.property-list-slider {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.property-list-slider__control {
+  background: var(--color-muted-bg);
+  border: none;
+  color: var(--color-background);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.property-list-slider__control:hover,
+.property-list-slider__control:focus-visible {
+  background: var(--color-accent);
+  color: var(--color-text);
+}
+
+.property-list-slider__control:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 2px;
+}
+
 
 .property-list .property-link {
   text-decoration: none;


### PR DESCRIPTION
## Summary
- add optional slider controls and five-per-row layout support to `PropertyList`
- style property listings for five-card rows with accessible navigation buttons
- update the homepage to apply the new layout to featured sales and lettings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5e087f7a8832ebab524e1593fb7d8