### PR TITLE
Add SEO plan and competitor keyword analysis

### DIFF
--- a/docs/seo/aktonz-seo-plan.md
+++ b/docs/seo/aktonz-seo-plan.md
@@ -1,0 +1,82 @@
+# Aktonz SEO Plan (London Lettings Focus)
+
+## Objectives
+
+1. Rank Aktonz landing and listings pages on page one for "London letting agent" and intent-matched rental search terms.
+2. Grow organic leads by improving visibility for long-tail renter queries (e.g., amenities, neighbourhood modifiers) surfaced in competitor copy.
+3. Strengthen topical authority around managed rentals, corporate lets, and premium amenities to differentiate from aggregated portals.
+
+## Keyword universe & prioritisation
+
+### Primary targets (high volume, core intent)
+
+| Keyword cluster | Rationale | Suggested target URL |
+| --- | --- | --- |
+| london letting agent | Competitive head term aligning with Aktonz's brand positioning; absent from competitor titles but relevant to service pages. | `/lettings` or dedicated "London Letting Agent" landing page |
+| properties to rent in london | Dominant portal phrasing used by Rightmove & Zoopla titles. Capture blended intent with optimised listings index page. | `/rent` |
+| flats to rent in london | High-frequency variation in competitor meta descriptions; aligns with Aktonz listings inventory. | `/rent/flats` filtered collection |
+
+### Secondary opportunities (mid volume, commercial intent)
+
+| Keyword cluster | Insight source | Page focus |
+| --- | --- | --- |
+| luxury apartments to rent london | Scraye emphasises "modern", "concierge", "high ceilings"—opportunity for premium segmentation. | New landing page highlighting amenities-driven lets |
+| pet friendly flats london | Scraye copy references pets & bills repeatedly—create pet-friendly filters & content. | Blog guide + filtered listings |
+| corporate let london | Competitor gap; incorporate service content for relocations and corporate lets. | Service page or pillar article |
+| furnished flats london | Frequent in Aktonz data ("fully", "modern")—reinforce in headings and filters. | `/rent/furnished` |
+
+### Long-tail / supporting content ideas
+
+* "Studio flats with concierge in [Neighbourhood]"
+* "London rentals with gym and co-working"
+* "Bills included apartments near [Transport hub]"
+* "Pet friendly rentals under £2,000 pcm"
+
+These combine Scraye's amenity-heavy language (`storage`, `windows`, `gym`, `amenities`, `pcm`) with Aktonz's existing copy, giving scope for targeted guides and landing pages.
+
+## On-page optimisation roadmap
+
+1. **Rework `/rent` template**
+   * Update `<title>` to `Properties to Rent in London | Aktonz Letting Agents` and meta description to highlight unique value (e.g., in-house management, virtual tours).
+   * Introduce an H1 that mirrors the primary keyword while weaving in differentiators ("Curated London Rentals with Concierge-Level Support").
+   * Add introductory copy (~120 words) referencing primary and secondary clusters plus internal links to filtered collections (pet-friendly, furnished, luxury, neighbourhoods).
+
+2. **Create segmented landing pages**
+   * Build static pages for `Pet-Friendly Flats in London`, `Luxury Apartments to Rent in London`, and `Corporate Lets in London` using dynamic listing embeds filtered by relevant attributes.
+   * For each page, craft structured sections: overview paragraph, amenity highlights (pulling from features like `concierge`, `gym`, `storage`), neighbourhood spotlights, and FAQ schema.
+
+3. **Blog & resource calendar**
+   * Publish two guides per month targeting long-tail intents (e.g., "How to Find Bills-Inclusive Flats in London"), embedding listings and CTAs.
+   * Use FAQ and HowTo schema where applicable to capture People Also Ask opportunities.
+
+4. **Schema & internal linking**
+   * Implement `ItemList` schema on listing indices and `RealEstateAgent` schema on about/service pages.
+   * Cross-link new landing pages from the homepage hero, footer, and relevant blog posts to build authority.
+
+## Technical SEO checks
+
+* Ensure listings pages load server-side rendered content for bots (avoid the empty responses observed on Scraye/OpenRent).
+* Generate and submit XML sitemaps segmented by property type and content type.
+* Enforce clean URL structures for filters (`/rent/pet-friendly`, `/rent/luxury`, `/rent/[area]`).
+* Add canonical tags on filtered pages to prevent duplication.
+* Monitor Core Web Vitals—optimise image delivery (WebP, responsive sizes) for rich media-heavy listings.
+
+## Off-page & authority building
+
+* **Partnership outreach**: Target relocation blogs, London lifestyle publications, and co-working spaces with guest content around concierge rentals and remote-work-ready flats.
+* **Local citations**: Audit and standardise NAP data across Google Business Profile, Bing Places, Yelp, and niche directories like AllAgents.
+* **Digital PR**: Launch quarterly data stories using Aktonz listings (e.g., amenity trends, average PCM by neighbourhood) to earn press backlinks.
+
+## Measurement & KPIs
+
+* Track rankings weekly for the primary and secondary keyword sets above.
+* Monitor organic sessions and enquiries to `/rent` and new landing pages.
+* Use Search Console to surface emerging long-tail queries and iterate content.
+* Attribute leads via CRM tagging to quantify SEO-driven revenue.
+
+## Execution timeline (90-day outline)
+
+1. **Weeks 1–2**: Keyword mapping, update existing `/rent` metadata and copy, implement schema foundations.
+2. **Weeks 3–6**: Launch pet-friendly and luxury landing pages, set up sitemap & canonical improvements.
+3. **Weeks 7–10**: Publish first three blog guides, begin outreach for partnership backlinks.
+4. **Weeks 11–13**: Release corporate lets page, push digital PR dataset story, evaluate rankings & refine.

--- a/docs/seo/competitor-keyword-scan.md
+++ b/docs/seo/competitor-keyword-scan.md
@@ -1,0 +1,66 @@
+# Competitor Keyword Scan
+
+This snapshot captures on-page keyword signals from high-ranking London lettings portals alongside lexical trends from Scraye listings included in the project dataset.
+
+## Meta data extracts (March 2025)
+
+| Site | URL | `<title>` | Meta description | Primary H1 |
+| --- | --- | --- | --- | --- |
+| Rightmove | https://www.rightmove.co.uk/property-to-rent/find.html?locationIdentifier=REGION%5E93917 | Properties To Rent in London \| Rightmove | Flats & Houses To Rent in London - Find properties with Rightmove - the UK's largest selection of properties. | Properties To Rent in Greater London |
+| Zoopla | https://www.zoopla.co.uk/to-rent/property/london/ | Property to rent in London - Zoopla | Use Zoopla to find the latest properties to rent in London. Search for houses, flats and bungalows for rent in London from the top letting agents. | Properties to rent in London |
+
+> Scraye and OpenRent serve their listing results via client-side rendering, so no meta description was exposed in the static HTML response. Their keyword focus was therefore inferred from the listing copy captured in `data/scraye.json`.
+
+## High-frequency terms in Scraye listings
+
+Top tokens (stop-words removed) from 202 Scraye rental listings bundled with the repo:
+
+| Keyword | Frequency |
+| --- | --- |
+| property | 64 |
+| available | 42 |
+| storage | 38 |
+| windows | 36 |
+| big | 35 |
+| high | 34 |
+| flat | 33 |
+| modern | 32 |
+| open | 32 |
+| ample | 31 |
+| kitchen | 30 |
+| pcm | 29 |
+| ceilings | 28 |
+| concierge | 28 |
+| road | 27 |
+| gym | 26 |
+| amenities | 25 |
+| plan | 25 |
+| rent | 24 |
+| london | 23 |
+
+## Aktonz listing language snapshot
+
+Top tokens (stop-words removed) across the bundled Aktonz listings cache:
+
+| Keyword | Frequency |
+| --- | --- |
+| property | 71 |
+| flat | 36 |
+| living | 29 |
+| rent | 28 |
+| bedroom | 25 |
+| amenities | 25 |
+| situated | 24 |
+| presenting | 24 |
+| kitchen | 23 |
+| fully | 21 |
+| available | 21 |
+| bathroom | 20 |
+| located | 20 |
+| space | 20 |
+| features | 19 |
+| modern | 18 |
+| double | 17 |
+| floor | 17 |
+| private | 16 |
+| spacious | 16 |


### PR DESCRIPTION
## Summary
- add competitor keyword scan referencing on-page metadata and listing term frequencies
- document a London-focused SEO roadmap with keyword prioritisation and execution steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e401fff0832eac780cc3b984f111