### PR TITLE
feat: add landlord services booking flow

### DIFF
--- a/data/services/landlordServices.ts
+++ b/data/services/landlordServices.ts
@@ -1,0 +1,84 @@
+export interface LandlordService {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  priceRange: string;
+  priceFrom: number;
+  image: string;
+  duration: string;
+}
+
+export const landlordServices: LandlordService[] = [
+  {
+    id: 'svc-001',
+    slug: 'gas-safety',
+    title: 'Gas Safety Certificate (Annual)',
+    description:
+      'Ensure every gas appliance is inspected and certified so that your tenancy stays compliant with UK legislation.',
+    priceRange: '£70–£120',
+    priceFrom: 70,
+    image: '/images/landlord-gas-safety.svg',
+    duration: '45–60 mins on site',
+  },
+  {
+    id: 'svc-002',
+    slug: 'eicr',
+    title: 'Electrical Installation Condition Report',
+    description:
+      'Full EICR completed by NICEIC-approved engineers covering fixed wiring, sockets and distribution boards.',
+    priceRange: '£150–£250',
+    priceFrom: 150,
+    image: '/images/landlord-eicr.svg',
+    duration: '1.5–3 hrs on site',
+  },
+  {
+    id: 'svc-003',
+    slug: 'pat-testing',
+    title: 'Portable Appliance Testing',
+    description:
+      'PAT testing for white goods and supplied appliances with a digital inventory and reminder schedule.',
+    priceRange: '£60–£110',
+    priceFrom: 60,
+    image: '/images/landlord-pat.svg',
+    duration: '60 mins for 10 items',
+  },
+  {
+    id: 'svc-004',
+    slug: 'epc',
+    title: 'Energy Performance Certificate',
+    description:
+      'Produce or renew your EPC with accredited assessors and receive upgrade recommendations for your property.',
+    priceRange: '£65–£95',
+    priceFrom: 65,
+    image: '/images/landlord-epc.svg',
+    duration: '45 mins per dwelling',
+  },
+  {
+    id: 'svc-005',
+    slug: 'boiler-service',
+    title: 'Boiler Service & Maintenance',
+    description:
+      'Annual boiler service including flue analysis, system pressure checks and digital service record.',
+    priceRange: '£80–£160',
+    priceFrom: 80,
+    image: '/images/landlord-boiler.svg',
+    duration: '60–90 mins on site',
+  },
+  {
+    id: 'svc-006',
+    slug: 'legionella',
+    title: 'Legionella Risk Assessment',
+    description:
+      'Survey and risk assessment for legionella with remedial recommendations and photographic evidence.',
+    priceRange: '£120–£200',
+    priceFrom: 120,
+    image: '/images/landlord-legionella.svg',
+    duration: '60 mins on site',
+  },
+];
+
+export function findLandlordService(slug?: string | null) {
+  if (!slug) return undefined;
+  return landlordServices.find((service) => service.slug === slug);
+}

--- a/lib/landlordServices/payments.ts
+++ b/lib/landlordServices/payments.ts
@@ -1,0 +1,50 @@
+export interface PaymentSession {
+  id: string;
+  bookingId: string;
+  amount: number;
+  currency: string;
+  status: 'pending' | 'paid';
+  checkoutUrl: string;
+  createdAt: string;
+  serviceName?: string;
+  customerEmail?: string;
+}
+
+const paymentSessions: PaymentSession[] = [];
+
+function resolveSiteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+}
+
+export function createPaymentSession(params: {
+  bookingId: string;
+  amount: number;
+  currency?: string;
+  serviceName?: string;
+  customerEmail?: string;
+}) {
+  const { bookingId, amount, currency = 'GBP', serviceName, customerEmail } = params;
+
+  const session: PaymentSession = {
+    id: `pay_${Date.now().toString(36)}`,
+    bookingId,
+    amount,
+    currency,
+    status: 'pending',
+    checkoutUrl: `${resolveSiteUrl()}/services/booking?bookingId=${bookingId}&step=payment`,
+    createdAt: new Date().toISOString(),
+    serviceName,
+    customerEmail,
+  };
+
+  paymentSessions.push(session);
+  return session;
+}
+
+export function listPaymentSessions() {
+  return paymentSessions;
+}

--- a/pages/api/bookings.ts
+++ b/pages/api/bookings.ts
@@ -1,0 +1,96 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  findLandlordService,
+  landlordServices,
+} from '../../data/services/landlordServices';
+import { createPaymentSession } from '../../lib/landlordServices/payments';
+
+type BookingRecord = {
+  id: string;
+  serviceSlug: string;
+  serviceName: string;
+  propertyAddress: string;
+  preferredDate: string;
+  preferredTime: string;
+  tenantName: string;
+  tenantEmail: string;
+  notes?: string;
+  photo?: { name: string; type: string; data: string } | null;
+  status: 'pending-payment' | 'confirmed';
+  createdAt: string;
+};
+
+const bookings: BookingRecord[] = [];
+
+function validatePayload(body: NextApiRequest['body']) {
+  const requiredFields = [
+    'serviceSlug',
+    'propertyAddress',
+    'preferredDate',
+    'preferredTime',
+    'tenantName',
+    'tenantEmail',
+  ];
+
+  for (const field of requiredFields) {
+    if (!body?.[field]) {
+      return `Missing field: ${field}`;
+    }
+  }
+
+  const service = findLandlordService(body.serviceSlug);
+  if (!service) {
+    return 'Invalid service selected';
+  }
+
+  return null;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const validationError = validatePayload(req.body);
+  if (validationError) {
+    return res.status(400).json({ error: validationError });
+  }
+
+  const service = findLandlordService(req.body.serviceSlug)!;
+  const booking: BookingRecord = {
+    id: `bk_${Date.now().toString(36)}`,
+    serviceSlug: service.slug,
+    serviceName: service.title,
+    propertyAddress: req.body.propertyAddress,
+    preferredDate: req.body.preferredDate,
+    preferredTime: req.body.preferredTime,
+    tenantName: req.body.tenantName,
+    tenantEmail: req.body.tenantEmail,
+    notes: req.body.notes,
+    photo: req.body.photo ?? null,
+    status: 'pending-payment',
+    createdAt: new Date().toISOString(),
+  };
+
+  bookings.push(booking);
+
+  const paymentSession = createPaymentSession({
+    bookingId: booking.id,
+    amount: service.priceFrom,
+    currency: 'GBP',
+    serviceName: service.title,
+    customerEmail: booking.tenantEmail,
+  });
+
+  return res.status(200).json({
+    bookingId: booking.id,
+    booking,
+    paymentUrl: paymentSession.checkoutUrl,
+    services: landlordServices,
+  });
+}

--- a/pages/api/payments/index.ts
+++ b/pages/api/payments/index.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  PaymentSession,
+  createPaymentSession,
+  listPaymentSessions,
+} from '../../../lib/landlordServices/payments';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json(listPaymentSessions());
+  }
+
+  if (req.method === 'POST') {
+    const { bookingId, amount, currency, serviceName, customerEmail } =
+      req.body || {};
+
+    if (!bookingId || !amount) {
+      return res
+        .status(400)
+        .json({ error: 'bookingId and amount are required for payments' });
+    }
+
+    const numericAmount = Number(amount);
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      return res.status(400).json({ error: 'Amount must be greater than 0' });
+    }
+
+    const session: PaymentSession = createPaymentSession({
+      bookingId,
+      amount: numericAmount,
+      currency,
+      serviceName,
+      customerEmail,
+    });
+
+    return res.status(200).json(session);
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/api/services/index.ts
+++ b/pages/api/services/index.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { landlordServices } from '../../../data/services/landlordServices';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json(landlordServices);
+  }
+
+  res.setHeader('Allow', ['GET']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/landlord-services.tsx
+++ b/pages/landlord-services.tsx
@@ -1,0 +1,65 @@
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import styles from '../styles/LandlordServices.module.css';
+import { landlordServices } from '../data/services/landlordServices';
+
+export default function LandlordServicesPage() {
+  return (
+    <>
+      <Head>
+        <title>Landlord Maintenance & Compliance Services | Aktonz</title>
+        <meta
+          name="description"
+          content="Book and pay for landlord maintenance, compliance and certification services directly with Aktonz."
+        />
+      </Head>
+
+      <section
+        id="landlord-maintenance-services"
+        className={styles.servicesSection}
+      >
+        <div className={styles.sectionHeading}>
+          <h2>Landlord Maintenance &amp; Compliance Services</h2>
+          <p>
+            Everything you need to keep your rental compliant – from gas safety
+            to legionella testing – with digital certificates, reminders and
+            online payments built in.
+          </p>
+        </div>
+
+        <div className={styles.servicesGrid}>
+          {landlordServices.map((service, index) => (
+            <article key={service.id} className={styles.serviceCard}>
+              <div className={styles.serviceImageWrapper}>
+                <Image
+                  src={service.image}
+                  alt={service.title}
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  style={{ objectFit: 'cover' }}
+                  priority={index < 2}
+                />
+              </div>
+              <h3>{service.title}</h3>
+              <p>{service.description}</p>
+              <div className={styles.serviceMeta}>
+                <span>
+                  <strong>Price Range:</strong> {service.priceRange}
+                </span>
+                <span className={styles.serviceDuration}>{service.duration}</span>
+              </div>
+              <Link
+                className={styles.bookNow}
+                href={`/services/booking?service=${service.slug}`}
+              >
+                Book &amp; Pay Online
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/pages/services/booking.tsx
+++ b/pages/services/booking.tsx
@@ -1,0 +1,279 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+import styles from '../../styles/ServiceBooking.module.css';
+import {
+  findLandlordService,
+  landlordServices,
+} from '../../data/services/landlordServices';
+
+type BookingStatus = 'idle' | 'success' | 'error';
+
+type PhotoAttachment = {
+  name: string;
+  type: string;
+  data: string;
+};
+
+interface BookingFormState {
+  serviceSlug: string;
+  propertyAddress: string;
+  preferredDate: string;
+  preferredTime: string;
+  tenantName: string;
+  tenantEmail: string;
+  notes: string;
+  photo?: PhotoAttachment | null;
+}
+
+const defaultFormState: BookingFormState = {
+  serviceSlug: landlordServices[0]?.slug ?? '',
+  propertyAddress: '',
+  preferredDate: '',
+  preferredTime: '',
+  tenantName: '',
+  tenantEmail: '',
+  notes: '',
+  photo: null,
+};
+
+async function fileToBase64(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function ServiceBookingPage() {
+  const router = useRouter();
+  const [formData, setFormData] = useState<BookingFormState>(defaultFormState);
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [status, setStatus] = useState<{ type: BookingStatus; message?: string }>(
+    { type: 'idle' }
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const serviceQuery = router.query.service;
+
+  useEffect(() => {
+    if (typeof serviceQuery === 'string') {
+      setFormData((prev) => ({ ...prev, serviceSlug: serviceQuery }));
+    }
+  }, [serviceQuery]);
+
+  const selectedService = useMemo(() => {
+    return (
+      findLandlordService(formData.serviceSlug) || landlordServices[0] || null
+    );
+  }, [formData.serviceSlug]);
+
+  const handleChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handlePhotoChange = async (
+    event: ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setFormData((prev) => ({ ...prev, photo: null }));
+      setPhotoPreview(null);
+      return;
+    }
+
+    try {
+      const base64 = await fileToBase64(file);
+      setFormData((prev) => ({
+        ...prev,
+        photo: { name: file.name, type: file.type, data: base64 },
+      }));
+      setPhotoPreview(URL.createObjectURL(file));
+    } catch (error) {
+      console.error('Failed to read file', error);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatus({ type: 'idle' });
+
+    try {
+      const response = await fetch('/api/bookings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...formData,
+          serviceSlug: selectedService?.slug ?? formData.serviceSlug,
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Unable to create booking');
+      }
+
+      setStatus({ type: 'success', message: 'Booking created. Redirecting…' });
+      if (payload?.paymentUrl) {
+        setTimeout(() => {
+          window.location.href = payload.paymentUrl as string;
+        }, 900);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Something went wrong';
+      setStatus({ type: 'error', message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Book Landlord Services | Aktonz</title>
+        <meta
+          name="description"
+          content="Reserve maintenance and compliance services online and pay securely."
+        />
+      </Head>
+      <section className={styles.bookingSection}>
+        <div className={styles.bookingContainer}>
+          <div className={styles.bookingHeader}>
+          <h1>Book &amp; Pay Online</h1>
+          <p>
+            Choose a service, tell us about the property, upload supporting
+            photos and we will confirm your slot before taking payment securely.
+          </p>
+        </div>
+
+        <form className={styles.bookingForm} onSubmit={handleSubmit}>
+          <div className={styles.fieldGroup}>
+            <label htmlFor="serviceSlug">Service</label>
+            <select
+              id="serviceSlug"
+              name="serviceSlug"
+              value={formData.serviceSlug}
+              onChange={handleChange}
+              required
+            >
+              {landlordServices.map((service) => (
+                <option key={service.id} value={service.slug}>
+                  {service.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {selectedService && (
+            <p>
+              <strong>{selectedService.title}</strong> · {selectedService.priceRange}
+              {' '}• {selectedService.duration}
+            </p>
+          )}
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="propertyAddress">Property Address</label>
+            <textarea
+              id="propertyAddress"
+              name="propertyAddress"
+              value={formData.propertyAddress}
+              onChange={handleChange}
+              placeholder="Street, town, postcode"
+              required
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="preferredDate">Preferred Date</label>
+            <input
+              type="date"
+              id="preferredDate"
+              name="preferredDate"
+              value={formData.preferredDate}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="preferredTime">Preferred Time</label>
+            <input
+              type="time"
+              id="preferredTime"
+              name="preferredTime"
+              value={formData.preferredTime}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="tenantName">Contact Name</label>
+            <input
+              type="text"
+              id="tenantName"
+              name="tenantName"
+              value={formData.tenantName}
+              onChange={handleChange}
+              placeholder="e.g. Main tenant or site contact"
+              required
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="tenantEmail">Contact Email</label>
+            <input
+              type="email"
+              id="tenantEmail"
+              name="tenantEmail"
+              value={formData.tenantEmail}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="notes">Notes / Access Details</label>
+            <textarea
+              id="notes"
+              name="notes"
+              value={formData.notes}
+              onChange={handleChange}
+              placeholder="Let us know about alarm panels, parking or access instructions"
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label htmlFor="photo">Optional photo upload</label>
+            <input type="file" id="photo" accept="image/*" onChange={handlePhotoChange} />
+            {photoPreview && (
+              <div className={styles.photoPreview}>
+                <img src={photoPreview} alt="Upload preview" />
+              </div>
+            )}
+          </div>
+
+          <div className={styles.formActions}>
+            <button className={styles.submitButton} disabled={isSubmitting}>
+              {isSubmitting ? 'Submitting…' : 'Submit &amp; Continue to Payment'}
+            </button>
+            {status.type !== 'idle' && (
+              <span className={styles.statusMessage}>{status.message}</span>
+            )}
+          </div>
+        </form>
+      </div>
+    </section>
+    </>
+  );
+}

--- a/public/images/landlord-boiler.svg
+++ b/public/images/landlord-boiler.svg
@@ -1,0 +1,13 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="boiler" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fee2e2" />
+      <stop offset="100%" stop-color="#ef4444" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#fef2f2" />
+  <rect x="150" y="70" width="180" height="200" rx="30" fill="#fff" stroke="#f43f5e" stroke-width="8" />
+  <circle cx="240" cy="200" r="38" fill="url(#boiler)" stroke="#b91c1c" stroke-width="6" />
+  <path d="M240 150c-24 32-24 54-10 64 8 6 20 6 28 0 14-10 14-32-18-64z" fill="#fff" opacity="0.8" />
+  <text x="50%" y="265" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#b91c1c">Boiler</text>
+</svg>

--- a/public/images/landlord-eicr.svg
+++ b/public/images/landlord-eicr.svg
@@ -1,0 +1,12 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="eicr" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#cffafe" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#ecfeff" />
+  <rect x="110" y="80" width="260" height="180" rx="24" fill="url(#eicr)" stroke="#0e7490" stroke-width="6" />
+  <polyline points="150,200 210,150 270,190 330,120" fill="none" stroke="#134e4a" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+  <text x="50%" y="265" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#0f172a">EICR</text>
+</svg>

--- a/public/images/landlord-epc.svg
+++ b/public/images/landlord-epc.svg
@@ -1,0 +1,12 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="epc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ede9fe" />
+      <stop offset="100%" stop-color="#a78bfa" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#f5f3ff" />
+  <polygon points="120,230 240,70 360,230" fill="url(#epc)" stroke="#6d28d9" stroke-width="8" stroke-linejoin="round" />
+  <rect x="205" y="160" width="70" height="70" rx="12" fill="#fff" stroke="#7c3aed" stroke-width="6" />
+  <text x="50%" y="265" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#5b21b6">EPC</text>
+</svg>

--- a/public/images/landlord-gas-safety.svg
+++ b/public/images/landlord-gas-safety.svg
@@ -1,0 +1,11 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gas" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fde68a" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#fff7ed" />
+  <path d="M240 60c-60 72-60 124-26 148 22 16 52 16 74 0 34-24 34-76-26-148z" fill="url(#gas)" stroke="#ea580c" stroke-width="6" stroke-linecap="round" />
+  <text x="50%" y="265" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#9a3412">Gas Safety</text>
+</svg>

--- a/public/images/landlord-legionella.svg
+++ b/public/images/landlord-legionella.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="leg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e0f2fe" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#dbeafe" />
+  <circle cx="240" cy="150" r="90" fill="url(#leg)" />
+  <circle cx="190" cy="140" r="24" fill="#bfdbfe" />
+  <circle cx="290" cy="180" r="30" fill="#bfdbfe" />
+  <circle cx="240" cy="210" r="22" fill="#bfdbfe" />
+  <text x="50%" y="275" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#1e3a8a">Legionella</text>
+</svg>

--- a/public/images/landlord-pat.svg
+++ b/public/images/landlord-pat.svg
@@ -1,0 +1,13 @@
+<svg width="480" height="320" viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="pat" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fef9c3" />
+      <stop offset="100%" stop-color="#a3e635" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="32" fill="#f7fee7" />
+  <rect x="150" y="90" width="180" height="160" rx="24" fill="url(#pat)" stroke="#4d7c0f" stroke-width="6" />
+  <circle cx="240" cy="170" r="40" fill="none" stroke="#3f6212" stroke-width="12" />
+  <line x1="240" y1="130" x2="240" y2="210" stroke="#3f6212" stroke-width="12" stroke-linecap="round" />
+  <text x="50%" y="265" font-family="'Helvetica Neue', Arial" font-weight="600" font-size="32" text-anchor="middle" fill="#3f6212">PAT</text>
+</svg>

--- a/styles/LandlordServices.module.css
+++ b/styles/LandlordServices.module.css
@@ -1,0 +1,104 @@
+.servicesSection {
+  padding: 4rem 1.5rem 5rem;
+  background: var(--color-background, #f8f8fb);
+}
+
+.sectionHeading {
+  text-align: center;
+  max-width: 740px;
+  margin: 0 auto 2.5rem;
+}
+
+.sectionHeading h2 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  margin-bottom: 0.75rem;
+}
+
+.sectionHeading p {
+  color: var(--color-text-muted, #5e6170);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.servicesGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.75rem;
+}
+
+.serviceCard {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 55px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.serviceCard:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 70px rgba(15, 23, 42, 0.14);
+}
+
+.serviceImageWrapper {
+  position: relative;
+  width: 100%;
+  height: 180px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #eff4ff, #fdf7f2);
+}
+
+.serviceCard h3 {
+  font-size: 1.25rem;
+  margin: 0.5rem 0 0;
+}
+
+.serviceCard p {
+  margin: 0;
+  color: #4c4f5d;
+  line-height: 1.5;
+}
+
+.serviceMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.serviceDuration {
+  font-size: 0.95rem;
+  color: #6a6f85;
+}
+
+.bookNow {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #6c3ef8, #a855f7);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  text-decoration: none;
+}
+
+.bookNow:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(97, 62, 247, 0.35);
+}
+
+@media (max-width: 640px) {
+  .servicesSection {
+    padding: 3rem 1rem;
+  }
+}

--- a/styles/ServiceBooking.module.css
+++ b/styles/ServiceBooking.module.css
@@ -1,0 +1,110 @@
+.bookingSection {
+  padding: 4rem 1.5rem 5rem;
+  background: #fff;
+}
+
+.bookingContainer {
+  max-width: 960px;
+  margin: 0 auto;
+  background: #f7f8ff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 65px rgba(20, 20, 43, 0.08);
+}
+
+.bookingHeader {
+  margin-bottom: 2rem;
+}
+
+.bookingHeader h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin-bottom: 0.5rem;
+}
+
+.bookingHeader p {
+  color: #5b5e71;
+}
+
+.bookingForm {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.fieldGroup label {
+  font-weight: 600;
+  color: #272848;
+}
+
+.fieldGroup input,
+.fieldGroup select,
+.fieldGroup textarea {
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
+}
+
+.fieldGroup textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.formActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.submitButton {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.95rem 2.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.submitButton:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.statusMessage {
+  font-size: 0.95rem;
+  color: #374151;
+}
+
+.photoPreview {
+  width: 160px;
+  height: 110px;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px dashed rgba(99, 102, 241, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.photoPreview img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: cover;
+}
+
+@media (max-width: 640px) {
+  .bookingContainer {
+    padding: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated landlord services landing page backed by structured service metadata and new imagery
- implement a booking form that reads the selected service from the query string, captures property details, and posts to the booking API before redirecting to payment
- expose supporting API routes for listings, bookings, and payments with a reusable mock payment session helper

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a6ae1736c832da7131c1bf0a64b39)